### PR TITLE
Add HSP optimal-planner sources and the plan-recognition dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ popd
 ## Original Notes (From Ramirez):
 
 - You'll need to compile the program for mapping PR tasks into planning tasks (see 'obs-compiler' folder) and put the resulting executable binary file ('plan2pr') inside this folder.
-- Download LAMA sources from the IPC-6 homepage, http://bit.ly/aPzUJh. Extract the tarball and copy the contents from 'seq-sat-lama' folder into this one. See LAMA's README for instructions for building and using LAMA.
-- Download hsp_f sources from the IPC-6 homepage, http://bit.ly/aI5xoS, build it and place the resulting executable binary file 'hsp_f' inside this folder.
+- Download [LAMA sources](https://ipc08.icaps-conference.org/deterministic/data/planners/seq-sat-lama.tar.bz2) from the [IPC-6 homepage](https://ipc08.icaps-conference.org/deterministic/Planners.html). Extract the tarball and copy the contents from 'seq-sat-lama' folder into this one. See LAMA's README for instructions for building and using LAMA.
+- Download [hsp_f sources](https://ipc08.icaps-conference.org/deterministic/data/planners/seq-opt-hspsf.tar.bz2) from the IPC-6 homepage, build it and place the resulting executable binary file 'hsp_f' inside this folder.
 - Note that you can easily add the code for trying different planners by writing a custom wrapper for it (see planners.py for examples).
 - 'prob_PR.py' is the main script, which glues together the PR to planning mapping transformation with one of the supported planners.
 - 'PR_sim.py' is the script we used to generate the data for the "Noisy Walk" figure in our AAAI-10 paper.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Probabilistic Plan Recognition
 
-Structured Ramirez's implementation of [Probabilistic plan recognition](http://dblp.org/rec/conf/aaai/RamirezG10) organized in a neat repository with links to the dependencies.
+Structured Ramirez's [implementation](https://sites.google.com/site/prasplanning) of [Probabilistic plan recognition](http://dblp.org/rec/conf/aaai/RamirezG10) organized in a neat repository with links to the dependencies.
 
 ## Instructions
 

--- a/pr/seq-opt-hspsf/additive.ccx
+++ b/pr/seq-opt-hspsf/additive.ccx
@@ -1,0 +1,5861 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+void sort2(index_type& i, index_type& j);
+void sort3(index_type& i, index_type& j, index_type& l);
+class PairIndexFunction : index_vec {
+ public:
+  PairIndexFunction(index_type n);
+  ~PairIndexFunction();
+  index_type operator()(index_type i, index_type j) const;
+  index_type max_in() const;
+  index_type max_out() const;
+};
+class CostNode {
+ public:
+  struct Value {
+    hsps::rational val;
+    bool opt;
+    CostNode* next;
+    bool mark;
+    count_type work;
+    Value() : val(0), opt(false), next(0), mark(false), work(0) { };
+    Value(hsps::rational v, bool o) : val(v), opt(o), next(0), mark(false), work(0) { };
+    Value& operator=(const Value& v)
+    { val = v.val; opt = v.opt; return *this; };
+    Value& operator=(hsps::rational v) { val = v; return *this; };
+    bool operator==(const Value& v) { return (val == v.val); };
+    bool operator<(const Value& v) { return (val < v.val); };
+    bool operator<=(const Value& v) { return (val <= v.val); };
+    bool operator>(const Value& v) { return (val > v.val); };
+    bool operator>=(const Value& v) { return (val >= v.val); };
+    bool operator==(const hsps::rational v) { return (val == v); };
+    bool operator<(const hsps::rational v) { return (val < v); };
+    bool operator<=(const hsps::rational v) { return (val <= v); };
+    bool operator>(const hsps::rational v) { return (val > v); };
+    bool operator>=(const hsps::rational v) { return (val >= v); };
+    void clear() {
+      val = 0;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+    void clear(hsps::rational v_default) {
+      val = v_default;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+  };
+ private:
+  index_type _size;
+  index_type _depth;
+  index_type _first;
+  hsps::rational _default;
+  hsps::rational _max;
+  Value* _store;
+  CostNode* _prev;
+  CostNode(CostNode* p, index_type f);
+  hsps::rational eval(const index_set& s, index_type i);
+  hsps::rational eval(const bool_vec& s, index_type i);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, index_type i, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, index_type i, hsps::rational bound);
+  void find_all(const index_set& s, index_type i, const index_set& c,
+   index_set_vec& a);
+  void set_max(hsps::rational v);
+  void write(std::ostream& s, index_set q) const;
+  void write_pddl(std::ostream& s, Instance& ins, index_set q) const;
+ public:
+  static bool eval_set_mark;
+  CostNode(index_type size);
+  CostNode(index_type size, hsps::rational v_default);
+  ~CostNode();
+  index_type size() const { return _size; };
+  index_type depth() const { return _depth; };
+  index_type first() const { return _first; };
+  index_type last() const { return _size - 1; };
+  Value& val(index_type p);
+  const Value& val(index_type p) const;
+  hsps::rational max() const { return _max; };
+  hsps::rational max_finite() const;
+  CostNode& next(index_type p);
+  Value* val_p(index_type p);
+  CostNode* next_p(index_type p);
+  Value* find(const index_set& s);
+  Value* find(const bool_vec& s);
+  void find_all(const index_set& s, index_set_vec& a);
+  Value& insert(const index_set& s);
+  Value& insert(const bool_vec& s);
+  void store(index_type p, hsps::rational v, bool opt);
+  void store(index_type p, hsps::rational v);
+  hsps::rational eval(const index_set& s);
+  hsps::rational eval(const bool_vec& s);
+  hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  void store(const index_set& s, hsps::rational v, bool opt);
+  void store(const bool_vec& s, hsps::rational v, bool opt);
+  void store(const index_set& s, hsps::rational v);
+  void store(const bool_vec& s, hsps::rational v);
+  hsps::rational eval_min(const index_set& s);
+  void compute_max();
+  void clear_marks();
+  void clear();
+  void write(std::ostream& s) const;
+  void write_pddl(std::ostream& s, Instance& ins) const;
+};
+class CostTable : public Heuristic, public CostNode {
+ public:
+  class Entry {
+  public:
+    index_set set;
+    CostNode::Value& val;
+    Entry* prev;
+    Entry* next;
+    Entry(index_set s, CostNode::Value& v)
+      : set(s), val(v), prev(0), next(0) { };
+    Entry& operator=(const Entry& e);
+    bool operator==(const Entry& e) { return set == e.set; };
+    bool operator<(const Entry& e) { return val < e.val; };
+    bool operator<=(const Entry& e) { return val <= e.val; };
+    bool operator>(const Entry& e) { return val > e.val; };
+    bool operator>=(const Entry& e) { return val >= e.val; };
+    Entry* first();
+    Entry* last();
+    Entry* move_down();
+    Entry* move_up();
+    void unlink();
+    void place_before(Entry* p);
+    void place_after(Entry* p);
+    void delete_list();
+    count_type list_length();
+  };
+ private:
+  Statistics& stats;
+  hsps::rational* pre_cost;
+  hsps::rational* per_cost;
+  bool update(index_type i, hsps::rational v, bool_vec& f);
+  bool update(index_type i, hsps::rational v);
+  bool update(index_type i, index_type j, hsps::rational v);
+  bool update(index_type i, index_type j, index_type l, hsps::rational v);
+  Entry* entries(CostNode* n, index_set s, Entry* l,
+   const index_set* filter, bool ign_zero, bool ign_opt,
+   bool ign_inf, bool req_mark, bool sort);
+  count_type count_entries(CostNode* n, index_set s, bool ign_zero,
+      bool ign_opt, bool ign_inf);
+  void fill(index_set& s, index_type d);
+  Entry* create_new_entries(const index_set& set,
+       const index_set& conflict_set,
+       const index_set& cd_ignore,
+       CostTable::Entry* list);
+  void compute_hm_graph_min
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+  void compute_hm_graph_max
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+ public:
+  static bool strong_conflict_detection;
+  static bool ultra_weak_conflict_detection;
+  static bool boost_new_entries;
+  static count_type n_entries_boosted;
+  static count_type n_entries_solved;
+  static count_type n_entries_discarded;
+  static count_type n_entries_created;
+  static count_type n_boost_searches;
+  static count_type n_boost_searches_with_cd;
+  CostTable(Instance& i, Statistics& s);
+  CostTable(Instance& i, Statistics& s, hsps::rational v_default);
+  ~CostTable();
+  virtual hsps::rational eval(index_type i);
+  virtual hsps::rational eval(index_type i, index_type j);
+  virtual hsps::rational eval(index_type i, index_type j, index_type k);
+  virtual hsps::rational eval(const index_set& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational eval(const bool_vec& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual void store(const index_set& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const index_set& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  virtual void store(const bool_vec& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  void store_list(Entry* l);
+  static Entry* insert_entry(Entry* e, Entry* l);
+  static Entry* prepend_entry(Entry* e, Entry* l);
+  static Entry* remove_entry(Entry* e, Entry* l);
+  static Entry* find_entry(index_set& s, Entry* l);
+  static Entry* copy_list(Entry* l);
+  count_type write_list(std::ostream& s, Entry* l);
+  bool interesting(const index_set& s);
+  Entry* atoms();
+  Entry* pairs();
+  Entry* entries();
+  Entry* entries(bool ign_zero, bool ign_opt, bool ign_inf, bool req_mark);
+  Entry* entries(const index_set& s);
+  Entry* unsorted_entries(bool ign_zero, bool ign_opt, bool ign_inf,
+     bool req_mark);
+  Entry* boostable_entries();
+  Entry* boostable_entries(const index_set& s);
+  Entry* boost_cd_entries();
+  Entry* marked_entries(bool ign_nb);
+  count_type count_entries(bool ign_zero, bool ign_opt, bool ign_inf);
+  hsps::rational action_pre_cost(index_type i);
+  hsps::rational action_per_cost(index_type i);
+  bool compatible(index_type a, index_type b, bool opt_resources) const;
+  void compute_H1(const ACF& cost);
+  void compute_H1(const ACF& cost, const bool_vec& init);
+  void compute_H1max(const ACF& cost, const bool_vec& init);
+  void compute_H2(const ACF& cost);
+  void compute_H2(const ACF& cost, const bool_vec& init);
+  void compute_H3(const ACF& cost);
+  void compute_H2C(const ACF& cost, bool opt_resources);
+  void verify_H2C(const ACF& cost, bool opt_resources, bool opt_verbose);
+  void compute_action_cost();
+  void fill(index_type to_depth);
+  void clear();
+  void closure(const ACF& cost);
+  void closure(const ACF& cost, const index_set& nd);
+  void compute_hm_graph(const ACF& cost, const index_set& s,
+   index_set_graph& g);
+};
+class LinearScanH2Eval : public CostTable {
+  index_type n_pairs;
+  index_pair* pairs;
+  hsps::rational* values;
+  bool complete;
+ public:
+  LinearScanH2Eval(Instance& i, Statistics& s);
+  ~LinearScanH2Eval();
+  void compile_finite();
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH1 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH1(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH1();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH2 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH2(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH2();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+inline void sort2(index_type& i, index_type& j)
+{
+  if (i > j) {
+    index_type t = i;
+    i = j;
+    j = t;
+  }
+}
+inline void sort3(index_type& i, index_type& j, index_type& l)
+{
+  sort2(i, l);
+  sort2(i, j);
+  sort2(j, l);
+}
+inline CostNode::Value& CostNode::val(index_type p)
+{
+  return _store[p];
+}
+inline const CostNode::Value& CostNode::val(index_type p) const
+{
+  return _store[p];
+}
+inline CostNode::Value* CostNode::val_p(index_type p)
+{
+  return &(_store[p]);
+}
+inline CostNode& CostNode::next(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return *(_store[p].next);
+}
+inline CostNode* CostNode::next_p(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return _store[p].next;
+}
+inline CostTable::Entry& CostTable::Entry::operator=(const Entry& e)
+{
+  set = e.set;
+  val = e.val;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode::Value& v)
+{
+  s << std::resetiosflags(std::ios::scientific) << ((v.val).decimal());
+  if (v.opt) s << '*';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode& t)
+{
+  t.write(s);
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostTable::Entry& e)
+{
+  if (e.set.length() > 0) {
+    s << "{" << e.set[0];
+    for (index_type k = 1; k < e.set.length(); k++) s << ',' << e.set[k];
+    s << "}:" << e.val;
+  }
+  else {
+    s << "{}:" << e.val;
+  }
+  return s;
+}
+}
+namespace hsps {
+class AH : public Heuristic {
+  void max_cost_mset(index_type m, const index_set& g, index_set& s);
+  void goal_relevant_remaining_actions(const index_set& g,
+           index_set& a,
+           bool_vec& rem);
+ protected:
+  CostTable* Hmax;
+  lvector<CostTable*> H_vec;
+  Statistics& stats;
+ public:
+  static count_type Hmax_wins;
+  static count_type Hsum_wins;
+  static count_type draws;
+  static bool use_linear_scan_eval;
+  AH(Instance& i, Statistics& s);
+  virtual ~AH();
+  index_type n_additive_components() { return H_vec.length(); };
+  CostTable* additive_component(index_type i) { return H_vec[i]; };
+  CostTable* max_component() { return Hmax; };
+  void compute_additive(const ACF& cost, const index_set_vec& p, bool useH2);
+  void compute_fractional(const ACF& cost, index_set_vec& p, bool useH2);
+  void compute_max(const ACF& cost, bool useH2);
+  void disable_max();
+  void compute_with_relevance_partitioning
+    (const ACF& cost, const index_set& g);
+  void compute_with_iterative_assignment
+    (const ACF& cost, const index_set& g, index_set_vec& app,
+     bool useH2, bool fractional, const index_set& g_limit);
+  void compute_with_iterative_assignment_1
+    (const ACF& cost, const index_set& g,
+     bool useH2, bool fractional, bool optimal,
+     const index_set& g_limit);
+  void compute_with_iterative_assignment_2
+    (const ACF& cost, const index_set& g, bool useH2, bool fractional,
+     const index_set& g_limit);
+  void compute_with_layered_partitioning
+    (const ACF& cost, const index_set& g);
+  void compute_layered_action_partition
+    (index_type m, const index_set& g, index_set_vec& p, index_type pg,
+     bool_vec& rem);
+  void compute_with_new_decomposition
+    (const ACF& cost, const index_set& g, bool useH2);
+  void compute_bottom_up_2
+    (const ACF& cost, const index_set& g, index_type p_max, bool useH2);
+  void compute_bottom_up
+    (const ACF& cost, const index_set& g, bool do_glue, bool useH2);
+  void compute_with_k_cuts
+    (const ACF& cost, const index_set& g, index_type k, bool useH2);
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual void write_eval(const index_set& s, std::ostream& st,
+     char* p = 0, bool e = true);
+  virtual void write_eval(const bool_vec& s, std::ostream& st,
+     char* p = 0, bool e = true);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+};
+}
+namespace hsps {
+class Preprocessor {
+ public:
+  Instance& instance;
+  index_vec atom_map;
+  index_vec action_map;
+  index_vec inv_map;
+ protected:
+  Statistics& stats;
+  CostTable* inc_relation;
+  graph* inc_graph;
+  bool make_invariant(index_type init_atom,
+        index_set& inv_set,
+        bool& exact,
+        index_set& branch_set);
+  void analyze_branch_set(const index_set& branch_set,
+     const index_set& inv_set,
+     index_set& effective);
+  void dfs_find_invariants(index_type init_atom,
+      const index_set& base_set,
+      const index_set& branch_set,
+      index_type branch_depth,
+      index_type max_branch_depth);
+  void extend_LsC1_relevance(const index_set& check,
+        const graph& lmg,
+        const bool_vec& p_act,
+        const bool_vec& p_add,
+        bool_vec& rel_atms,
+        bool_vec& rel_acts);
+ public:
+  static int default_trace_level;
+  int trace_level;
+  Preprocessor(Instance& ins, Statistics& s);
+  ~Preprocessor();
+  void compute_reachability(bool_vec& reachable_atoms,
+       bool_vec& reachable_actions,
+       bool opt_H2 = false);
+  void compute_static_atoms(const bool_vec& reachable_actions,
+       bool_vec& static_atoms);
+  void compute_relevance(const index_set& check,
+    bool_vec& r_atm,
+    bool_vec& r_act);
+  void compute_relevance(const index_set& check,
+    index_type d_check,
+    index_vec& d_atm,
+    index_vec& d_act);
+  void between(index_type p,
+        index_type q,
+        const graph& lmg,
+        bool_vec& b_atm,
+        bool_vec& b_act);
+  void compute_L1C1_relevance(const index_set& check,
+         index_type d_check,
+         const graph& lmg,
+         index_vec& d_atm,
+         index_vec& d_act);
+  void compute_L1C1_relevance(const index_set& check,
+         const graph& lmg,
+         bool_vec& rel_atms,
+         bool_vec& rel_acts);
+  void compute_LsC1_relevance(const index_set& check,
+         const graph& lmg,
+         bool_vec& rel_atms,
+         bool_vec& rel_acts);
+  void compute_relaxed_relevance(const index_set& g,
+     index_vec& path,
+     const index_set& pre,
+     bool_vec& rel_acts);
+  void strictly_relevant_actions(index_type p,
+     Heuristic& h,
+     const ACF& f,
+     bool_vec& rel);
+  void strictly_relevant_actions(index_type p,
+     hsps::rational c,
+     Heuristic& h,
+     const ACF& f,
+     bool_vec& rel);
+  void relevant_at_cost(index_type p,
+   hsps::rational c,
+   Heuristic& h,
+   const ACF& f,
+   bool_vec& r_atoms,
+   bool_vec& r_actions);
+  void relevant_at_cost(const index_set& s,
+   hsps::rational c,
+   Heuristic& h,
+   const ACF& f,
+   bool_vec& r_atoms,
+   bool_vec& r_actions);
+  CostTable* inconsistency();
+  graph* inconsistency_graph();
+  bool inconsistent(index_type p, index_type q, Heuristic& inc);
+  bool consistent(index_type p, index_type q, Heuristic& inc);
+  bool inconsistent(const index_set& s, index_type p, Heuristic& inc);
+  bool consistent(const index_set& s, index_type p, Heuristic& inc);
+  bool inconsistent(index_type p, index_type q);
+  bool consistent(index_type p, index_type q);
+  bool inconsistent(const index_set& s);
+  bool consistent(const index_set& s);
+  bool inconsistent(const index_set& s, index_type p);
+  bool consistent(const index_set& s, index_type p);
+  bool inconsistent(const index_set& s0, const index_set& s1);
+  bool consistent(const index_set& s0, const index_set& s1);
+  bool implies(index_type p, index_type q, Heuristic& inc);
+  bool implies(const index_set& s, index_type q, Heuristic& inc);
+  bool implies(index_type p, index_type q);
+  bool implies(const index_set& s, index_type q);
+  void implied_atom_set(const index_set& s, index_set& is, Heuristic& inc);
+  bool landmark_test(const index_set& init,
+       const index_set& goal,
+       index_type p,
+       bool opt_H2 = false);
+  void compute_landmarks(const index_set& init,
+    const index_set& goal,
+    index_set& landmark_atoms);
+  void compute_landmarks(bool exclude_goal,
+    bool exclude_init,
+    bool_vec& landmark_atoms);
+  void compute_landmarks(bool exclude_goal,
+    bool exclude_init,
+    index_set& landmark_atoms);
+  void quick_landmark_graph(graph& g, bool opt_H2 = false);
+  void compute_landmark_graph(graph& g, bool opt_H2 = false);
+  void compute_hierarchy(index_set_graph& g);
+  void compute_hierarchy(graph& g0, index_set_graph& g);
+  void necessary_completions_for_safeness(index_set& atoms_missing_negation);
+  void compute_irrelevant_atoms();
+  void dfs_find_invariants(index_type max_branch_depth);
+  void bfs_find_invariants();
+  void find_inconsistent_set_invariants(graph& inc);
+  void find_maximal_inconsistent_set_invariants(graph& inc);
+  void find_binary_iff_invariants(bool opt_weak_verify);
+  bool verify_invariant(Instance::Constraint& inv, Heuristic& inc);
+  bool verify_invariants(Heuristic& inc);
+  void compute_ncw_sets(Heuristic& inc);
+  void compute_ncw_sets();
+  void preprocess(bool opt_H2 = false);
+  void remove_irrelevant_atoms();
+  void remove_unverified_invariants();
+  void remove_useless_actions();
+  void remove_useless_invariants();
+  void remove_redundant_preconditions();
+  void eliminate_strictly_determined_atoms();
+  void make_safe();
+  void apply_place_replication();
+  void write_heuristic_graph(std::ostream& s,
+        Heuristic& h,
+        const ACF& cost,
+        const bool_vec& atoms,
+        const bool_vec& actions);
+  void write_heuristic_graph(std::ostream& s,
+        Heuristic& h,
+        const ACF& cost);
+  void write_relevance_graph(std::ostream& s,
+        const index_vec& d_atm,
+        const index_vec& d_act,
+        const char* label);
+  void write_relevance_graph(std::ostream& s,
+        const index_vec& d_atm,
+        const index_vec& d_act,
+        const bool_vec& mark_atm,
+        const bool_vec& mark_act,
+        const char* label);
+  bool find_inverse_actions(const Instance::Action& act, Heuristic& inc,
+       index_set& inverses);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+count_type AH::Hmax_wins = 0;
+count_type AH::Hsum_wins = 0;
+count_type AH::draws = 0;
+bool AH::use_linear_scan_eval = false;
+AH::AH(Instance& i, Statistics& s)
+  : Heuristic(i), Hmax(0), H_vec(0, 0), stats(s)
+{
+}
+AH::~AH()
+{
+  if (Hmax) delete Hmax;
+  for (index_type k = 0; k < H_vec.length(); k++)
+    if (H_vec[k]) delete H_vec[k];
+}
+void AH::compute_additive(const ACF& cost, const index_set_vec& p, bool useH2)
+{
+  stats.start();
+  index_type i_first = H_vec.length();
+  index_type n_useless = 0;
+  for (index_type k = 0; k < p.length(); k++) if (!p[k].empty()) {
+    if (stats.break_signal_raised()) return;
+    if (trace_level > 0) {
+      std::cerr << "counting " << p[k].length()
+  << " of " << instance.n_actions() << " actions..."
+  << std::endl;
+      if (trace_level > 1) {
+ instance.write_action_set(std::cerr, p[k]);
+ std::cerr << std::endl;
+      }
+    }
+    FracACF d_cost(cost, instance.n_actions(), 0);
+    d_cost.set(p[k], 1);
+    CostTable* Hd = (use_linear_scan_eval ?
+       new LinearScanH2Eval(instance, stats) :
+       new CostTable(instance, stats));
+    if (useH2)
+      Hd->compute_H2(d_cost);
+    else
+      Hd->compute_H1(d_cost);
+    if (Hd->max_finite() == 0) {
+      n_useless += 1;
+    }
+    else {
+      H_vec.append(Hd);
+    }
+  }
+  std::cerr << H_vec.length() << " additive H2 built" << std::endl;
+  if (n_useless > 0) {
+    std::cerr << n_useless << " useless action sets detected" << std::endl;
+  }
+  if (use_linear_scan_eval) {
+    for (index_type i = i_first; i < H_vec.length(); i++) {
+      if (stats.break_signal_raised()) return;
+      ((LinearScanH2Eval*)H_vec[i])->compile_finite();
+    }
+  }
+  stats.stop();
+}
+void AH::compute_fractional(const ACF& cost, index_set_vec& p, bool useH2)
+{
+  stats.start();
+  index_vec occ(0, instance.n_actions());
+  for (index_type k = 0; k < p.length(); k++)
+    for (index_type i = 0; i < p[k].length(); i++)
+      occ[p[k][i]] += 1;
+  index_type i_first = H_vec.length();
+  index_set useless_p;
+  for (index_type k = 0; k < p.length(); k++) if (!p[k].empty()) {
+    if (stats.break_signal_raised()) return;
+    if (trace_level > 0) {
+      std::cerr << "counting " << p[k].length()
+  << " of " << instance.n_actions() << " actions..."
+  << std::endl;
+      if (trace_level > 1) {
+ instance.write_action_set(std::cerr, p[k]);
+ std::cerr << std::endl;
+      }
+    }
+    FracACF d_cost(cost, instance.n_actions(), 0);
+    for (index_type i = 0; i < p[k].length(); i++)
+      d_cost.set(p[k][i], (hsps::rational(1,occ[p[k][i]]).reduce()));
+    CostTable* Hd = (use_linear_scan_eval ?
+       new LinearScanH2Eval(instance, stats) :
+       new CostTable(instance, stats));
+    if (useH2)
+      Hd->compute_H2(d_cost);
+    else
+      Hd->compute_H1(d_cost);
+    H_vec.append(Hd);
+    if (H_vec[H_vec.length() - 1]->max_finite() == 0)
+      useless_p.insert(k);
+  }
+  std::cerr << H_vec.length() << " additive H2 built" << std::endl;
+  if ((useless_p.length() > 0) && ((H_vec.length() - i_first) > 0)) {
+    std::cerr << "useless action sets detected, recomputing..." << std::endl;
+    for (index_type i = i_first; i < H_vec.length(); i++)
+      delete H_vec[i];
+    H_vec.set_length(i_first);
+    for (index_type i = 0; i < useless_p.length(); i++)
+      p[useless_p[i]].clear();
+    compute_fractional(cost, p, useH2);
+  }
+  else if (use_linear_scan_eval) {
+    for (index_type i = i_first; i < H_vec.length(); i++) {
+      if (stats.break_signal_raised()) return;
+      ((LinearScanH2Eval*)H_vec[i])->compile_finite();
+    }
+  }
+  stats.stop();
+}
+void AH::compute_max(const ACF& cost, bool useH2)
+{
+  if (Hmax) delete Hmax;
+  Hmax = new CostTable(instance, stats);
+  Hmax->compute_H2(cost);
+}
+void AH::disable_max()
+{
+  if (Hmax) delete Hmax;
+  Hmax = 0;
+}
+class decreasing_cost : public index_vec::order {
+  CostTable* h;
+ public:
+  decreasing_cost(CostTable* _h) : h(_h) { };
+  virtual bool operator()(const index_type& v0, const index_type& v1) const;
+};
+bool decreasing_cost::operator()
+(const index_type& v0, const index_type& v1) const
+{
+  return (h->eval(v0) >= h->eval(v1));
+}
+class increasing_cost : public index_vec::order {
+  CostTable* h;
+ public:
+  increasing_cost(CostTable* _h) : h(_h) { };
+  virtual bool operator()(const index_type& v0, const index_type& v1) const;
+};
+bool increasing_cost::operator()
+(const index_type& v0, const index_type& v1) const
+{
+  return (h->eval(v0) <= h->eval(v1));
+}
+void AH::compute_with_relevance_partitioning
+(const ACF& cost, const index_set& g)
+{
+  stats.start();
+  Hmax = new CostTable(instance, stats);
+  Hmax->compute_H2(cost);
+  Preprocessor* prep = new Preprocessor(instance, stats);
+  bool_vec rem(true, instance.n_actions());
+  index_type n_rem = instance.n_actions();
+  index_vec g_sort;
+  g_sort.insert_ordered(g, decreasing_cost(Hmax));
+  for (index_type k = 0; (k < g_sort.length()) && (rem.count(true) > 0); k++) {
+    bool_vec arg(false, instance.n_actions());
+    prep->strictly_relevant_actions(g_sort[k], Hmax->eval(g_sort[k]),
+        *Hmax, cost, arg);
+    arg.intersect(rem);
+    if (arg.count(true) > 0) {
+      if (trace_level > 0) {
+ std::cerr << "goal " << instance.atoms[g_sort[k]].name
+    << ": counting " << arg.count(true)
+    << " of " << instance.n_actions() << " actions..."
+    << std::endl;
+ if (trace_level > 1) {
+   instance.write_action_set(std::cerr, arg);
+   std::cerr << std::endl;
+ }
+      }
+      bool_vec d(arg);
+      d.complement();
+      DiscountACF d_cost(cost, d);
+      CostTable* Hd = new CostTable(instance, stats);
+      Hd->compute_H2(d_cost);
+      H_vec.append(Hd);
+      rem.subtract(arg);
+    }
+  }
+  if (rem.count(true) > 0) {
+    if (trace_level > 0) {
+      std::cerr << "remaining: " << rem.count(true)
+  << " of " << instance.n_actions() << " actions..."
+  << std::endl;
+      if (trace_level > 1) {
+ instance.write_action_set(std::cerr, rem);
+ std::cerr << std::endl;
+      }
+    }
+    bool_vec d(rem);
+    d.complement();
+    DiscountACF d_cost(cost, d);
+    CostTable* Hd = new CostTable(instance, stats);
+    Hd->compute_H2(d_cost);
+    H_vec.append(Hd);
+  }
+  if (trace_level > 0) {
+    std::cerr << H_vec.length() << " additive H2 built" << std::endl;
+  }
+  delete prep;
+  stats.stop();
+}
+void AH::compute_with_iterative_assignment
+(const ACF& cost, const index_set& g, index_set_vec& app,
+ bool useH2, bool fractional, const index_set& g_prio)
+{
+  stats.start();
+  std::cerr << "computing h^1..." << std::endl;
+  Hmax = new CostTable(instance, stats);
+  Hmax->compute_H1(cost);
+  hsps::rational h_limit = Hmax->eval(g_prio);
+  index_set_vec p;
+  p.assign_value(EMPTYSET, g.length());
+  bool_vec rem(true, instance.n_actions());
+  std::cerr << app.length() << " action pre-partitions..." << std::endl;
+  for (index_type k = 0; k < app.length(); k++) if (!app[k].empty()) {
+    if (!fractional) {
+      if (app[k].count_common(rem) != app[k].length()) {
+ std::cerr << "error: action pre-partitioning is not a partitioning!"
+    << std::endl;
+ exit(255);
+      }
+    }
+    if (trace_level > 0) {
+      std::cerr << "classifying set of " << app[k].length() << " actions..."
+  << std::endl;
+    }
+    cost_vec l(0, g.length());
+    for (index_type i = 0; i < g.length(); i++) {
+      DiscountACF d_cost(cost, instance.n_actions());
+      d_cost.discount(app[k]);
+      CostTable* Hd = new CostTable(instance, stats);
+      Hd->compute_H1(d_cost);
+      l[i] = (Hmax->eval(g[i]) - Hd->eval(g[i]));
+      if (trace_level > 0) {
+ std::cerr << "loss for goal " << instance.atoms[g[i]].name
+    << " = " << l[i] << std::endl;
+      }
+      delete Hd;
+    }
+    index_type mi = l.arg_max();
+    assert(mi != no_such_index);
+    if (fractional) {
+      for (index_type i = 0; i < g.length(); i++) if (l[i] == l[mi]) {
+ if (trace_level > 0) {
+   std::cerr << "set assigned to goal " << instance.atoms[g[i]].name
+      << std::endl;
+ }
+ p[i].insert(app[k]);
+      }
+    }
+    else {
+      index_type mn = p[mi].length();
+      hsps::rational mv = Hmax->eval(g[mi]);
+      for (index_type i = mi + 1; i < g.length(); i++)
+ if (l[i] == l[mi]) {
+   hsps::rational vi = Hmax->eval(g[i]);
+   if (vi < mv) {
+     mi = i;
+     mn = p[i].length();
+     mv = Hmax->eval(g[mi]);
+   }
+   else if ((vi == mv) && (p[i].length() < mn)) {
+     mi = i;
+     mn = p[i].length();
+   }
+ }
+      assert(mi < g.length());
+      if (trace_level > 0) {
+ std::cerr << "set assigned to goal " << instance.atoms[g[mi]].name
+    << std::endl;
+      }
+      p[mi].insert(app[k]);
+    }
+    rem.subtract(app[k]);
+  }
+  bool done = (rem.count(true) == 0);
+  if (!done) {
+    index_set_vec p_new;
+    p_new.assign_value(EMPTYSET, g.length());
+    while (!done) {
+      std::cerr << rem.count(true) << " actions remain..." << std::endl;
+      done = true;
+      for (index_type k = 0; k < instance.n_actions(); k++) if (rem[k]) {
+ bool assigned = false;
+ for (index_type i = 0; (i < g.length()) && !assigned; i++) {
+   DiscountACF d_cost(cost, instance.n_actions());
+   for (index_type j = 0; j < g.length(); j++)
+     if (j != i) d_cost.discount(p[j]);
+   d_cost.discount(k);
+   CostTable* Hd = new CostTable(instance, stats);
+   Hd->compute_H1(d_cost);
+   if (Hd->eval(g[i]) < Hmax->eval(g[i])) {
+     p_new[i].insert(k);
+     rem[k] = false;
+     if (!fractional)
+       assigned = true;
+     done = false;
+   }
+   delete Hd;
+ }
+      }
+      for (index_type i = 0; i < g.length(); i++) {
+ p[i].insert(p_new[i]);
+ p_new[i].clear();
+      }
+    }
+  }
+  if (rem.count(true) > 0) {
+    std::cerr << rem.count(true) << " actions still remain..." << std::endl;
+    if (fractional) {
+      for (index_type i = 0; i < g.length(); i++)
+ if (!p[i].empty())
+   p[i].insert(rem);
+    }
+  }
+  if (fractional)
+    compute_fractional(cost, p, useH2);
+  else
+    compute_additive(cost, p, useH2);
+  if (useH2)
+    compute_max(cost, true);
+  stats.stop();
+}
+void AH::compute_with_iterative_assignment_1
+(const ACF& cost, const index_set& g,
+ bool useH2, bool fractional, bool optimal,
+ const index_set& g_prio)
+{
+  stats.start();
+  index_set_vec app;
+  index_set v;
+  for (index_type k = 0; k < instance.n_invariants(); k++)
+    if ((instance.invariants[k].lim == 1) && instance.invariants[k].exact)
+      v.insert(k);
+  if (v.empty()) {
+    std::cerr << "warning: no invariants usable for action partitioning"
+       << std::endl;
+  }
+  else {
+    std::cerr << v.length() << " variables in problem..." << std::endl;
+    std::cerr << "associating actions to variables..." << std::endl;
+    index_set_vec a(v.length());
+    for (index_type k = 0; k < instance.n_actions(); k++) {
+      index_set e(instance.actions[k].add);
+      e.insert(instance.actions[k].del);
+      for (index_type i = 0; i < v.length(); i++)
+ if (instance.invariants[v[i]].set.count_common(e) > 0)
+   a[i].insert(k);
+    }
+    std::cerr << "building graph of conflicts..." << std::endl;
+    graph c(v.length());
+    for (index_type i = 0; i < v.length(); i++)
+      for (index_type j = i+1; j < v.length(); j++)
+ if (a[i].count_common(a[j]))
+   c.add_undirected_edge(i, j);
+    index_set s;
+    if (optimal) {
+      std::cerr << "searching for maximal conflict-free set..." << std::endl;
+      c.complement();
+      c.maximal_clique(s);
+    }
+    else {
+      std::cerr << "searching for conflict-free set..." << std::endl;
+      c.apx_independent_set(s);
+    }
+    std::cerr << s.length() << " variables in maximal additive set"
+       << std::endl;
+    app.assign_select(a, s);
+  }
+  compute_with_iterative_assignment(cost, g, app, useH2, fractional, g_prio);
+  stats.stop();
+}
+void AH::compute_with_iterative_assignment_2
+(const ACF& cost, const index_set& g,
+ bool useH2, bool fractional, const index_set& g_prio)
+{
+  stats.start();
+  index_set_vec app;
+  graph cag;
+  instance.coadd_graph(cag);
+  index_set s;
+  cag.apx_independent_set(s);
+  app.assign_value(EMPTYSET, s.length());
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    index_pair ij = s.first_common(instance.actions[k].add);
+    if (ij.first != no_such_index)
+      app[ij.first].insert(k);
+  }
+  compute_with_iterative_assignment(cost, g, app, useH2, fractional, g_prio);
+  stats.stop();
+}
+void AH::compute_with_new_decomposition
+(const ACF& cost, const index_set& g, bool useH2)
+{
+  stats.start();
+  index_set_graph cg;
+  bool_vec a(true, instance.n_atoms());
+  for (index_type k = 0; k < instance.n_invariants(); k++)
+    if (instance.invariants[k].lim == 1) {
+      cg.add_node();
+      cg.node_label(cg.size() - 1).assign_copy(instance.invariants[k].set);
+      a.subtract(instance.invariants[k].set);
+    }
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (a[k]) {
+      cg.add_node();
+      cg.node_label(cg.size() - 1).assign_singleton(k);
+    }
+  std::cerr << cg.size() << " state variables" << std::endl;
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    index_set ps;
+    for (index_type i = 0; i < cg.size(); i++)
+      if (instance.actions[k].pre.have_common_element(cg.node_label(i)))
+ ps.insert(i);
+    for (index_type i = 0; i < cg.size(); i++)
+      if (instance.actions[k].add.have_common_element(cg.node_label(i)))
+ cg.add_edge(ps, i);
+  }
+  index_set_graph ccg(cg);
+  ccg.merge_labels_downwards();
+  index_set gv;
+  for (index_type k = 0; k < cg.size(); k++)
+    if (g.have_common_element(cg.node_label(k)))
+      gv.insert(k);
+  index_set_vec p(EMPTYSET, gv.length());
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    for (index_type i = 0; i < gv.length(); i++)
+      if (instance.actions[k].add.have_common_element(ccg.node_label(gv[i])))
+ p[i].insert(k);
+  }
+  if (trace_level > 0) {
+    for (index_type k = 0; k < gv.length(); k++) {
+      std::cerr << "goal variable #" << k + 1 << ": ";
+      instance.write_atom_set(std::cerr, cg.node_label(gv[k]));
+      std::cerr << std::endl << " actions: ";
+      instance.write_action_set(std::cerr, p[k]);
+      std::cerr << std::endl;
+    }
+  }
+  compute_fractional(cost, p, useH2);
+  stats.stop();
+}
+void AH::compute_bottom_up_2
+(const ACF& cost, const index_set& g, index_type p_max, bool useH2)
+{
+  stats.start();
+  compute_max(cost, true);
+  std::cerr << "H2max computed in " << stats.time() << " seconds" << std::endl;
+  PairIndexFunction pi(instance.n_atoms());
+  graph prg(pi.max_out() + 1);
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    index_set pre_pairs;
+    for (index_type i = 0; i < instance.actions[k].pre.length(); i++)
+      for (index_type j = i; j < instance.actions[k].pre.length(); j++)
+ pre_pairs.insert(pi(instance.actions[k].pre[i],
+       instance.actions[k].pre[j]));
+    for (index_type i = 0; i < instance.n_atoms(); i++) {
+      if (instance.actions[k].add.contains(i)) {
+ prg.add_edge(pre_pairs, pi(i, i));
+ for (index_type j = 0; j < instance.actions[k].add.length(); j++)
+   if (instance.actions[k].add[j] > i)
+     prg.add_edge(pre_pairs, pi(i, instance.actions[k].add[j]));
+      }
+      else if (!instance.actions[k].del.contains(i)) {
+ if ((Hmax->incremental_eval(instance.actions[k].pre, i)).finite()) {
+   for (index_type j = 0; j < instance.actions[k].add.length(); j++) {
+     prg.add_edge(pre_pairs, pi(instance.actions[k].add[j], i));
+     if (!instance.actions[k].pre.contains(i))
+       for (index_type l = 0; l < instance.actions[k].pre.length(); l++)
+  prg.add_edge(pi(instance.actions[k].pre[l], i),
+        pi(instance.actions[k].add[j], i));
+   }
+ }
+      }
+    }
+  }
+  std::cerr << "prg construction finished in " << stats.time()
+     << " seconds" << std::endl;
+  bool_vec rp(false, prg.size());
+  prg.ancestors(g, rp);
+  std::cerr << "relevant pairs: " << rp.count(true)
+     << " of " << rp.length() << ", " << stats.time() << " seconds"
+     << std::endl;
+  graph nmg(instance.n_atoms());
+  for (index_type i = 0; i < instance.n_atoms(); i++)
+    for (index_type j = i + 1; j < instance.n_atoms(); j++)
+      if (rp[pi(i, j)])
+ nmg.add_undirected_edge(i, j);
+  std::cerr << "computed graph: " << nmg.n_edges() / 2
+     << " of " << (nmg.size() * (nmg.size() - 1)) / 2
+     << " edges present, " << stats.time() << " seconds"
+     << std::endl;
+  index_set_vec p_atms;
+  nmg.apx_independent_set_disjoint_cover(p_atms);
+  std::cerr << "cover by " << p_atms.length() << " independent sets"
+     << std::endl;
+  if (p_atms.length() > p_max) {
+    cost_matrix mc(0, p_atms.length(), p_atms.length());
+    for (index_type i = 0; i < p_atms.length(); i++)
+      for (index_type j = i + 1; j < p_atms.length(); j++)
+ mc[i][j] = nmg.n_induced_undirected_edges(p_atms[i], p_atms[j]);
+    while (p_atms.length() > p_max) {
+      index_type last = p_atms.length() - 1;
+      index_type i_min = 0;
+      for (index_type i = 1; i < last; i++)
+ if (mc[i][last] < mc[i_min][last])
+   i_min = i;
+      p_atms[i_min].insert(p_atms[last]);
+      p_atms.dec_length();
+      for (index_type i = 0; i < p_atms.length(); i++)
+ if (i < i_min)
+   mc[i][i_min] =
+     nmg.n_induced_undirected_edges(p_atms[i], p_atms[i_min]);
+ else if (i > i_min)
+   mc[i_min][i] =
+     nmg.n_induced_undirected_edges(p_atms[i], p_atms[i_min]);
+    }
+  }
+  index_set_vec p_acts(EMPTYSET, p_atms.length());
+  for (index_type k = 0; k < p_atms.length(); k++)
+    for (index_type i = 0; i < p_atms[k].length(); i++)
+      p_acts[k].insert(instance.atoms[p_atms[k][i]].add_by);
+  compute_fractional(cost, p_acts, useH2);
+  stats.stop();
+}
+void AH::compute_bottom_up
+(const ACF& cost, const index_set& g, bool do_glue, bool useH2)
+{
+  stats.start();
+  index_set_graph cg;
+  bool_vec rem(true, instance.n_atoms());
+  for (index_type k = 0; k < instance.n_invariants(); k++)
+    if (instance.invariants[k].lim == 1) {
+      cg.add_node();
+      cg.node_label(cg.size() - 1).assign_copy(instance.invariants[k].set);
+      rem.subtract(instance.invariants[k].set);
+    }
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (rem[k]) {
+      cg.add_node();
+      cg.node_label(cg.size() - 1).assign_singleton(k);
+    }
+  std::cerr << cg.size() << " state variables" << std::endl;
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    index_set ps;
+    for (index_type i = 0; i < cg.size(); i++)
+      if (instance.actions[k].pre.have_common_element(cg.node_label(i)))
+ ps.insert(i);
+    for (index_type i = 0; i < cg.size(); i++)
+      if (instance.actions[k].add.have_common_element(cg.node_label(i)))
+ cg.add_edge(ps, i);
+  }
+  equivalence p_eq(instance.n_atoms());
+  rem.assign_value(true, instance.n_atoms());
+  for (index_type k = 0; k < cg.size(); k++)
+    if (cg.out_degree(k) == 0) {
+      p_eq.merge(cg.node_label(k));
+      rem.subtract(cg.node_label(k));
+    }
+  std::cerr << p_eq.n_classes() << " initial partitions" << std::endl;
+  compute_max(cost, true);
+  graph hg0;
+  Hmax->compute_heuristic_graph(cost, hg0);
+  if (do_glue) {
+    bool done = false;
+    while (!done) {
+      done = true;
+      index_set_graph hg(hg0, p_eq);
+      index_set gn;
+      for (index_type i = 0; i < hg.size(); i++)
+ if (hg.node_label(i).have_common_element(instance.goal_atoms))
+   gn.insert(i);
+      bool_vec rn;
+      hg.ancestors(gn, rn);
+      for (index_type i = 0; i < hg.size(); i++) {
+ if (rn[i]) {
+   index_type nc = hg.predecessors(i).count_common(rn);
+   if (nc == 1) {
+     index_type fc = hg.predecessors(i).first_common_element(rn);
+     p_eq.merge(hg.node_label(i), hg.node_label(fc));
+     done = false;
+   }
+ }
+ else {
+   if (hg.in_degree(i) == 1) {
+     index_type j = hg.predecessors(i)[0];
+     p_eq.merge(hg.node_label(i), hg.node_label(j));
+     done = false;
+   }
+ }
+      }
+      std::cerr << p_eq.n_classes() << " partitions after glueing"
+  << std::endl;
+    }
+  }
+  index_set_vec p_atms;
+  p_eq.classes(p_atms);
+  index_set_vec p_acts(EMPTYSET, p_atms.length());
+  for (index_type k = 0; k < p_atms.length(); k++)
+    for (index_type i = 0; i < p_atms[k].length(); i++)
+      p_acts[k].insert(instance.atoms[p_atms[k][i]].add_by);
+  compute_fractional(cost, p_acts, useH2);
+  stats.stop();
+}
+void AH::compute_with_k_cuts
+(const ACF& cost, const index_set& g, index_type k, bool useH2)
+{
+  stats.start();
+  weighted_graph lg(instance.n_actions());
+  for (index_type i = 0; i < instance.n_actions(); i++)
+    for (index_type j = 0; j < instance.n_actions(); j++)
+      if ((i != j) &&
+   instance.actions[i].add.have_common_element(instance.actions[j].add))
+ lg.add_undirected_edge(i, j, 1);
+  equivalence a_eq;
+  lg.induced_partitioning(a_eq);
+  index_type b = a_eq.n_classes();
+  std::cerr << b << " initial partitions" << std::endl;
+  if (b < k) {
+    weighted_vec<index_pair, hsps::rational> cuts;
+    for (index_type i = 0; i < instance.n_actions(); i++)
+      for (index_type j = i+1; j < instance.n_actions(); j++)
+ if (lg.adjacent(i, j)) {
+   hsps::rational c = lg.max_flow(i, j);
+   std::cerr << "cut " << i << "-" << j << ": " << c << std::endl;
+   cuts.insert_increasing(index_pair(i, j), c);
+ }
+    for (index_type i = 0; i < cuts.length(); i++)
+      std::cerr << cuts[i].value << ", cost = " << cuts[i].weight
+  << std::endl;
+    pair_set e_all;
+    index_type i = 0;
+    while (b < k) {
+      assert(i < cuts.length());
+      index_type s = cuts[i].value.first;
+      index_type t = cuts[i].value.second;
+      assert(a_eq.canonical(s) == a_eq.canonical(t));
+      pair_set e_cut;
+      lg.min_cut(s, t, e_cut);
+      if (!e_all.contains(e_cut)) {
+ b += 1;
+ e_all.insert(e_cut);
+ std::cerr << "selected cut " << e_cut
+    << " with cost " << cuts[i].weight << std::endl;
+      }
+      i += 1;
+    }
+    lg.remove_undirected_edges(e_all);
+    lg.induced_partitioning(a_eq);
+    index_type b = a_eq.n_classes();
+    std::cerr << b << " final partitions" << std::endl;
+  }
+  index_set_vec p_acts;
+  a_eq.classes(p_acts);
+  compute_additive(cost, p_acts, useH2);
+  stats.stop();
+}
+void AH::compute_with_layered_partitioning
+(const ACF& cost, const index_set& g)
+{
+  stats.start();
+  std::cerr << "computing H2..." << std::endl;
+  Hmax = new CostTable(instance, stats);
+  Hmax->compute_H2(cost);
+  index_set_vec p;
+  bool_vec rem(true, instance.n_actions());
+  std::cerr << "computing layered action partition..." << std::endl;
+  compute_layered_action_partition(2, g, p, no_such_index, rem);
+  std::cerr << "computing additive H2 ("
+     << p.length() << " components)..."
+     << std::endl;
+  compute_additive(cost, p, true);
+  stats.stop();
+}
+void AH::max_cost_mset
+(index_type m, const index_set& g, index_set& s)
+{
+  assert(Hmax);
+  hsps::rational v_max = NEG_INF;
+  mSubsetEnumerator se(g.length(), m);
+  bool more = se.first();
+  while (more) {
+    index_set cs;
+    se.current_set(g, cs);
+    if (Hmax->eval(cs) > v_max) {
+      v_max = Hmax->eval(cs);
+      s.assign_copy(cs);
+    }
+    more = se.next();
+  }
+}
+void AH::goal_relevant_remaining_actions
+(const index_set& g, index_set& a, bool_vec& rem)
+{
+  a.clear();
+  for (index_type k = 0; k < instance.n_actions(); k++) if (rem[k]) {
+    Instance::Action& act = instance.actions[k];
+    if ((act.add.count_common(g) > 0) && (act.del.count_common(g) == 0))
+      a.insert(k);
+  }
+}
+void AH::compute_layered_action_partition
+(index_type m, const index_set& g, index_set_vec& p, index_type pg,
+ bool_vec& rem)
+{
+  std::cerr << "splitting " << g << "..." << std::endl;
+  index_set g0(g);
+  index_set_vec sub_g;
+  while (!g0.empty()) {
+    index_set next_p;
+    max_cost_mset(m, g0, next_p);
+    sub_g.append(next_p);
+    g0.subtract(next_p);
+  }
+  std::cerr << "result: " << sub_g << std::endl;
+  index_vec sub_p(no_such_index, sub_g.length());
+  index_set_vec new_g(sub_g.length());
+  for (index_type k = 0; k < sub_g.length(); k++) {
+    index_set rra;
+    goal_relevant_remaining_actions(sub_g[k], rra, rem);
+    std::cerr << "goal subset " << k << " = " << sub_g[k]
+       << ", rra = " << rra << std::endl;
+    if (!rra.empty()) {
+      if (pg != no_such_index) {
+ p[pg].insert(rra);
+ sub_p[k] = pg;
+ pg = no_such_index;
+      }
+      else {
+ p.inc_length();
+ p[p.length() - 1].insert(rra);
+ sub_p[k] = p.length() - 1;
+      }
+      for (index_type i = 0; i < rra.length(); i++) {
+ rem[rra[i]] = false;
+ new_g[k].insert(instance.actions[rra[i]].pre);
+      }
+    }
+  }
+  std::cerr << "action partitions: " << p << std::endl;
+  std::cerr << "new_g = " << new_g << std::endl;
+  for (index_type k = 0; k < sub_g.length(); k++) if (!new_g[k].empty()) {
+    compute_layered_action_partition(m, new_g[k], p, sub_p[k], rem);
+  }
+}
+hsps::rational AH::eval(const index_set& s)
+{
+  hsps::rational v_max = (Hmax ? Hmax->eval(s) : 0);
+  if ((v_max).infinite()) {
+    return v_max;
+  }
+  hsps::rational v_sum = 0;
+  if (trace_level > 2) {
+    std::cerr << "AH: v_max = " << v_max << ", v_sum = ";
+  }
+  for (index_type k = 0; k < H_vec.length(); k++) {
+    assert(H_vec[k]);
+    v_sum += H_vec[k]->eval(s);
+    if (trace_level > 2) {
+      std::cerr << " + " << H_vec[k]->eval(s);
+    }
+  }
+  if (trace_level > 2) {
+    std::cerr << " = " << v_sum << std::endl;
+  }
+  if (v_sum > v_max) {
+    Hsum_wins += 1;
+    return v_sum;
+  }
+  else if (v_max > v_sum) {
+    Hmax_wins += 1;
+    return v_max;
+  }
+  else {
+    draws += 1;
+    return v_max;
+  }
+}
+hsps::rational AH::eval(const bool_vec& s)
+{
+  hsps::rational v_max = (Hmax ? Hmax->eval(s) : 0);
+  if ((v_max).infinite()) {
+    return v_max;
+  }
+  hsps::rational v_sum = 0;
+  if (trace_level > 2) {
+    std::cerr << "AH: v_max = " << v_max << ", v_sum = ";
+  }
+  for (index_type k = 0; k < H_vec.length(); k++) {
+    assert(H_vec[k]);
+    v_sum += H_vec[k]->eval(s);
+    if (trace_level > 2) {
+      std::cerr << " + " << H_vec[k]->eval(s);
+    }
+  }
+  if (trace_level > 2) {
+    std::cerr << " = " << v_sum << std::endl;
+  }
+  if (v_sum > v_max) {
+    Hsum_wins += 1;
+    return v_sum;
+  }
+  else if (v_max > v_sum) {
+    Hmax_wins += 1;
+    return v_max;
+  }
+  else {
+    draws += 1;
+    return v_max;
+  }
+}
+void AH::write_eval(const index_set& s, std::ostream& st, char* p, bool e)
+{
+  hsps::rational v_max = (Hmax ? Hmax->eval(s) : 0);
+  hsps::rational v_sum = 0;
+  if (p) st << p << " (";
+  for (index_type k = 0; k < H_vec.length(); k++) {
+    assert(H_vec[k]);
+    v_sum += H_vec[k]->eval(s);
+    if (k > 0) st << " ";
+    st << H_vec[k]->eval(s);
+  }
+  st << ") " << v_sum << " " << v_max;
+  if (e) st << std::endl;
+}
+void AH::write_eval(const bool_vec& s, std::ostream& st, char* p, bool e)
+{
+  hsps::rational v_max = (Hmax ? Hmax->eval(s) : 0);
+  hsps::rational v_sum = 0;
+  if (p) st << p << " (";
+  for (index_type k = 0; k < H_vec.length(); k++) {
+    assert(H_vec[k]);
+    v_sum += H_vec[k]->eval(s);
+    if (k > 0) st << " ";
+    st << H_vec[k]->eval(s);
+  }
+  st << ") " << v_sum << " " << v_max;
+  if (e) st << std::endl;
+}
+hsps::rational AH::incremental_eval(const index_set& s, index_type i_new)
+{
+  hsps::rational v_max = (Hmax ? Hmax->incremental_eval(s, i_new) : 0);
+  hsps::rational v_sum = 0;
+  for (index_type k = 0; k < H_vec.length(); k++) {
+    assert(H_vec[k]);
+    v_sum += H_vec[k]->incremental_eval(s, i_new);
+  }
+  if (v_sum > v_max) {
+    Hsum_wins += 1;
+    return v_sum;
+  }
+  else if (v_max > v_sum) {
+    Hmax_wins += 1;
+    return v_max;
+  }
+  else {
+    draws += 1;
+    return v_max;
+  }
+}
+hsps::rational AH::incremental_eval(const bool_vec& s, index_type i_new)
+{
+  hsps::rational v_max = (Hmax ? Hmax->incremental_eval(s, i_new) : 0);
+  hsps::rational v_sum = 0;
+  for (index_type k = 0; k < H_vec.length(); k++) {
+    assert(H_vec[k]);
+    v_sum += H_vec[k]->incremental_eval(s, i_new);
+  }
+  if (v_sum > v_max) {
+    Hsum_wins += 1;
+    return v_sum;
+  }
+  else if (v_max > v_sum) {
+    Hmax_wins += 1;
+    return v_max;
+  }
+  else {
+    draws += 1;
+    return v_max;
+  }
+}
+hsps::rational AH::eval_to_bound(const index_set& s, hsps::rational bound)
+{
+  hsps::rational v_max = (Hmax ? Hmax->eval_to_bound(s, bound) : 0);
+  hsps::rational v_sum = 0;
+  for (index_type k = 0; (k < H_vec.length()) && (v_sum < bound); k++) {
+    assert(H_vec[k]);
+    v_sum += H_vec[k]->eval(s);
+  }
+  if (v_sum > v_max) {
+    Hsum_wins += 1;
+    return v_sum;
+  }
+  else if (v_max > v_sum) {
+    Hmax_wins += 1;
+    return v_max;
+  }
+  else {
+    draws += 1;
+    return v_max;
+  }
+}
+hsps::rational AH::eval_to_bound(const bool_vec& s, hsps::rational bound)
+{
+  hsps::rational v_max = (Hmax ? Hmax->eval_to_bound(s, bound) : 0);
+  hsps::rational v_sum = 0;
+  for (index_type k = 0; (k < H_vec.length()) && (v_sum < bound); k++) {
+    assert(H_vec[k]);
+    v_sum += H_vec[k]->eval(s);
+  }
+  if (v_sum > v_max) {
+    Hsum_wins += 1;
+    return v_sum;
+  }
+  else if (v_max > v_sum) {
+    Hmax_wins += 1;
+    return v_max;
+  }
+  else {
+    draws += 1;
+    return v_max;
+  }
+}
+void AH::store(const index_set& s, hsps::rational v, bool opt)
+{
+  if (Hmax) Hmax->store(s, v, opt);
+}
+void AH::store(const bool_vec& s, hsps::rational v, bool opt)
+{
+  if (Hmax) Hmax->store(s, v, opt);
+}
+}

--- a/pr/seq-opt-hspsf/atomset.ccx
+++ b/pr/seq-opt-hspsf/atomset.ccx
@@ -1,0 +1,4605 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+class AtomSet {
+ protected:
+  Instance& instance;
+  bool_vec set;
+  index_type size;
+  index_type count();
+ private:
+  hsps::rational split(index_set g, index_type p, index_type n_out, index_type limit,
+       StateFactory& f, State* sp, Search& s, hsps::rational bound);
+  hsps::rational split_random(index_set g, index_type p, index_type n_out,
+       index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+ public:
+  static index_type max_set_size_encountered;
+  AtomSet(Instance& i);
+  AtomSet(Instance& i, const index_set& g);
+  AtomSet(Instance& i, const bool_vec& g);
+  AtomSet(const AtomSet& s);
+  ~AtomSet();
+  index_type atom_set_size() { return size; };
+  void add(const index_set& s);
+  void add(const bool_vec& s);
+  void del(const index_set& s);
+  void del(const bool_vec& s);
+  bool is_init_all();
+  bool is_init_some();
+  bool is_goal_all();
+  bool is_goal_some();
+  index_vec& copy_to(index_vec& s);
+  bool_vec& copy_to(bool_vec& s);
+  hsps::rational split(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound);
+  hsps::rational split_random(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+  int compare(const AtomSet& s);
+  index_type hash();
+};
+class AtomSetState : public AtomSet, public State {
+ protected:
+  Heuristic& heuristic;
+  hsps::rational est;
+  hsps::rational eval();
+  hsps::rational eval(hsps::rational b_est);
+  hsps::rational eval_with_trace_level(int level);
+  void apply_path_max();
+ public:
+  AtomSetState(Instance& i, Heuristic& h);
+  AtomSetState(Instance& i, Heuristic& h, const index_set& g);
+  AtomSetState(Instance& i, Heuristic& h, const bool_vec& g);
+  AtomSetState(const AtomSetState& s);
+  virtual ~AtomSetState();
+  index_type atom_set_size() { return size; };
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual void write(std::ostream& s);
+  virtual void write_eval(std::ostream& s, char* p = 0, bool e = true);
+};
+}
+namespace hsps {
+index_type AtomSet::max_set_size_encountered = 0;
+index_type AtomSet::count() {
+  size = 0;
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (set[k]) size += 1;
+  return size;
+}
+void AtomSet::add(const index_set& s)
+{
+  for (index_type k = 0; k < s.length(); k++) {
+    if (!set[s[k]]) size += 1;
+    set[s[k]] = true;
+  }
+}
+void AtomSet::add(const bool_vec& s)
+{
+  for (index_type k = 0; k < instance.n_atoms(); k++) if (s[k]) {
+    if (!set[k]) size += 1;
+    set[k] = true;
+  }
+}
+void AtomSet::del(const index_set& s)
+{
+  for (index_type k = 0; k < s.length(); k++) {
+    if (set[s[k]]) size -= 1;
+    set[s[k]] = false;
+  }
+}
+void AtomSet::del(const bool_vec& s)
+{
+  for (index_type k = 0; k < instance.n_atoms(); k++) if (s[k]) {
+    if (set[k]) size -= 1;
+    set[k] = false;
+  }
+}
+bool AtomSet::is_init_all()
+{
+  for (index_type k = 0; k < instance.n_atoms(); k++) if (set[k])
+    if (!instance.atoms[k].init) return false;
+  return true;
+}
+bool AtomSet::is_init_some()
+{
+  for (index_type k = 0; k < instance.n_atoms(); k++) if (set[k])
+    if (!instance.atoms[k].init) return true;
+  return false;
+}
+bool AtomSet::is_goal_all()
+{
+  for (index_type k = 0; k < instance.n_atoms(); k++) if (set[k])
+    if (!instance.atoms[k].goal) return false;
+  return true;
+}
+bool AtomSet::is_goal_some()
+{
+  for (index_type k = 0; k < instance.n_atoms(); k++) if (set[k])
+    if (!instance.atoms[k].goal) return true;
+  return false;
+}
+AtomSet::AtomSet(Instance& i)
+  : instance(i),
+    set(false, instance.n_atoms()),
+    size(0)
+{
+}
+AtomSet::AtomSet(Instance& i, const index_set& g)
+  : instance(i),
+    set(false, instance.n_atoms()),
+    size(g.length())
+{
+  set.insert(g);
+}
+AtomSet::AtomSet(Instance& i, const bool_vec& g)
+  : instance(i),
+    set(g),
+    size(0)
+{
+  size = set.count(true);
+}
+AtomSet::AtomSet(const AtomSet& s)
+  : instance(s.instance),
+    set(s.set),
+    size(s.size)
+{
+}
+AtomSet::~AtomSet()
+{
+}
+index_vec& AtomSet::copy_to(index_vec& s)
+{
+  s.set_length(0);
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (set[k]) s.append(k);
+  return s;
+}
+bool_vec& AtomSet::copy_to(bool_vec& s)
+{
+  s = set;
+  return s;
+}
+hsps::rational AtomSet::split
+(index_set g,
+ index_type p,
+ index_type n_out,
+ index_type limit,
+ StateFactory& f,
+ State* sp,
+ Search& s,
+ hsps::rational bound)
+{
+  if ((g.length() - n_out) <= limit) {
+    State* sub_s = f.new_state(set, sp);
+    hsps::rational c_sub = s.new_state(*sub_s, bound);
+    delete sub_s;
+    return c_sub;
+  }
+  else if ((g.length() - p) > ((g.length() - limit) - n_out)) {
+    hsps::rational c_in = split(g, p + 1, n_out, limit, f, sp, s, bound);
+    if (s.done()) return c_in;
+    set[g[p]] = false;
+    hsps::rational c_out = split(g, p + 1, n_out + 1, limit, f, sp, s, bound);
+    set[g[p]] = true;
+    return hsps::rational::max(c_in,c_out);
+  }
+  else {
+    for (index_type k = p; k < g.length(); k++) set[g[k]] = false;
+    State* sub_s = f.new_state(set, sp);
+    hsps::rational c_sub = s.new_state(*sub_s, bound);
+    for (index_type k = p; k < g.length(); k++) set[g[k]] = true;
+    delete sub_s;
+    return c_sub;
+  }
+}
+hsps::rational AtomSet::split
+(index_type limit, StateFactory& f, State* sp, Search& s, hsps::rational bound)
+{
+  index_set g;
+  copy_to(g);
+  hsps::rational c = split(g, 0, 0, limit, f, sp, s, bound);
+  return c;
+}
+hsps::rational AtomSet::split_random
+(index_set g,
+ index_type p,
+ index_type n_out,
+ index_type limit,
+ StateFactory& f,
+ State* sp,
+ Search& s,
+ hsps::rational bound,
+ RNG& r)
+{
+  if ((g.length() - n_out) <= limit) {
+    State* sub_s = f.new_state(set, sp);
+    hsps::rational c_sub = s.new_state(*sub_s, bound);
+    delete sub_s;
+    return c_sub;
+  }
+  else if ((g.length() - p) > ((g.length() - limit) - n_out)) {
+    if (r.random() % 2) {
+      return split_random(g, p + 1, n_out, limit, f, sp, s, bound, r);
+    }
+    else {
+      set[g[p]] = false;
+      hsps::rational c_out = split_random(g, p + 1, n_out + 1, limit, f, sp, s, bound, r);
+      set[g[p]] = true;
+      return c_out;
+    }
+  }
+  else {
+    for (index_type k = p; k < g.length(); k++) set[g[k]] = false;
+    State* sub_s = f.new_state(set, sp);
+    hsps::rational c_sub = s.new_state(*sub_s, bound);
+    for (index_type k = p; k < g.length(); k++) set[g[k]] = true;
+    delete sub_s;
+    return c_sub;
+  }
+}
+hsps::rational AtomSet::split_random
+(index_type limit, StateFactory& f, State* sp, Search& s, hsps::rational bound, RNG& r)
+{
+  index_set g;
+  copy_to(g);
+  return split_random(g, 0, 0, limit, f, sp, s, bound, r);
+}
+int AtomSet::compare(const AtomSet& s)
+{
+  for (index_type k = 0; k < instance.n_atoms(); k++) {
+    if (!set[k] && s.set[k]) return -1;
+    else if (set[k] && !s.set[k]) return 1;
+  }
+  return 0;
+}
+index_type AtomSet::hash()
+{
+  index_type val = instance.atom_set_hash(set);
+  return val;
+}
+AtomSetState::AtomSetState(Instance& i, Heuristic& h)
+  : AtomSet(i),
+    heuristic(h),
+    est(0)
+{
+}
+AtomSetState::AtomSetState(Instance& i, Heuristic& h, const index_set& g)
+  : AtomSet(i, g),
+    heuristic(h),
+    est(0)
+{
+  reevaluate();
+}
+AtomSetState::AtomSetState(Instance& i, Heuristic& h, const bool_vec& g)
+  : AtomSet(i, g),
+    heuristic(h),
+    est(0)
+{
+  reevaluate();
+}
+AtomSetState::AtomSetState(const AtomSetState& s)
+  : AtomSet(s),
+    State(s),
+    heuristic(s.heuristic),
+    est(s.est)
+{
+}
+AtomSetState::~AtomSetState()
+{
+}
+hsps::rational AtomSetState::eval()
+{
+  est = heuristic.eval(set);
+  return est;
+}
+hsps::rational AtomSetState::eval(hsps::rational bound)
+{
+  return heuristic.eval_to_bound(set, bound);
+}
+hsps::rational AtomSetState::eval_with_trace_level(int level)
+{
+  heuristic.set_trace_level(level);
+  est = heuristic.eval(set);
+  heuristic.set_trace_level(0);
+  return est;
+}
+void AtomSetState::apply_path_max()
+{
+  if (pre) {
+    if (pre->est_cost() > (delta_cost() + est)) {
+      est = (pre->est_cost() - delta_cost());
+    }
+  }
+}
+hsps::rational AtomSetState::est_cost()
+{
+  return est;
+}
+bool AtomSetState::is_final()
+{
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (set[k] && !instance.atoms[k].init) return false;
+  if (size > max_set_size_encountered) max_set_size_encountered = size;
+  return true;
+}
+bool AtomSetState::is_max()
+{
+  return false;
+}
+void AtomSetState::store(hsps::rational cost, bool opt)
+{
+  heuristic.store(set, cost, opt);
+}
+void AtomSetState::reevaluate()
+{
+  est = heuristic.eval(set);
+}
+int AtomSetState::compare(const State& s)
+{
+  const AtomSetState& as = (const AtomSetState&)s;
+  return AtomSet::compare(as);
+}
+index_type AtomSetState::hash()
+{
+  index_type val = instance.atom_set_hash(set);
+  return val;
+}
+void AtomSetState::write(std::ostream& s)
+{
+  instance.write_atom_set(s, set);
+}
+void AtomSetState::write_eval(std::ostream& s, char* p, bool e)
+{
+  heuristic.write_eval(set, s, p, e);
+}
+}

--- a/pr/seq-opt-hspsf/base.ccx
+++ b/pr/seq-opt-hspsf/base.ccx
@@ -1,0 +1,17035 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class PDDL_Name;
+class PDDL_Base {
+ public:
+  static bool use_default_function_value;
+  static hsps::rational default_function_value;
+  static bool use_strict_borrow_definition;
+  static bool use_extended_borrow_definition;
+  static bool del_before_add_semantics;
+  static bool compact_resource_effects;
+  static bool compile_away_disjunctive_preconditions;
+  static bool check_precondition_consistency;
+  static bool compile_away_conditional_effects;
+  static bool compile_away_plan_constraints;
+  static bool compile_away_object_functions;
+  static bool compile_for_validator;
+  static bool create_all_atoms;
+  static bool create_all_actions;
+  static bool number_multiple_action_instances;
+  static bool exclude_all_dkel_items;
+  static string_set excluded_dkel_tags;
+  static string_set required_dkel_tags;
+  static bool strict_set_export;
+  static bool best_effort;
+  static bool write_PDDL31;
+  static bool write_warnings;
+  static bool write_info;
+  static bool write_trace;
+  static bool trace_print_context;
+  static bool name_instance_by_problem_file;
+  static const char* instance_name_prefix;
+  enum symbol_class {
+    sym_object,
+    sym_typename,
+    sym_predicate,
+    sym_object_function,
+    sym_function,
+    sym_action,
+    sym_variable,
+    sym_misc,
+    sym_preference,
+    sym_set,
+    sym_meta_variable
+  };
+  enum metric_class {
+    metric_none,
+    metric_makespan,
+    metric_minimize,
+    metric_maximize
+  };
+  enum mode_keyword {
+    md_none,
+    md_start,
+    md_end,
+    md_all,
+    md_init,
+    md_pos_goal,
+    md_neg_goal
+  };
+  enum partial_value { p_false, p_true, p_unknown };
+  enum expression_class {
+    exp_fun,
+    exp_list,
+    exp_const,
+    exp_add,
+    exp_sub,
+    exp_mul,
+    exp_div,
+    exp_time,
+    exp_preference
+  };
+  enum relation_type {
+    rel_equal,
+    rel_greater,
+    rel_greater_equal,
+    rel_less,
+    rel_less_equal
+  };
+  enum formula_class { fc_false,
+         fc_true,
+         fc_atom,
+         fc_equality,
+         fc_negation,
+         fc_conjunction,
+         fc_disjunction,
+         fc_equivalence,
+         fc_implication,
+         fc_universal,
+         fc_existential,
+         fc_list
+  };
+  struct Symbol;
+  struct TypeSymbol;
+  struct Atom;
+  struct FTerm;
+  struct FChangeAtom;
+  struct SetOf;
+  struct ListExpression;
+  struct ActionSymbol;
+  struct Reference;
+  struct IrrelevantItem;
+  typedef lvector<TypeSymbol*> type_vec;
+  typedef lvector<Atom*> atom_vec;
+  typedef lvector<FChangeAtom*> ch_atom_vec;
+  typedef lvector<SetOf*> atom_set_vec;
+  typedef lvector<Reference*> ref_vec;
+  typedef lvector<IrrelevantItem*> irrelevant_vec;
+  struct TypeSet : public type_vec {
+    TypeSet() : type_vec(0, 0) { };
+    TypeSet(const TypeSet& s) : type_vec(s) { };
+    TypeSet(TypeSymbol* t) : type_vec(t, 1) { };
+    index_type n_elements() const;
+    Symbol* get_element(index_type n);
+    bool is_object() const;
+    bool subtype_or_equal(const TypeSet& s) const;
+    bool subtype_or_equal(TypeSymbol* t) const;
+    void print(std::ostream& s) const;
+    void write_type(std::ostream& s) const;
+  };
+  struct Symbol {
+    symbol_class sym_class;
+    char* print_name;
+    TypeSet sym_types;
+    bool defined_in_problem;
+    bool visible;
+    Symbol(symbol_class c, char* n)
+      : sym_class(c), print_name(n), defined_in_problem(false), visible(true) { };
+    Symbol(char* n)
+      : sym_class(sym_object), print_name(n), defined_in_problem(false), visible(true) { };
+    void print(std::ostream& s) const;
+  };
+  typedef zero_init_pair<Symbol*> symbol_pair;
+  typedef lvector<Symbol*> symbol_vec;
+  typedef svector<Symbol*> symbol_set;
+  typedef lvector<symbol_pair> symbol_pair_vec;
+  static bool extend_substitution(Symbol* out, Symbol* in, symbol_pair_vec& u);
+  static bool print_substitution(std::ostream& s, const symbol_pair_vec& u);
+  static bool print_inequality(std::ostream& s, const symbol_pair_vec& neq);
+  static bool substitution_violates_inequality(const symbol_pair_vec& neq,
+            const symbol_pair_vec& u);
+  static index_type find_matching_atom(Atom* a, atom_vec& v);
+  static index_type find_matching_atom(Atom* a, mode_keyword m, atom_vec& v);
+  static index_type find_matching_fluent_atom
+    (FChangeAtom* a, mode_keyword m, ch_atom_vec& v);
+  struct TypeSymbol : public Symbol {
+    symbol_vec elements;
+    bool is_base_type;
+    TypeSymbol(char* n) : Symbol(sym_typename, n), elements(0, 0),
+  is_base_type(false) { };
+    void add_element(Symbol* e);
+    bool is_object() const { return (strcmp(print_name, "object") == 0); };
+    bool subtype_or_equal(TypeSymbol* t) const;
+    bool subtype_or_equal(const TypeSet& t) const;
+    void print(std::ostream& s) const;
+  };
+  struct VariableSymbol : public Symbol {
+    Symbol* value;
+    FTerm* binding;
+    VariableSymbol(char* n) : Symbol(sym_variable, n), value(0), binding(0) {};
+    bool equality_type_check(Symbol* s);
+    void print(std::ostream& s);
+  };
+  typedef lvector<VariableSymbol*> variable_vec;
+  struct ParamSymbol : public Symbol {
+    variable_vec param;
+    ParamSymbol(symbol_class c, char* n) : Symbol(c, n), param(0, 0) { };
+  };
+  struct PredicateSymbol : public ParamSymbol {
+    bool pos_pre;
+    bool neg_pre;
+    bool added;
+    bool deleted;
+    bool locked;
+    bool modded;
+    ptr_table init;
+    ptr_table pos_goal;
+    ptr_table neg_goal;
+    ptr_table pos_prop;
+    ptr_table neg_prop;
+    irrelevant_vec irr_ins;
+    PredicateSymbol(char* n) : ParamSymbol(sym_predicate, n),
+  pos_pre(false), neg_pre(false), added(false), deleted(false),
+  locked(false), modded(false), irr_ins(0, 0) { };
+    bool is_static() const { return !modded; };
+    bool is_equality() const { return (strcmp(print_name, "=") == 0); };
+    void instantiate(Instance& ins);
+    void initialise_missing(const symbol_vec& p,
+       atom_vec* created,
+       index_type i = 0);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+  };
+  struct ObjectFunctionSymbol : public ParamSymbol {
+    bool modded;
+    ptr_table init;
+    ObjectFunctionSymbol(char* n)
+      : ParamSymbol(sym_object_function, n), modded(false) { };
+    bool is_static() const { return !modded; };
+    void print(std::ostream& s);
+  };
+  struct FunctionSymbol : public ParamSymbol {
+    bool modified;
+    bool integral;
+    bool linear;
+    bool conditioned;
+    bool increased;
+    bool decreased;
+    bool assigned;
+    bool borrowed;
+    ptr_table init;
+    FunctionSymbol(char* n) : ParamSymbol(sym_function, n),
+  modified(false), integral(true), linear(true), conditioned(false),
+  increased(false), decreased(false), assigned(false), borrowed(false)
+    { };
+    bool is_static() const
+    { return !modified; };
+    bool is_reusable() const
+    { return borrowed && !increased && !decreased && !assigned; };
+    bool is_consumable() const
+    { return !borrowed && !increased && decreased && !assigned; };
+    interval eval_init_bounds(ptr_table* p, index_type i, ListExpression* r);
+    void print(std::ostream& s);
+  };
+  struct AtomBase {
+    symbol_vec param;
+    mode_keyword at;
+    hsps::rational at_time;
+    AtomBase() : param(0, 0), at(md_none), at_time(0) { };
+    AtomBase(mode_keyword t) : param(0, 0), at(t), at_time(0) { };
+    AtomBase(AtomBase* b);
+    bool equals(AtomBase& b);
+    void free_variables(variable_vec& v);
+    bool occurs(Symbol* s);
+    void fill_in_args(AtomBase* b);
+    void collect_bound_variables(variable_vec& v);
+    void insert(ptr_table& t);
+    static bool print_bindings;
+    void print(std::ostream& s) const;
+    void print_instance(std::ostream& s);
+  };
+  typedef lvector<AtomBase*> atom_base_vec;
+  struct Atom : AtomBase {
+    PredicateSymbol* pred;
+    Atom(PredicateSymbol* p) : pred(p) { };
+    Atom(PredicateSymbol* p, mode_keyword t) : AtomBase(t), pred(p) { };
+    Atom(PredicateSymbol* p, variable_vec& a, bool as_value)
+      : pred(p)
+    {
+      param.set_length(a.length());
+      for (index_type k = 0; k < a.length(); k++)
+ param[k] = (as_value ? a[k]->value : a[k]);
+    };
+    Atom(PredicateSymbol* p, Symbol* a0)
+      : pred(p)
+    {
+      param.append(a0);
+    };
+    Atom(Atom* a) : AtomBase(a), pred(a->pred) { };
+    bool equals(Atom& a);
+    bool is_static() const {
+      return ((at == md_init) ||
+       (at == md_pos_goal) ||
+       (at == md_neg_goal) ||
+       pred->is_static());
+    };
+    bool check();
+    Instance::Atom* find_prop(Instance& ins, bool neg, bool create);
+    void build(Instance& ins, bool neg, index_type p);
+    Atom* instantiate_partially();
+    partial_value partial_eval(ptr_table* r, index_type p);
+    partial_value partial_eval();
+    bool initial_value();
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    void print(std::ostream& s, bool neg) const;
+    void print(std::ostream& s) const { print(s, false); };
+  };
+  struct CAtom : public Atom {
+    symbol_pair_vec neq;
+    CAtom(Atom* a) : Atom(a), neq(symbol_pair(0, 0), 0) { };
+    CAtom(CAtom* s) : Atom(s), neq(s->neq) { };
+    CAtom(const Atom* a, symbol_pair_vec& u);
+    CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool instance_of(CAtom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(CAtom* a, symbol_pair_vec& u);
+    void print(std::ostream& s);
+  };
+  typedef lvector<CAtom*> catom_vec;
+  struct FTerm : AtomBase {
+    ObjectFunctionSymbol* fun;
+    FTerm(ObjectFunctionSymbol* f) : fun(f) { };
+    bool equals(FTerm& a);
+    void print(std::ostream& s) const;
+  };
+  struct OInitAtom : AtomBase {
+    ObjectFunctionSymbol* fun;
+    Symbol* val;
+    OInitAtom(ObjectFunctionSymbol* f) : fun(f), val(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<OInitAtom*> obj_init_atom_vec;
+  struct FInitAtom : AtomBase {
+    FunctionSymbol* fun;
+    hsps::rational val;
+    Instance::resource_ref res;
+    FInitAtom(FunctionSymbol* f) : fun(f), val(0) { };
+    FInitAtom(FChangeAtom* a);
+    bool is_static() const { return fun->is_static(); };
+    void print(std::ostream& s);
+  };
+  typedef lvector<FInitAtom*> fun_init_atom_vec;
+  struct Expression;
+  typedef lvector<Expression*> exp_vec;
+  struct Expression {
+    expression_class exp_class;
+    Expression(expression_class c) : exp_class(c) { };
+    static bool print_nary;
+    bool is_static();
+    bool is_constant();
+    bool is_integral();
+    hsps::rational eval_static();
+    bool eval_partial(hsps::rational& val);
+    interval eval_bounds();
+    hsps::rational eval_init();
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    hsps::rational eval_delta(Symbol* preference, hsps::rational p_value, hsps::rational d_value);
+    Expression* copy();
+    Expression* simplify();
+    void collect_constants(exp_vec& c);
+    void mark_functions_in_condition();
+    hsps::rational integrify();
+    void substitute_for_time(Expression* e);
+    Expression* substitute_for_preference(Symbol* n, Expression* e);
+    bool equals(Expression* e);
+    void print_sum(std::ostream& s, bool grnd);
+    void print_product(std::ostream& s, bool grnd);
+    void print(std::ostream& s, bool grnd);
+  };
+  struct ListExpression : public Expression {
+    Symbol* sym;
+    ListExpression* rest;
+    ListExpression(Symbol* s, ListExpression* r) :
+      Expression(exp_list), sym(s), rest(r) { };
+    bool match(AtomBase* atom);
+  };
+  struct FunctionExpression : public Expression {
+    FunctionSymbol* fun;
+    ListExpression* args;
+    FunctionExpression(FunctionSymbol* f, ListExpression* a) :
+      Expression(exp_fun), fun(f), args(a) { };
+    bool match(FChangeAtom* atom);
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    FChangeAtom* make_atom_base();
+  };
+  struct ConstantExpression : public Expression {
+    hsps::rational val;
+    ConstantExpression(hsps::rational v) :
+      Expression(exp_const), val(v) { };
+  };
+  struct TimeExpression : public Expression {
+    Expression* time_exp;
+    TimeExpression() :
+      Expression(exp_time), time_exp(0) { };
+    TimeExpression(Expression* e) :
+      Expression(exp_time), time_exp(e) { };
+  };
+  struct BinaryExpression : public Expression {
+    Expression* first;
+    Expression* second;
+    BinaryExpression(expression_class c, Expression* e1, Expression* e2) :
+      Expression(c), first(e1), second(e2) { };
+  };
+  struct PreferenceExpression : public Expression {
+    Symbol* name;
+    PreferenceExpression(Symbol* n) :
+      Expression(exp_preference), name(n) { };
+  };
+  struct Relation {
+    relation_type rel;
+    mode_keyword at;
+    Expression* first;
+    Expression* second;
+    Relation(relation_type r, Expression* e1, Expression* e2) :
+      rel(r), at(md_none), first(e1), second(e2) { };
+    Relation(relation_type r, mode_keyword m, Expression* e1, Expression* e2) :
+      rel(r), at(m), first(e1), second(e2) { };
+    Expression* match_gteq_constant(FChangeAtom* atom);
+    FunctionExpression* match_lteq_fun(FChangeAtom* atom);
+    bool is_static();
+    partial_value partial_eval();
+    void print(std::ostream& s, bool grnd);
+  };
+  typedef lvector<Relation*> relation_vec;
+  struct FChangeAtom : AtomBase {
+    FunctionSymbol* fun;
+    Expression* val;
+    FChangeAtom(FunctionSymbol* f) :
+      fun(f), val(0) { };
+    FChangeAtom(FunctionSymbol* f, mode_keyword t) :
+      AtomBase(t), fun(f), val(0) { };
+    FChangeAtom(FChangeAtom* a, hsps::rational v) :
+      AtomBase(a), fun(a->fun), val(new ConstantExpression(v)) { };
+    bool equals(FChangeAtom& a);
+    bool fluent_equals(FChangeAtom& a);
+    bool fluent_and_mode_equals(FChangeAtom& a);
+    FChangeAtom* find_fluent_equals(ch_atom_vec& vec);
+    Instance::Resource* find_resource(Instance& ins);
+    void print(std::ostream& s);
+  };
+  struct Formula {
+    formula_class fc;
+    Formula(formula_class c) : fc(c) { };
+    void rename_variables_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_variables_2(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_2(PDDL_Base::symbol_pair_vec& sub);
+    Formula* simplify();
+    void write_otter(std::ostream& s) const;
+    void print(std::ostream& s) const;
+    void untype(PDDL_Base* base);
+  };
+  typedef lvector<Formula*> formula_vec;
+  struct AFormula : public Formula, public Atom {
+    AFormula(Atom* a) :
+      Formula(fc_atom), Atom(a) { };
+    AFormula(PredicateSymbol* p) :
+      Formula(fc_atom), Atom(p) { };
+    AFormula(PredicateSymbol* p, variable_vec& a) :
+      Formula(fc_atom), Atom(p, a, false) { };
+    void print(std::ostream& s) const;
+    void write_otter(std::ostream& s) const;
+  };
+  struct EqFormula : public Formula {
+    Symbol* t1;
+    Symbol* t2;
+    EqFormula(Symbol* s1, Symbol* s2) :
+      Formula(fc_equality), t1(s1), t2(s2) { };
+    void write_otter(std::ostream& s) const;
+  };
+  struct NFormula : public Formula {
+    Formula* f;
+    NFormula(Formula* g) : Formula(fc_negation), f(g) { };
+  };
+  struct BFormula : public Formula {
+    Formula* f1;
+    Formula* f2;
+    BFormula(formula_class c, Formula* g1, Formula* g2) :
+      Formula(c), f1(g1), f2(g2) { };
+  };
+  struct CFormula : public Formula {
+    formula_vec parts;
+    CFormula(formula_class c) : Formula(c), parts(0, 0) { };
+    CFormula(formula_class c, Formula* f1, Formula* f2) :
+      Formula(c), parts(0, 0)
+    {
+      parts.append(f1);
+      parts.append(f2);
+    };
+    void add(Formula* f) { parts.append(f); };
+    void add(formula_vec& f) { parts.append(f); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct QFormula : public Formula {
+    variable_vec vars;
+    Formula* f;
+    QFormula(formula_class c) : Formula(c), vars(0, 0), f(0) { };
+    QFormula(formula_class c, Formula* g) : Formula(c), vars(0, 0), f(g) { };
+    QFormula(formula_class c, variable_vec& v, Formula* g) :
+      Formula(c), vars(0, 0), f(g)
+    {
+      for (index_type k = 0; k < v.length(); k++) vars.append(v[k]);
+    };
+    void add(PDDL_Base::VariableSymbol* v) { vars.append(v); };
+    void add(PDDL_Base::variable_vec& v) { vars.append(v); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct TypeConstraint {
+    VariableSymbol* var;
+    TypeSymbol* typ;
+    TypeConstraint(VariableSymbol* v, TypeSymbol* t) : var(v), typ(t) { };
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+  };
+  typedef lvector<TypeConstraint*> type_constraint_vec;
+  struct Context {
+    variable_vec param;
+    atom_vec pos_con;
+    atom_vec neg_con;
+    type_constraint_vec type_con;
+    Context() : param(0, 0), pos_con(0, 0), neg_con(0, 0), type_con(0, 0) { };
+    Context(const Context* c) : param(c->param), pos_con(c->pos_con),
+  neg_con(c->neg_con), type_con(c->type_con) { };
+    bool context_is_static() const;
+    bool occurs_in_context(Symbol* s);
+    void clear_arguments();
+    void set_mode(mode_keyword m);
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+    void print_assignment(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct DKEL_Item : public Context {
+    char* item_name;
+    Symbol* name;
+    string_set item_tags;
+    bool defined_in_problem;
+    bool included;
+    DKEL_Item(char* name) : item_name(name), name(0),
+  defined_in_problem(false), included(true) { };
+    DKEL_Item(const DKEL_Item* i) : Context(i), item_name(i->item_name),
+  name(i->name), item_tags(i->item_tags),
+  defined_in_problem(i->defined_in_problem), included(i->included) { };
+    bool item_is_included(string_set& ex_tags, string_set& req_tags);
+    void print_begin(std::ostream& s);
+    void print_end(std::ostream& s);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SetOf : public Context {
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    SetOf() : pos_atoms(0, 0), neg_atoms(0, 0) { };
+    SetOf(const SetOf* s)
+      : Context(s), pos_atoms(s->pos_atoms), neg_atoms(s->neg_atoms)
+    { };
+    SetOf(Atom* a)
+    { pos_atoms.append(a); };
+    SetOf(Atom* a, bool n)
+    { if (n) neg_atoms.append(a); else pos_atoms.append(a); };
+    bool is_static() const;
+    void set_mode(mode_keyword m);
+    partial_value partial_eval(bool as_disjunction = false);
+    partial_value partial_eval(index_type p, bool as_disjunction = false);
+    void instantiate_as_set(Instance& ins, index_set& s);
+    void instantiate_as_effect(Instance& ins, index_set& s_add,
+          index_set& s_del);
+    void instantiate_conditional(Instance& ins, rule_set& s_pos,
+     rule_set& s_neg);
+    SetOf* instantiate_partially();
+    void compile(atom_vec& pos_ins, atom_vec& neg_ins, index_type p);
+    void compile_non_static(atom_set_vec& ins, index_type p);
+    void print(std::ostream& s);
+    void print_as_disjunction(std::ostream& s);
+    void build_set(Instance& ins, index_set& s, index_type p);
+    void build_effect(Instance& ins, index_set& s_add, index_set& s_del,
+        index_type p);
+    void build_conditional(Instance& ins, rule_set& s_pos, rule_set& s_neg,
+      index_type p);
+  };
+  struct QCNumericEffect : public Context {
+    FChangeAtom* atom;
+    QCNumericEffect() : atom(0) { };
+    QCNumericEffect(FChangeAtom* a) : atom(a) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<QCNumericEffect*> qc_numeric_effect_vec;
+  enum set_constraint_keyword { sc_at_least, sc_at_most, sc_exactly };
+  struct SetConstraint : public DKEL_Item {
+    set_constraint_keyword sc_type;
+    index_type sc_count;
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    atom_set_vec atom_sets;
+    SetConstraint() : DKEL_Item(":invariant"), sc_type(sc_at_least),
+  sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0), atom_sets(0, 0) { };
+    SetConstraint(const DKEL_Item* item) : DKEL_Item(item),
+  sc_type(sc_at_least), sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0),
+  atom_sets(0, 0) { };
+    void build(Instance& ins, index_type p);
+    void instantiate(Instance& ins);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InvariantFormula : public DKEL_Item {
+    Formula* f;
+    InvariantFormula(Formula* g)
+      : DKEL_Item(":invariant"), f(g) { };
+    InvariantFormula(const DKEL_Item* item, Formula* g)
+      : DKEL_Item(item), f(g) { };
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct Reference : public AtomBase {
+    Symbol* name;
+    bool neg;
+    bool has_args;
+    index_set index;
+    Reference(Symbol* n) : name(n), neg(false), has_args(true) { };
+    Reference(Symbol* n, bool ng, bool ha)
+      : name(n), neg(ng), has_args(ha) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    void* find_action();
+    void find(const name_vec& names, index_set& ind);
+    Reference* instantiate_partially();
+    void print(std::ostream& s);
+  };
+  struct IrrelevantItem : public DKEL_Item {
+    Reference* entity;
+    IrrelevantItem() : DKEL_Item(":irrelevant"), entity(0) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    IrrelevantItem* instantiate_partially();
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SequentialTaskNet : public Context {
+    ref_vec tasks;
+    ActionSymbol* abs_act;
+    SequentialTaskNet() : tasks(0, 0), abs_act(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<SequentialTaskNet*> task_net_vec;
+  struct SetSymbol : public Symbol {
+    ptr_table set_table;
+    lvector<index_set*> sets;
+    name_vec names;
+    SetSymbol(char* n) : Symbol(sym_set, n), sets(0, 0), names(0, 0) { };
+  };
+  struct SetName : public AtomBase {
+    SetSymbol* sym;
+    SetName(SetSymbol* s) : sym(s) { };
+    index_set* find();
+    SetName* instantiate_partially();
+    void print(std::ostream& s);
+    void print_instance(std::ostream& s);
+  };
+  struct ActionSymbol : public ParamSymbol {
+    atom_vec pos_pre;
+    atom_vec neg_pre;
+    atom_set_vec set_pre;
+    atom_set_vec dis_pre;
+    relation_vec num_pre;
+    atom_vec adds;
+    atom_vec dels;
+    atom_set_vec set_eff;
+    atom_vec cons;
+    atom_set_vec cond_eff;
+    atom_vec locks;
+    atom_vec enables;
+    ch_atom_vec reqs;
+    ch_atom_vec incs;
+    ch_atom_vec decs;
+    ch_atom_vec fass;
+    qc_numeric_effect_vec qc_incs;
+    qc_numeric_effect_vec qc_decs;
+    qc_numeric_effect_vec qc_fass;
+    Expression* dmin;
+    Expression* dmax;
+    irrelevant_vec irr_ins;
+    ref_vec refs;
+    task_net_vec exps;
+    ptr_table instances;
+    SetName* part;
+    const char* assoc;
+    ActionSymbol(char* n) : ParamSymbol(sym_action, n), pos_pre(0, 0),
+  neg_pre(0, 0), set_pre(0, 0), dis_pre(0, 0), num_pre(0, 0),
+  adds(0, 0), dels(0, 0), set_eff(0, 0), cons(0, 0), cond_eff(0, 0),
+  locks(0, 0), enables(0, 0), reqs(0, 0), incs(0, 0), decs(0, 0),
+  fass(0, 0), qc_incs(0, 0), qc_decs(0, 0), qc_fass(0, 0), dmin(0),
+  dmax(0), irr_ins(0, 0), refs(0, 0), exps(0, 0), part(0), assoc(0) { };
+    void build(Instance& ins, index_type p, Expression* cost_exp);
+    Instance::Action& build_action(Instance& ins,
+       PDDL_Name* name,
+       index_type& count,
+       const index_set& pre,
+       const index_set& add,
+       const index_set& del,
+       const index_set& lck,
+       const index_cost_vec& r_use,
+       const index_cost_vec& r_cons,
+       hsps::rational dmin,
+       hsps::rational dmax,
+       hsps::rational dur,
+       hsps::rational cost);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          index_vec& s,
+          index_type p);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc);
+    void build_actions_with_dc_and_ce(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          const rule_set& pce,
+          const rule_set& nce,
+          const bool_vec& ece);
+    index_type param_index(VariableSymbol* p);
+    void get_param_inequalities(symbol_pair_vec& neq);
+    void set_arguments(const symbol_vec& args);
+    void set_arguments(const ptr_table::key_vec& args);
+    void clear_arguments();
+    void* find_instance();
+    bool is_abstract();
+    void post_process();
+    void instantiate(Instance& ins, Expression* cost_exp);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InputPlanStep {
+    Reference* act;
+    hsps::rational start_time;
+    InputPlanStep() : act(0), start_time(0) { };
+    InputPlanStep(Reference* a, hsps::rational t) : act(a), start_time(t) { };
+  };
+  struct InputPlan {
+    Symbol* name;
+    bool is_opt;
+    lvector<InputPlanStep*> steps;
+    InputPlan() : name(0), is_opt(false), steps(0, 0) { };
+    bool export_to_instance(Instance& ins, const index_vec& map, Plan& p);
+    void print(std::ostream& s);
+  };
+  struct HTableEntry {
+    atom_vec atoms;
+    bool_vec neg;
+    hsps::rational cost;
+    bool opt;
+    HTableEntry() : atoms(0, 0), neg(false, 0), cost(0), opt(false) { };
+  };
+  struct SimpleReferenceSet : public Context {
+    Reference* ref;
+    SimpleReferenceSet(Reference* r) : ref(r) { };
+    bool build(const name_vec& names, index_set& set, index_type p);
+    void print(std::ostream& s);
+  };
+  typedef lvector<SimpleReferenceSet*> refs_vec;
+  struct ReferenceSet : public Context {
+    refs_vec refs;
+    Symbol* name;
+    ReferenceSet() : refs(0, 0), name(0) { };
+    void add(SimpleReferenceSet* ref) { refs.append(ref); };
+    void build(const name_vec& names, index_set_vec& sets, index_type p);
+    void print(std::ostream& s);
+  };
+  struct CPG {
+    atom_vec atoms;
+    index_vec atom_first_arg;
+    bool_vec neg;
+    symbol_vec args;
+    type_vec arg_types;
+    CPG() : atoms(0, 0), neg(false, 0), args(0, 0), arg_types(0, 0) { };
+    CPG(CPG& g, index_vec& s);
+    void make_key(ptr_table::key_vec& key);
+    void make_typed_key(ptr_table::key_vec& key);
+    void make_parameters(variable_vec& params);
+    ListExpression* make_argument_list(index_type first);
+    void add_asserting_effects(ActionSymbol* act,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          bool strict);
+    void add_destroying_effects(ActionSymbol* act,
+    ParamSymbol* pf,
+    PredicateSymbol* p,
+    bool p_val,
+    PredicateSymbol* g,
+    FunctionSymbol* f,
+    Expression* f_val,
+    bool strict);
+    bool initial_value();
+    void add_asserting_effects(index_type c_atom,
+          ActionSymbol* act,
+          index_type c_eff,
+          bool_vec& sat,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          symbol_pair_vec& eq,
+          symbol_pair_vec& neq,
+          bool strict);
+    void add_propositional_effect(ActionSymbol* act,
+      PredicateSymbol* p, bool p_val,
+      index_type c_atom, Atom* a_eff,
+      bool strict);
+    void add_fluent_effect(ActionSymbol* act,
+      FunctionSymbol* f, Expression* f_val,
+      index_type c_atom, Atom* a_eff);
+    void add_effect_conditions(Context* e, ParamSymbol* pf, bool_vec& sat,
+          symbol_vec& subs, symbol_pair_vec& eq,
+          symbol_pair_vec& neq);
+  };
+  enum goal_class { goal_pos_atom, goal_neg_atom, goal_relation, goal_task,
+      goal_conjunction, goal_disjunction, goal_forall,
+      goal_exists, goal_always, goal_sometime,
+      goal_at_most_once, goal_within, goal_always_within,
+      goal_sometime_before, goal_sometime_after };
+  struct Goal {
+    goal_class g_class;
+    Goal(goal_class c) : g_class(c) { };
+    bool is_state();
+    bool is_propositional();
+    bool is_singular();
+    bool makeCPG(CPG& g);
+    bool makeCPG(CPG& g, index_vec& s);
+    void instantiate(Instance& ins, hsps::rational deadline);
+    void instantiate(Instance& ins, index_set& set, Symbol* p, index_type i);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Goal*> goal_vec;
+  struct AtomicGoal : public Goal {
+    Atom* atom;
+    AtomicGoal(Atom* a, bool neg)
+      : Goal(neg ? goal_neg_atom : goal_pos_atom), atom(a) { };
+    void print(std::ostream& s);
+  };
+  struct NumericGoal : public Goal {
+    Relation* rel;
+    NumericGoal(Relation* r) : Goal(goal_relation), rel(r) { };
+    void print(std::ostream& s);
+  };
+  struct TaskGoal : public Goal {
+    Reference* task;
+    TaskGoal(Reference* r) : Goal(goal_task), task(r) { };
+    void print(std::ostream& s);
+  };
+  struct ConjunctiveGoal : public Goal {
+    goal_vec goals;
+    ConjunctiveGoal() : Goal(goal_conjunction), goals(0, 0) { };
+    ConjunctiveGoal(goal_class gc) : Goal(gc), goals(0, 0) { };
+    void print(std::ostream& s);
+  };
+  struct DisjunctiveGoal : public ConjunctiveGoal {
+    DisjunctiveGoal() : ConjunctiveGoal(goal_disjunction) { };
+    void print(std::ostream& s);
+  };
+  struct QuantifiedGoal : public Goal, public Context {
+    Goal* goal;
+    QuantifiedGoal() : Goal(goal_forall), goal(0) { };
+    QuantifiedGoal(goal_class gc) : Goal(gc), goal(0) { };
+    void print(std::ostream& s);
+  };
+  struct SimpleSequenceGoal : public Goal {
+    Goal* constraint;
+    SimpleSequenceGoal(goal_class c, Goal* g) : Goal(c), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredSequenceGoal : public Goal {
+    Goal* trigger;
+    Goal* constraint;
+    TriggeredSequenceGoal(goal_class c, Goal* t, Goal* g)
+      : Goal(c), trigger(t), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct DeadlineGoal : public Goal {
+    Goal* goal;
+    hsps::rational at;
+    DeadlineGoal(hsps::rational t, Goal* g) : Goal(goal_within), goal(g), at(t) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredDeadlineGoal : public Goal {
+    Goal* trigger;
+    Goal* goal;
+    hsps::rational delay;
+    TriggeredDeadlineGoal(Goal* t, hsps::rational d, Goal* g)
+      : Goal(goal_always_within), trigger(t), delay(d), goal(g) { };
+    void print(std::ostream& s);
+  };
+  struct Preference {
+    Symbol* name;
+    Goal* goal;
+    Preference() : name(0), goal(0) { };
+    Preference(Symbol* n) : name(n), goal(0) { };
+    Preference(Symbol* n, Goal* g) : name(n), goal(g) { };
+    bool is_state() { return goal->is_state(); };
+    bool is_propositional() { return goal->is_propositional(); };
+    hsps::rational value(metric_class metric_type, Expression* m);
+    void instantiate(SoftInstance& ins,
+       metric_class metric_type,
+       Expression* m);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Preference*> preference_vec;
+  char* domain_name;
+  char* problem_name;
+  char* domain_file;
+  char* problem_file;
+  bool ready_to_instantiate;
+  char* problem_file_basename();
+  char* enum_problem_filename(const char* s, index_type i);
+  StringTable& tab;
+  type_vec dom_types;
+  type_vec dom_base_types;
+  TypeSymbol* dom_top_type;
+  symbol_vec dom_constants;
+  PredicateSymbol* dom_eq_pred;
+  PredicateSymbol* dom_assign_pred;
+  Symbol* dom_undefined_obj;
+  static PredicateSymbol* current_eq_predicate;
+  lvector<PredicateSymbol*> dom_predicates;
+  lvector<ObjectFunctionSymbol*> dom_object_functions;
+  lvector<FunctionSymbol*> dom_functions;
+  lvector<ActionSymbol*> dom_actions;
+  lvector<SetConstraint*> dom_sc_invariants;
+  lvector<InvariantFormula*> dom_f_invariants;
+  lvector<IrrelevantItem*> dom_irrelevant;
+  atom_vec dom_init;
+  obj_init_atom_vec dom_obj_init;
+  fun_init_atom_vec dom_fun_init;
+  goal_vec dom_goals;
+  preference_vec dom_preferences;
+  ref_vec goal_tasks;
+  metric_class metric_type;
+  Expression* metric;
+  hsps::rational serial_length;
+  hsps::rational parallel_length;
+  lvector<InputPlan*> input_plans;
+  lvector<HTableEntry*> h_table;
+  lvector<ReferenceSet*> input_sets;
+  lvector<SetSymbol*> partitions;
+  static ActionSymbol* src_action_symbol(ptr_pair* p);
+  TypeSymbol* find_type(const char* name);
+  PredicateSymbol* find_predicate(const char* name);
+  FunctionSymbol* find_function(const char* name);
+  bool find_initial_fact(const char* pname, const symbol_vec& arg);
+  hsps::rational find_function_value(const char* fname, const symbol_vec& arg);
+  index_type find_element_satisfying(const symbol_vec& elements,
+         const char* pname,
+         symbol_vec& arg,
+         index_type element_arg_p);
+  void find_elements_satisfying(const symbol_vec& elements,
+    const char* pname,
+    symbol_vec& arg,
+    index_type element_arg_p,
+    index_set& sats);
+  Atom* goal_to_atom(Goal* g);
+  bool goal_to_atom_vec(Goal* g, atom_vec& av);
+  PDDL_Base(StringTable& t);
+  ~PDDL_Base();
+  void set_variable_type(variable_vec& vec, TypeSymbol* t);
+  void set_variable_type(variable_vec& vec, const TypeSet& t);
+  void set_type_type(type_vec& vec, TypeSymbol* t);
+  void set_constant_type(symbol_vec& vec, TypeSymbol* t);
+  void clear_context(variable_vec& vec);
+  void clear_context(variable_vec& vec, index_type n_min, index_type n_max);
+  bool merge_type_vectors(type_vec& v0, type_vec& v1);
+  void make_parameters(type_vec& t, const char* prefix, variable_vec& v);
+  Atom* make_atom_from_prop(ptr_pair& src, bool& neg);
+  Symbol* gensym(symbol_class c, const char* p, const TypeSet& t);
+  Symbol* gensym(symbol_class c, const char* p, TypeSymbol* t);
+  Symbol* gensym_i(symbol_class c, const char* p, index_type i, TypeSymbol* t);
+  Symbol* gensym_s(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t);
+  Symbol* gensym_n(symbol_class c, const char* p, const Name* n, TypeSymbol* t);
+  void new_variable_substitution(Atom* a,
+     symbol_pair_vec& u,
+     symbol_pair_vec& new_u);
+  Atom* new_meta_atom(PredicateSymbol* p);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& u);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+  void extend_cc(CAtom* l, catom_vec& m, catom_vec& nm,
+   lvector< swapable_pair<catom_vec> >& x,
+   index_type d);
+  void find_cc();
+  void post_process();
+  void instantiate(Instance& ins);
+  void instantiate_soft(SoftInstance& ins);
+  void instantiate_atom_set(Instance& ins, atom_vec& a, index_set& s);
+  index_type n_plans() const { return input_plans.length(); };
+  bool export_plan(index_type i, Instance& ins, const index_vec& map, Plan& p);
+  bool export_plan(index_type i, Instance& ins, Plan& p);
+  void export_heuristic(Instance& ins,
+   const index_vec& map,
+   bool opt_maximize,
+   Heuristic& h);
+  void export_sets(const name_vec& names, index_set_vec& sets);
+  void export_action_partitions(name_vec& names, index_set_vec& sets);
+  void lift_DKEL_Items(const Instance& ins);
+  PredicateSymbol* find_type_predicate(Symbol* type_sym);
+  void untype();
+  void compile_preferences();
+  void compile_constraints_1();
+  void compile_constraints_2();
+  void select_preferences(const bool_vec& sel);
+  void metric_to_goal(hsps::rational bound);
+  void compile_set_conditions_and_effects();
+  void compile_object_functions();
+  Expression* replace_violations_1(Expression* exp,
+       CPG* cpg[],
+       FunctionSymbol* f_violated[]);
+  Goal* compile_constraint_1(Goal* g, index_type i, const Symbol* n,
+        symbol_vec& aut_states, index_type n_ra);
+  AtomicGoal* make_automaton_type_a(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_e(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_o(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sb(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sa(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  void make_automaton_transition(Symbol* s_from,
+     Symbol* s_to,
+     bool is_accept,
+     CPG* f, bool neg_f,
+     CPG* g, bool neg_g,
+     PredicateSymbol* p_state,
+     PredicateSymbol* p_accept,
+     PredicateSymbol* p_synch);
+  void add_precondition_formula(ActionSymbol* a, CPG* f, bool is_neg);
+  Goal* compile_constraint_2(Goal* g, const Symbol* n);
+  Goal* compile_always_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_sometime_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_at_most_once_constraint(SimpleSequenceGoal* g,
+     const Symbol* n);
+  Goal* compile_sometime_before_constraint(TriggeredSequenceGoal* g,
+        const Symbol* n);
+  void compile_set_conditions_and_effects(ActionSymbol* act);
+  void compile_set_conditions_and_effects(ActionSymbol* act,
+       variable_vec& i_param,
+       variable_vec& d_param,
+       index_type p);
+  Atom* make_binding_atom(VariableSymbol* v);
+  void compile_object_functions(ActionSymbol* act, Symbol* undefined_value);
+  void compile_object_functions_for_validator(ActionSymbol* act);
+  Goal* compile_object_functions(Goal* g);
+  void write_declarations(std::ostream& s);
+  void write_action(std::ostream& s, ActionSymbol* act);
+  void write_set_precondition(std::ostream& s, SetOf* set);
+  void write_disjunctive_set_precondition(std::ostream& s, SetOf* set);
+  void write_set_effect(std::ostream& s, SetOf* set);
+  void write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn);
+  void write_objects(std::ostream& s, bool defined_in_problem);
+  void write_init(std::ostream& s);
+  void write_goal(std::ostream& s);
+  void write_metric(std::ostream& s);
+  void write_dkel_items(std::ostream& s, bool defined_in_problem);
+  void write_domain_begin(std::ostream& s);
+  void write_problem_begin(std::ostream& s);
+  void write_end(std::ostream& s);
+  void write_dkel_domain(std::ostream& s, bool leave_open);
+  void write_dkel_problem(std::ostream& s, bool leave_open);
+  void write_plans(std::ostream& s);
+  void write_heuristic_table(std::ostream& s);
+  void write_sets(std::ostream& s);
+  void print(std::ostream& s);
+};
+class InstanceName : public Name {
+  char* domain_name;
+  char* problem_name;
+ public:
+  InstanceName(char* d, char* p) : domain_name(d), problem_name(p) { };
+  virtual ~InstanceName() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class PDDL_Name : public Name {
+ protected:
+  bool neg;
+  PDDL_Base::Symbol* sym;
+  PDDL_Base::symbol_vec arg;
+  bool vis;
+  bool_vec avis;
+ public:
+  static char catc;
+  static bool obscure_symbol_names;
+  PDDL_Name(PDDL_Base::Symbol* s)
+    : neg(false), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, bool n)
+    : neg(n), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::symbol_vec a, bool n)
+    : neg(n), sym(s), arg(a), vis(true), avis(true, a.length()) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n);
+  void add(PDDL_Base::Symbol* s);
+  void add(PDDL_Base::Symbol* s, bool v);
+  PDDL_Base::Symbol* symbol() { return sym; };
+  PDDL_Base::symbol_vec& args() { return arg; };
+  index_type argc() { return arg.length(); };
+  bool is_neg() { return neg; };
+  virtual ~PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class Numbered_PDDL_Name : public PDDL_Name {
+  index_type copy;
+ public:
+  Numbered_PDDL_Name(PDDL_Base::Symbol* sym, index_type c)
+    : PDDL_Name(sym), copy(c) { };
+  Numbered_PDDL_Name(PDDL_Name* n, index_type c);
+  virtual ~Numbered_PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+};
+}
+#include <stdlib.h>
+#include <sstream>
+namespace hsps {
+bool PDDL_Base::use_default_function_value = true;
+hsps::rational PDDL_Base::default_function_value(0);
+bool PDDL_Base::use_strict_borrow_definition = false;
+bool PDDL_Base::use_extended_borrow_definition = false;
+bool PDDL_Base::del_before_add_semantics = false;
+bool PDDL_Base::compact_resource_effects = true;
+bool PDDL_Base::compile_away_disjunctive_preconditions = true;
+bool PDDL_Base::check_precondition_consistency = true;
+bool PDDL_Base::compile_away_conditional_effects = true;
+bool PDDL_Base::compile_away_plan_constraints = true;
+bool PDDL_Base::compile_away_object_functions = true;
+bool PDDL_Base::compile_for_validator = false;
+bool PDDL_Base::create_all_atoms = false;
+bool PDDL_Base::create_all_actions = false;
+bool PDDL_Base::number_multiple_action_instances = false;
+bool PDDL_Base::exclude_all_dkel_items = false;
+string_set PDDL_Base::excluded_dkel_tags;
+string_set PDDL_Base::required_dkel_tags;
+bool PDDL_Base::strict_set_export = true;
+bool PDDL_Base::write_PDDL31 = true;
+bool PDDL_Base::best_effort = true;
+bool PDDL_Base::write_warnings = true;
+bool PDDL_Base::write_info = false;
+bool PDDL_Base::write_trace = false;
+bool PDDL_Base::name_instance_by_problem_file = false;
+const char* PDDL_Base::instance_name_prefix = 0;
+bool PDDL_Base::trace_print_context = false;
+bool PDDL_Base::AtomBase::print_bindings = false;
+bool PDDL_Base::Expression::print_nary = false;
+PDDL_Base::PredicateSymbol* PDDL_Base::current_eq_predicate = 0;
+char* PDDL_Base::problem_file_basename()
+{
+  if (problem_file) {
+    char* p0 = strdup(problem_file);
+    char* p1 = strrchr(p0, '/');
+    char* p2 = strrchr(p0, '.');
+    if ((p1 != 0) && (p2 != 0) && (p1 < p2)) {
+      *p2 = '\0';
+    }
+    else if ((p1 == 0) && (p2 != 0)) {
+      *p2 = '\0';
+    }
+    if (p1)
+      return p1 + 1;
+    else
+      return p0;
+  }
+  else {
+    return 0;
+  }
+}
+char* PDDL_Base::enum_problem_filename(const char* s, index_type i)
+{
+  std::ostringstream fname;
+  char* b = problem_file_basename();
+  if (b) {
+    fname << b << "-" << s << i << ".pddl";
+  }
+  else {
+    fname << s << i << ".pddl";
+  }
+  return strdup(fname.str().c_str());
+}
+index_type PDDL_Base::TypeSet::n_elements() const
+{
+  index_type n = 0;
+  for (index_type k = 0; k < length(); k++)
+    n += (*this)[k]->elements.length();
+  return n;
+}
+PDDL_Base::Symbol* PDDL_Base::TypeSet::get_element
+(index_type n)
+{
+  index_type k = 0;
+  while (k < length()) {
+    if (n < (*this)[k]->elements.length())
+      return (*this)[k]->elements[n];
+    n -= (*this)[k]->elements.length();
+    k += 1;
+  }
+  std::cerr << "error: index out of range in get_element ";
+  print(std::cerr);
+  exit(255);
+}
+bool PDDL_Base::TypeSet::is_object() const
+{
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k]->is_object()) return true;
+  return false;
+}
+bool PDDL_Base::TypeSet::subtype_or_equal(const TypeSet& s) const
+{
+  if (s.length() == 0) return true;
+  if (length() == 0) {
+    for (index_type l = 0; l < s.length(); l++)
+      if (s[l]->is_object()) return true;
+    return false;
+  }
+  else {
+    for (index_type k = 0; k < length(); k++) {
+      bool ok = false;
+      for (index_type l = 0; (l < s.length()) && !ok; l++)
+ if ((*this)[k]->subtype_or_equal(s[l]))
+   ok = true;
+      if (!ok) return false;
+    }
+    return true;
+  }
+}
+bool PDDL_Base::TypeSet::subtype_or_equal(TypeSymbol* t) const
+{
+  if (length() == 0) {
+    if (t->is_object()) return true;
+    return false;
+  }
+  else {
+    for (index_type k = 0; k < length(); k++) {
+      if (!(*this)[k]->subtype_or_equal(t))
+ return false;
+    }
+    return true;
+  }
+}
+void PDDL_Base::TypeSet::print(std::ostream& s) const
+{
+  if (length() > 1) {
+    s << "(either";
+    for (index_type k = 0; k < length(); k++) {
+      s << " ";
+      (*this)[k]->print(s);
+    }
+    s << ")";
+  }
+  else if (length() == 1) {
+    (*this)[0]->print(s);
+  }
+}
+void PDDL_Base::TypeSet::write_type(std::ostream& s) const
+{
+  if (length() > 1) {
+    s << " - (either";
+    for (index_type k = 0; k < length(); k++) {
+      s << " " << (*this)[k]->print_name;
+    }
+    s << ")";
+  }
+  else if (length() == 1) {
+    s << " - " << (*this)[0]->print_name;
+  }
+  else {
+    s << " - object";
+  }
+}
+PDDL_Base::TypeSymbol* PDDL_Base::find_type(const char* name)
+{
+  for (index_type k = 0; k < dom_types.length(); k++)
+    if (tab.table_char_map().strcmp(dom_types[k]->print_name, name) == 0)
+      return dom_types[k];
+  return 0;
+}
+PDDL_Base::PredicateSymbol* PDDL_Base::find_predicate(const char* name)
+{
+  for (index_type k = 0; k < dom_predicates.length(); k++)
+    if (tab.table_char_map().strcmp(dom_predicates[k]->print_name, name) == 0)
+      return dom_predicates[k];
+  return 0;
+}
+PDDL_Base::FunctionSymbol* PDDL_Base::find_function(const char* name)
+{
+  for (index_type k = 0; k < dom_functions.length(); k++)
+    if (tab.table_char_map().strcmp(dom_functions[k]->print_name, name) == 0)
+      return dom_functions[k];
+  return 0;
+}
+bool PDDL_Base::find_initial_fact(const char* pname, const symbol_vec& arg)
+{
+  PredicateSymbol* pred = find_predicate(pname);
+  if (pred == 0) {
+    std::cerr << "error: can't check static fact " << pname << arg
+       << " - no such predicate" << std::endl;
+    exit(255);
+  }
+  ptr_table* r = &(pred->init);
+  for (index_type k = 0; (k < arg.length()) && r; k++) {
+    if (arg[k]->sym_class == sym_variable) {
+      if (((VariableSymbol*)arg[k])->value == 0) {
+ std::cerr << "error: can't evaluate " << pname << arg
+    << " - " << arg[k]->print_name << " not set"
+    << std::endl;
+ exit(255);
+      }
+      r = r->find_next(((VariableSymbol*)arg[k])->value);
+    }
+    else {
+      r = r->find_next(arg[k]);
+    }
+  }
+  if (r) {
+    if (r->val) return true;
+  }
+  return false;
+}
+hsps::rational PDDL_Base::find_function_value(const char* fname, const symbol_vec& arg)
+{
+  FunctionSymbol* fun = find_function(fname);
+  if (fun == 0) {
+    std::cerr << "error: can't eval static exp " << fname << arg
+       << " - no such function" << std::endl;
+    exit(255);
+  }
+  if (!fun->is_static()) {
+    std::cerr << "error: can't eval static exp " << fname << arg
+       << " - function not static" << std::endl;
+    exit(255);
+  }
+  ptr_table* r = &(fun->init);
+  for (index_type k = 0; (k < arg.length()) && r; k++) {
+    if (arg[k]->sym_class == sym_variable) {
+      if (((VariableSymbol*)arg[k])->value == 0) {
+ std::cerr << "error: can't evaluate " << fname << arg
+    << " - " << arg[k]->print_name << " not set"
+    << std::endl;
+ exit(255);
+      }
+      r = r->find_next(((VariableSymbol*)arg[k])->value);
+    }
+    else {
+      r = r->find_next(arg[k]);
+    }
+  }
+  if (r) {
+    if (r->val) {
+      return ((FInitAtom*)r->val)->val;
+    }
+  }
+  if (use_default_function_value) {
+    return default_function_value;
+  }
+  else {
+    std::cerr << "error: " << fname << arg << " has no value" << std::endl;
+    exit(255);
+  }
+}
+index_type PDDL_Base::find_element_satisfying
+(const symbol_vec& elements,
+ const char* pname,
+ symbol_vec& arg,
+ index_type element_arg_p)
+{
+  for (index_type k = 0; k < elements.length(); k++) {
+    arg[element_arg_p] = elements[k];
+    if (find_initial_fact(pname, arg))
+      return k;
+  }
+  return no_such_index;
+}
+void PDDL_Base::find_elements_satisfying
+(const symbol_vec& elements,
+ const char* pname,
+ symbol_vec& arg,
+ index_type element_arg_p,
+ index_set& sats)
+{
+  sats.clear();
+  for (index_type k = 0; k < elements.length(); k++) {
+    arg[element_arg_p] = elements[k];
+    if (find_initial_fact(pname, arg))
+      sats.insert(k);
+  }
+}
+PDDL_Base::Atom* PDDL_Base::goal_to_atom(Goal* g)
+{
+  if ((g->g_class == goal_pos_atom) || (g->g_class == goal_neg_atom))
+    return ((AtomicGoal*)g)->atom;
+  else
+    return 0;
+}
+bool PDDL_Base::goal_to_atom_vec(Goal* g, atom_vec& av)
+{
+  av.clear();
+  if ((g->g_class == goal_pos_atom) || (g->g_class == goal_neg_atom)) {
+    av.append(((AtomicGoal*)g)->atom);
+    return true;
+  }
+  else if (g->g_class == goal_conjunction) {
+    ConjunctiveGoal* cg = (ConjunctiveGoal*)g;
+    for (index_type k = 0; k < cg->goals.length(); k++) {
+      Atom* g_k = goal_to_atom(cg->goals[k]);
+      if (g_k == 0) return false;
+      av.append(g_k);
+    }
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+PDDL_Base::ActionSymbol* PDDL_Base::src_action_symbol(ptr_pair* p)
+{
+  PDDL_Base::ActionSymbol* act = (PDDL_Base::ActionSymbol*)p->first;
+  ptr_table* ins = (ptr_table*)p->second;
+  ptr_table::key_vec* args = ins->key_sequence();
+  for (index_type k = 0; k < act->param.length(); k++)
+    act->param[k]->value = (PDDL_Base::Symbol*)((*args)[k + 1]);
+  delete args;
+  return act;
+}
+PDDL_Base::PDDL_Base(StringTable& t)
+  : domain_name(0),
+    problem_name(0),
+    domain_file(0),
+    problem_file(0),
+    ready_to_instantiate(false),
+    tab(t),
+    dom_types(0, 0),
+    dom_top_type(0),
+    dom_constants(0, 0),
+    dom_predicates(0, 0),
+    dom_object_functions(0, 0),
+    dom_functions(0, 0),
+    dom_actions(0, 0),
+    dom_sc_invariants(0, 0),
+    dom_f_invariants(0, 0),
+    dom_irrelevant(0, 0),
+    dom_init(0, 0),
+    dom_fun_init(0, 0),
+    dom_obj_init(0, 0),
+    dom_goals(0, 0),
+    dom_preferences(0, 0),
+    goal_tasks(0, 0),
+    metric_type(metric_none),
+    metric(0),
+    serial_length(POS_INF),
+    parallel_length(POS_INF),
+    input_plans(0, 0),
+    h_table(0, 0),
+    input_sets(0, 0),
+    partitions(0, 0)
+{
+  StringTable::Cell* sc = tab.inserta("object");
+  dom_top_type = new TypeSymbol(sc->text);
+  sc->val = dom_top_type;
+  sc = tab.inserta("=");
+  dom_eq_pred = new PredicateSymbol(sc->text);
+  dom_eq_pred->param.append(new VariableSymbol("?x"));
+  dom_eq_pred->param.append(new VariableSymbol("?y"));
+  sc = tab.inserta("assign");
+  dom_assign_pred = new PredicateSymbol(sc->text);
+  dom_assign_pred->param.append(new VariableSymbol("?x"));
+  dom_assign_pred->param.append(new VariableSymbol("?y"));
+  sc->val = dom_assign_pred;
+  sc = tab.inserta("undefined");
+  dom_undefined_obj = new Symbol(sc->text);
+  sc->val = dom_undefined_obj;
+}
+PDDL_Base::~PDDL_Base()
+{
+}
+void PDDL_Base::set_variable_type(variable_vec& vec, TypeSymbol* t)
+{
+  for (index_type k = vec.length(); k > 0; k--) {
+    if (vec[k - 1]->sym_types.length() > 0) return;
+    vec[k - 1]->sym_types.append(t);
+    if (trace_print_context) {
+      std::cerr << "set type of " << k - 1 << "th variable ";
+      vec[k - 1]->print(std::cerr);
+      std::cerr << " to ";
+      t->print(std::cerr);
+      std::cerr << std::endl;
+    }
+  }
+}
+void PDDL_Base::set_variable_type(variable_vec& vec, const TypeSet& t)
+{
+  for (index_type k = vec.length(); k > 0; k--) {
+    if (vec[k - 1]->sym_types.length() > 0) return;
+    vec[k - 1]->sym_types.assign_copy(t);
+    if (trace_print_context) {
+      std::cerr << "set type of " << k - 1 << "th variable ";
+      vec[k - 1]->print(std::cerr);
+      std::cerr << " to ";
+      t.print(std::cerr);
+      std::cerr << std::endl;
+    }
+  }
+}
+void PDDL_Base::set_type_type(type_vec& vec, TypeSymbol* t)
+{
+  for (index_type k = vec.length(); k > 0; k--) {
+    if (vec[k - 1]->sym_types.length() > 0) return;
+    vec[k - 1]->sym_types.append(t);
+  }
+}
+void PDDL_Base::set_constant_type(symbol_vec& vec, TypeSymbol* t)
+{
+  for (index_type k = vec.length(); k > 0; k--) {
+    if (vec[k - 1]->sym_types.length() > 0) return;
+    vec[k - 1]->sym_types.append(t);
+    t->add_element(vec[k - 1]);
+  }
+}
+void PDDL_Base::clear_context(variable_vec& vec)
+{
+  for (index_type k = 0; k < vec.length(); k++) {
+    tab.set(vec[k]->print_name, (void*)0);
+    if (trace_print_context) {
+      std::cerr << k << "th variable ";
+      vec[k]->print(std::cerr);
+      std::cerr << " cleared from context"
+  << std::endl;
+    }
+  }
+}
+void PDDL_Base::clear_context
+(variable_vec& vec, index_type n_min, index_type n_max)
+{
+  assert((n_min <= n_max) && n_max <= vec.length());
+  for (index_type k = n_min; k < n_max; k++) {
+    tab.set(vec[k]->print_name, (void*)0);
+    if (trace_print_context) {
+      std::cerr << k << "th variable ";
+      vec[k]->print(std::cerr);
+      std::cerr << " cleared from context"
+  << std::endl;
+    }
+  }
+}
+bool PDDL_Base::merge_type_vectors
+(type_vec& v0, type_vec& v1)
+{
+  if (v0.length() != v1.length()) return false;
+  bool_vec set(false, v0.length());
+  for (index_type k = 0; k < v0.length(); k++) {
+    if (v1[k]->subtype_or_equal(v0[k])) {
+      set[k] = false;
+    }
+    else if (v0[k]->subtype_or_equal(v1[k])) {
+      set[k] = true;
+    }
+    else {
+      return false;
+    }
+  }
+  for (index_type k = 0; k < v0.length(); k++)
+    if (set[k]) v0[k] = v1[k];
+  return true;
+}
+void PDDL_Base::make_parameters
+(type_vec& t, const char* prefix, variable_vec& v)
+{
+  v.set_length(t.length());
+  for (index_type k = 0; k < t.length(); k++) {
+    EnumName v_name(prefix, k);
+    v[k] = new VariableSymbol(v_name.to_cstring(Name::NC_INSTANCE));
+    v[k]->sym_types.assign_value(t[k], 1);
+  }
+}
+PDDL_Base::Symbol* PDDL_Base::gensym
+(symbol_class c, const char* p, const TypeSet& t)
+{
+  StringTable::Cell* sc = tab.inserta(p);
+  index_type i = 0;
+  while (sc->val) {
+    std::ostringstream s;
+    s << p << i++;
+    sc = tab.inserta(s.str().c_str());
+  }
+  Symbol* s = 0;
+  switch (c) {
+  case sym_action:
+    s = new ActionSymbol(sc->text);
+    break;
+  case sym_predicate:
+    s = new PredicateSymbol(sc->text);
+    break;
+  case sym_variable:
+    s = new VariableSymbol(sc->text);
+    break;
+  case sym_typename:
+    s = new TypeSymbol(sc->text);
+    break;
+  default:
+    s = new Symbol(c, sc->text);
+  }
+  sc->val = s;
+  s->sym_types = t;
+  return s;
+}
+PDDL_Base::Symbol* PDDL_Base::gensym
+(symbol_class c, const char* p, TypeSymbol* t)
+{
+  assert(t != 0);
+  TypeSet v(t);
+  return gensym(c, p, v);
+}
+PDDL_Base::Symbol* PDDL_Base::gensym_i
+(symbol_class c, const char* p, index_type i, TypeSymbol* t)
+{
+  std::ostringstream s;
+  s << p << i;
+  return gensym(c, s.str().c_str(), t);
+}
+PDDL_Base::Symbol* PDDL_Base::gensym_n
+(symbol_class c, const char* p, const Name* n, TypeSymbol* t)
+{
+  std::ostringstream s;
+  s << p << n;
+  return gensym(c, s.str().c_str(), t);
+}
+PDDL_Base::Symbol* PDDL_Base::gensym_s
+(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t)
+{
+  std::ostringstream ss;
+  ss << p << s->print_name;
+  return gensym(c, ss.str().c_str(), t);
+}
+PDDL_Base::Atom* PDDL_Base::new_meta_atom(PredicateSymbol* p)
+{
+  Atom* a = new Atom(p);
+  a->param.set_length(p->param.length());
+  for (index_type k = 0; k < p->param.length(); k++) {
+    a->param[k] = gensym(sym_meta_variable, "V", p->param[k]->sym_types);
+  }
+  return a;
+}
+void PDDL_Base::new_variable_substitution
+(Atom* a, symbol_pair_vec& u, symbol_pair_vec& new_u)
+{
+  for (index_type k = 0; k < u.length(); k++) {
+    if (u[k].second->sym_class == sym_variable) {
+      new_u.append(symbol_pair(u[k].first,
+          gensym(sym_variable,
+          u[k].second->print_name,
+          u[k].second->sym_types)));
+    }
+    else {
+      new_u.append(u[k]);
+    }
+  }
+  for (index_type k = 0; k < a->param.length(); k++)
+    if (a->param[k]->sym_class == sym_variable) {
+      bool found = false;
+      for (index_type i = 0; (i < new_u.length()) && !found; i++)
+ if (new_u[i].first == a->param[k]) found = true;
+      if (!found) {
+ new_u.append(symbol_pair(a->param[k],
+     gensym(sym_variable,
+     a->param[k]->print_name,
+     a->param[k]->sym_types)));
+      }
+    }
+}
+PDDL_Base::CAtom* PDDL_Base::new_CAtom
+(Atom* a, symbol_pair_vec& u)
+{
+  symbol_pair_vec new_u;
+  new_variable_substitution(a, u, new_u);
+  return new CAtom(a, new_u);
+}
+PDDL_Base::CAtom* PDDL_Base::new_CAtom
+(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u)
+{
+  symbol_pair_vec new_u;
+  new_variable_substitution(a, u, new_u);
+  return new CAtom(a, n, new_u);
+}
+PDDL_Base::CAtom::CAtom(const Atom* a, symbol_pair_vec& u)
+  : Atom(a->pred), neq(0, 0)
+{
+  param.set_length(a->param.length());
+  for (index_type k = 0; k < a->param.length(); k++) {
+    bool found = false;
+    for (index_type i = 0; (i < u.length()) && !found; i++)
+      if (a->param[k] == u[i].first) {
+ param[k] = u[i].second;
+ found = true;
+      }
+    if (!found) {
+      param[k] = a->param[k];
+    }
+  }
+}
+PDDL_Base::CAtom::CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u)
+  : Atom(a->pred), neq(0, 0)
+{
+  param.set_length(a->param.length());
+  for (index_type k = 0; k < a->param.length(); k++) {
+    bool found = false;
+    for (index_type i = 0; (i < u.length()) && !found; i++)
+      if (a->param[k] == u[i].first) {
+ param[k] = u[i].second;
+ found = true;
+      }
+    if (!found) {
+      param[k] = a->param[k];
+    }
+  }
+  for (index_type k = 0; k < n.length(); k++) {
+    Symbol* s1 = 0;
+    Symbol* s2 = 0;
+    for (index_type i = 0; i < u.length(); i++) {
+      if ((s1 == 0) && (u[i].first == n[k].first)) s1 = u[i].second;
+      if ((s2 == 0) && (u[i].first == n[k].second)) s2 = u[i].second;
+    }
+    if (s1 == 0) s1 = n[k].first;
+    if (s2 == 0) s2 = n[k].second;
+    neq.append(symbol_pair(s1, s2));
+  }
+}
+void PDDL_Base::extend_cc
+(CAtom* lit,
+ catom_vec& m,
+ catom_vec& nm,
+ lvector< swapable_pair<catom_vec> >& q,
+ index_type d)
+{
+  symbol_pair_vec u;
+  if (write_info) {
+    std::cerr << "[" << d << "] extend_cc: lit = ";
+    lit->print(std::cerr);
+    std::cerr << ", m = {";
+    for (index_type k = 0; k < m.length(); k++) {
+      if (k > 0) std::cerr << ", ";
+      m[k]->print(std::cerr);
+    }
+    std::cerr << "}, nm = {";
+    for (index_type k = 0; k < nm.length(); k++) {
+      if (k > 0) std::cerr << ", ";
+      nm[k]->print(std::cerr);
+    }
+    std::cerr << "}, |q| = " << q.length()
+       << std::endl;
+  }
+  for (index_type k = 0; k < nm.length(); k++) {
+    if (lit->unify(nm[k], u)) {
+      if (write_info) {
+ std::cerr << "[" << d << "] cut (1) due to ";
+ nm[k]->print(std::cerr);
+ std::cerr << ", ";
+ print_substitution(std::cerr, u);
+ std::cerr << std::endl;
+      }
+      return;
+    }
+  }
+  bool lit_subsumed = false;
+  for (index_type k = 0; (k < m.length()) && !lit_subsumed; k++)
+    if (lit->instance_of(m[k], u)) {
+      if (write_info) {
+ std::cerr << "[" << d << "] ";
+ lit->print(std::cerr);
+ std::cerr << " subsumed by ";
+ m[k]->print(std::cerr);
+ std::cerr << ", ";
+ print_substitution(std::cerr, u);
+ std::cerr << std::endl;
+      }
+      lit_subsumed = true;
+    }
+  index_type reset_m_to = m.length();
+  index_type reset_q_to = q.length();
+  if (!lit_subsumed) {
+    symbol_pair_vec actneq;
+    for (index_type k = 0; k < dom_actions.length(); k++) {
+      dom_actions[k]->get_param_inequalities(actneq);
+      for (index_type i = 0; i < dom_actions[k]->adds.length(); i++) {
+ if (lit->instance_of(dom_actions[k]->adds[i], actneq, u)) {
+   if (write_info) {
+     std::cerr << "[" << d << "] match with ";
+     dom_actions[k]->adds[i]->print(std::cerr);
+     std::cerr << " of " << dom_actions[k]->print_name << ", ";
+     print_inequality(std::cerr, actneq);
+     std::cerr << ", ";
+     print_substitution(std::cerr, u);
+     std::cerr << std::endl;
+   }
+   swapable_pair<catom_vec> e;
+   for (index_type j = 0; j < dom_actions[k]->cons.length(); j++) {
+     CAtom* xa = new_CAtom(dom_actions[k]->cons[j], actneq, u);
+     e.first.append(xa);
+   }
+   for (index_type j = 0; j < dom_actions[k]->adds.length(); j++) if (j != i) {
+     CAtom* nxa = new_CAtom(dom_actions[k]->adds[j], actneq, u);
+     e.second.append(nxa);
+   }
+   q.append(e);
+ }
+      }
+    }
+    m.append(lit);
+  }
+  if (q.length() == 0) {
+    if (write_info) {
+      std::cerr << "info: found invariant {";
+      for (index_type k = 0; k < m.length(); k++) {
+ if (k > 0) std::cerr << ", ";
+ m[k]->print(std::cerr);
+      }
+      std::cerr << "}" << std::endl;
+    }
+    graph lsg(m.length());
+    for (index_type i = 0; i < m.length(); i++)
+      for (index_type j = 0; j < m.length(); j++) if (i != j) {
+ if (m[i]->instance_of(m[j], u))
+   lsg.add_edge(j, i);
+      }
+    graph lsg_tree;
+    lsg.strongly_connected_components();
+    lsg.component_tree(lsg_tree);
+    catom_vec mprime(0, 0);
+    for (index_type k = 0; k < lsg_tree.size(); k++)
+      if (lsg_tree.in_degree(k) == 0) {
+ index_type i = lsg.component_node(k);
+ mprime.append(m[i]);
+      }
+    bool is_exclusive = true;
+    for (index_type i = 0; (i < mprime.length()) && is_exclusive; i++)
+      for (index_type j = i + 1; (j < mprime.length()) && is_exclusive; j++)
+ if (mprime[i]->unify(mprime[j], u))
+   is_exclusive = false;
+    if (write_info) {
+      std::cerr << "info: invariant reduced to {";
+      for (index_type k = 0; k < mprime.length(); k++) {
+ if (k > 0) std::cerr << ", ";
+ mprime[k]->print(std::cerr);
+      }
+      std::cerr << "}" << std::endl;
+    }
+    symbol_set meta_vars;
+    for (index_type k = 0; k < mprime.length(); k++)
+      for (index_type p = 0; p < mprime[k]->param.length(); p++)
+ if (mprime[k]->param[p]->sym_class == sym_meta_variable)
+   meta_vars.insert(mprime[k]->param[p]);
+    SetConstraint* c = new SetConstraint();
+    for (index_type k = 0; k < meta_vars.length(); k++)
+      c->param.append((VariableSymbol*)gensym(sym_variable, "?v", meta_vars[k]->sym_types));
+    for (index_type k = 0; k < mprime.length(); k++) {
+      bool is_set = false;
+      for (index_type i = 0; i < mprime[k]->param.length(); i++)
+ if (mprime[k]->param[i]->sym_class == sym_variable)
+   is_set = true;
+      if (is_set) {
+ SetOf* s = new SetOf();
+ s->pos_atoms.append(new Atom(mprime[k]->pred));
+ for (index_type i = 0; i < mprime[k]->param.length(); i++) {
+   if (mprime[k]->param[i]->sym_class == sym_meta_variable) {
+     index_type j = meta_vars.first(mprime[k]->param[i]);
+     assert(j < c->param.length());
+     s->pos_atoms[0]->param.append(c->param[j]);
+   }
+   else {
+     if (mprime[k]->param[i]->sym_class == sym_variable) {
+       s->param.append((VariableSymbol*)mprime[k]->param[i]);
+     }
+     s->pos_atoms[0]->param.append(mprime[k]->param[i]);
+   }
+ }
+ for (index_type i = 0; i < mprime[k]->neq.length(); i++) {
+   if ((mprime[k]->neq[i].first->sym_class == sym_variable) ||
+       (mprime[k]->neq[i].second->sym_class == sym_variable)) {
+     if (mprime[k]->neq[i].first->sym_class == sym_meta_variable) {
+       index_type j1 = meta_vars.first(mprime[k]->neq[i].first);
+       index_type j2 = s->param.first((VariableSymbol*)mprime[k]->neq[i].second);
+       if ((j1 < c->param.length()) && (j2 != no_such_index)) {
+  Atom* q = new Atom(dom_eq_pred);
+  q->param.append(c->param[j1]);
+  q->param.append(mprime[k]->neq[i].second);
+  s->neg_con.append(q);
+       }
+     }
+     else if (mprime[k]->neq[i].second->sym_class == sym_meta_variable) {
+       index_type j1 = s->param.first((VariableSymbol*)mprime[k]->neq[i].first);
+       index_type j2 = meta_vars.first(mprime[k]->neq[i].second);
+       if ((j1 != no_such_index) && (j2 < c->param.length())) {
+  Atom* q = new Atom(dom_eq_pred);
+  q->param.append(mprime[k]->neq[i].first);
+  q->param.append(c->param[j2]);
+  s->neg_con.append(q);
+       }
+     }
+     else {
+       index_type j1 = s->param.first((VariableSymbol*)mprime[k]->neq[i].first);
+       index_type j2 = s->param.first((VariableSymbol*)mprime[k]->neq[i].second);
+       if (((j1 != no_such_index) ||
+     (mprime[k]->neq[i].first->sym_class == sym_object)) &&
+    ((j2 != no_such_index) ||
+     (mprime[k]->neq[i].second->sym_class == sym_object))) {
+  Atom* q = new Atom(dom_eq_pred);
+  q->param.append(mprime[k]->neq[i].first);
+  q->param.append(mprime[k]->neq[i].second);
+  s->neg_con.append(q);
+       }
+     }
+   }
+ }
+ c->atom_sets.append(s);
+      }
+      else {
+ Atom* a = new Atom(mprime[k]->pred);
+ for (index_type i = 0; i < mprime[k]->param.length(); i++) {
+   if (mprime[k]->param[i]->sym_class == sym_meta_variable) {
+     index_type j = meta_vars.first(mprime[k]->param[i]);
+     assert(j < c->param.length());
+     a->param.append(c->param[j]);
+   }
+   else {
+     assert(mprime[k]->param[i]->sym_class == sym_object);
+     a->param.append(mprime[k]->param[i]);
+   }
+ }
+ c->pos_atoms.append(a);
+ for (index_type i = 0; i < mprime[k]->neq.length(); i++) {
+   index_type j1 = meta_vars.first(mprime[k]->neq[i].first);
+   index_type j2 = meta_vars.first(mprime[k]->neq[i].second);
+   if ((j1 < c->param.length()) && (j2 < c->param.length())) {
+     Atom* q = new Atom(dom_eq_pred);
+     q->param.append(c->param[j1]);
+     q->param.append(c->param[j2]);
+     c->neg_con.append(q);
+   }
+ }
+      }
+    }
+    c->sc_type = sc_at_most;
+    c->sc_count = 1;
+    c->item_tags.append((char*)"c-constraint");
+    if (is_exclusive) {
+      c->item_tags.append((char*)"is-exclusive");
+    }
+    if ((c->atom_sets.length() > 0) || (c->pos_atoms.length() > 1)) {
+      dom_sc_invariants.append(c);
+    }
+    else if (write_info) {
+      std::cerr << "info: useless invariant {";
+      for (index_type k = 0; k < mprime.length(); k++) {
+ if (k > 0) std::cerr << ", ";
+ mprime[k]->print(std::cerr);
+      }
+      std::cerr << "} ignored" << std::endl;
+    }
+    m.set_length(reset_m_to);
+    q.set_length(reset_q_to);
+    return;
+  }
+  index_type last = q.length() - 1;
+  catom_vec x(q[last].first);
+  catom_vec not_x(q[last].second);
+  if (write_info) {
+    std::cerr << "[" << d << "] next: x = {";
+    for (index_type k = 0; k < x.length(); k++) {
+      if (k > 0) std::cerr << ", ";
+      x[k]->print(std::cerr);
+    }
+    std::cerr << "}, nx = {";
+    for (index_type k = 0; k < not_x.length(); k++) {
+      if (k > 0) std::cerr << ", ";
+      not_x[k]->print(std::cerr);
+    }
+    std::cerr << "}" << std::endl;
+  }
+  for (index_type k = 0; k < not_x.length(); k++)
+    for (index_type i = 0; i < m.length(); i++)
+      if (not_x[k]->unify(m[i], u)) {
+ if (write_info) {
+   std::cerr << "[" << d << "] cut (2) due to ";
+   not_x[k]->print(std::cerr);
+   std::cerr << ", ";
+   m[i]->print(std::cerr);
+   std::cerr << ", ";
+   print_substitution(std::cerr, u);
+   std::cerr << std::endl;
+ }
+ m.set_length(reset_m_to);
+ q.set_length(reset_q_to);
+ return;
+      }
+  q.dec_length();
+  index_type reset_nm_to = nm.length();
+  nm.append(not_x);
+  index_type local_reset_nm_to = nm.length();
+  for (index_type k = 0; k < x.length(); k++) {
+    bool ok = true;
+    for (index_type i = 0; (i < x.length()) && ok; i++) if (i != k) {
+      for (index_type j = 0; (j < m.length()) && ok; j++)
+ if (x[i]->unify(m[j], u)) ok = false;
+      if (ok) nm.append(x[i]);
+    }
+    if (ok) {
+      extend_cc(x[k], m, nm, q, d + 1);
+    }
+    nm.set_length(local_reset_nm_to);
+  }
+  m.set_length(reset_m_to);
+  nm.set_length(reset_nm_to);
+  q.append(swapable_pair<catom_vec>(x, not_x));
+  q.set_length(reset_q_to);
+  if (write_info) {
+    std::cerr << "[" << d << "] finished" << std::endl;
+  }
+}
+void PDDL_Base::find_cc()
+{
+  catom_vec m(0, 0);
+  catom_vec nm(0, 0);
+  lvector< swapable_pair<catom_vec> > q;
+  for (index_type k = 0; k < dom_predicates.length(); k++) {
+    if (!dom_predicates[k]->is_static()) {
+      CAtom* lit = new CAtom(new_meta_atom(dom_predicates[k]));
+      m.assign_value(0, 0);
+      nm.assign_value(0, 0);
+      q.set_length(0);
+      extend_cc(lit, m, nm, q, 0);
+    }
+  }
+}
+void PDDL_Base::TypeSymbol::add_element(Symbol* e)
+{
+  elements.append(e);
+  for (index_type k = 0; k < sym_types.length(); k++)
+    sym_types[k]->add_element(e);
+}
+bool PDDL_Base::TypeSymbol::subtype_or_equal(TypeSymbol* t) const
+{
+  if (t == 0) return true;
+  if (t == this) return true;
+  if (sym_types.subtype_or_equal(t))
+    return true;
+  return false;
+}
+bool PDDL_Base::TypeSymbol::subtype_or_equal(const TypeSet& t) const
+{
+  if (t.length() == 0) return true;
+  for (index_type k = 0; k < t.length(); k++)
+    if (!subtype_or_equal(t[k]))
+      return false;
+  return true;
+}
+bool PDDL_Base::VariableSymbol::equality_type_check(Symbol* s)
+{
+  if ((sym_types.length() > 0) && (s->sym_types.length() > 0)) {
+    for (index_type i = 0; i < sym_types.length(); i++) {
+      for (index_type j = 0; j < s->sym_types.length(); j++) {
+ if (sym_types[i]->subtype_or_equal(s->sym_types[j]))
+   return true;
+ if (s->sym_types[j]->subtype_or_equal(sym_types[i]))
+   return true;
+      }
+    }
+    return false;
+  }
+  else {
+    return true;
+  }
+}
+bool PDDL_Base::Expression::is_static()
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      FunctionSymbol* fun = ((FunctionExpression*)this)->fun;
+      return fun->is_static();
+    }
+  case exp_list:
+  case exp_time:
+    {
+      std::cerr << "error (is_static): expression ";
+      print(std::cerr, false);
+      std::cerr << " can not be evaluated" << std::endl;
+      exit(255);
+    }
+  case exp_const:
+    {
+      return true;
+    }
+  case exp_add:
+  case exp_sub:
+  case exp_mul:
+  case exp_div:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      return (bexp->first->is_static() && bexp->second->is_static());
+    }
+  case exp_preference:
+    return false;
+  }
+  assert(0);
+}
+bool PDDL_Base::Expression::is_constant()
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      FunctionSymbol* fun = ((FunctionExpression*)this)->fun;
+      return (fun->is_static() && (((FunctionExpression*)this)->args == 0));
+    }
+  case exp_list:
+  case exp_time:
+    {
+      std::cerr << "error (is_constant): expression ";
+      print(std::cerr, false);
+      std::cerr << " can not be evaluated" << std::endl;
+      exit(255);
+    }
+  case exp_const:
+    {
+      return true;
+    }
+  case exp_add:
+  case exp_sub:
+  case exp_mul:
+  case exp_div:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      return (bexp->first->is_constant() && bexp->second->is_constant());
+    }
+  case exp_preference:
+    return false;
+  }
+  assert(0);
+}
+bool PDDL_Base::Expression::is_integral()
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      FunctionSymbol* fun = ((FunctionExpression*)this)->fun;
+      return fun->integral;
+    }
+  case exp_list:
+  case exp_time:
+    {
+      std::cerr << "error (is_integral): expression ";
+      print(std::cerr, false);
+      std::cerr << " can not be evaluated" << std::endl;
+      exit(255);
+    }
+  case exp_const:
+    {
+      return (((ConstantExpression*)this)->val).integral();
+    }
+  case exp_add:
+  case exp_sub:
+  case exp_mul:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      return (bexp->first->is_integral() && bexp->second->is_integral());
+    }
+  case exp_div:
+    return false;
+  case exp_preference:
+    return true;
+  }
+  assert(0);
+}
+PDDL_Base::Expression* PDDL_Base::Expression::copy()
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      FunctionExpression* f_exp = (FunctionExpression*)this;
+      if (f_exp->args) {
+ ListExpression* args = (ListExpression*)f_exp->args->copy();
+ return new FunctionExpression(f_exp->fun, args);
+      }
+      else {
+ return new FunctionExpression(f_exp->fun, 0);
+      }
+    }
+  case exp_list:
+    {
+      ListExpression* l_exp = (ListExpression*)this;
+      if (l_exp->rest) {
+ ListExpression* rest = (ListExpression*)l_exp->rest->copy();
+ return new ListExpression(l_exp->sym, rest);
+      }
+      else {
+ return new ListExpression(l_exp->sym, 0);
+      }
+    }
+  case exp_time:
+    {
+      TimeExpression* t_exp = (TimeExpression*)this;
+      if (t_exp->time_exp == 0)
+ return new TimeExpression();
+      else
+ return new TimeExpression(t_exp->time_exp->copy());
+    }
+  case exp_const:
+    {
+      ConstantExpression* c_exp = (ConstantExpression*)this;
+      return new ConstantExpression(c_exp->val);
+    }
+  case exp_add:
+  case exp_sub:
+  case exp_mul:
+  case exp_div:
+    {
+      BinaryExpression* b_exp = (BinaryExpression*)this;
+      return new BinaryExpression(exp_class, b_exp->first->copy(),
+      b_exp->second->copy());
+    }
+  case exp_preference:
+    {
+      PreferenceExpression* p_exp = (PreferenceExpression*)this;
+      return new PreferenceExpression(p_exp->name);
+    }
+  }
+  assert(0);
+}
+void PDDL_Base::Expression::substitute_for_time(Expression* e)
+{
+  switch (exp_class) {
+  case exp_time:
+    {
+      ((TimeExpression*)this)->time_exp = e;
+      break;
+    }
+  case exp_add:
+  case exp_sub:
+  case exp_mul:
+  case exp_div:
+    {
+      BinaryExpression* b_exp = (BinaryExpression*)this;
+      b_exp->first->substitute_for_time(e);
+      b_exp->second->substitute_for_time(e);
+    }
+  }
+}
+PDDL_Base::Expression* PDDL_Base::Expression::substitute_for_preference
+(Symbol* n, Expression* e)
+{
+  switch (exp_class) {
+  case exp_preference:
+    {
+      PreferenceExpression* p_exp = (PreferenceExpression*)this;
+      if (p_exp->name == n) {
+ return e;
+      }
+      else {
+ return this;
+      }
+    }
+  case exp_add:
+  case exp_sub:
+  case exp_mul:
+  case exp_div:
+    {
+      BinaryExpression* b_exp = (BinaryExpression*)this;
+      b_exp->first = b_exp->first->substitute_for_preference(n, e);
+      b_exp->second = b_exp->second->substitute_for_preference(n, e);
+      return this;
+    }
+  default:
+    return this;
+  }
+}
+hsps::rational PDDL_Base::Expression::eval_static()
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      FunctionSymbol* fun = ((FunctionExpression*)this)->fun;
+      if (!fun->is_static()) {
+ std::cerr << "error: function " << fun->print_name
+    << " is not static" << std::endl;
+ exit(255);
+      }
+      ListExpression* args = ((FunctionExpression*)this)->args;
+      ptr_table* r = &(fun->init);
+      while (args && r) {
+ if (args->sym->sym_class == sym_variable) {
+   if (((VariableSymbol*)args->sym)->value == 0) {
+     std::cerr << "error: unbound variable "
+        << args->sym->print_name << " in ";
+     print(std::cerr, true);
+     std::cerr << " - uncompiled object function?"
+        << std::endl;
+     exit(255);
+   }
+   r = r->find_next(((VariableSymbol*)args->sym)->value);
+ }
+ else {
+   r = r->find_next(args->sym);
+ }
+ if (!r) {
+   if (use_default_function_value) {
+     return default_function_value;
+   }
+   else {
+     std::cerr << "error: ";
+     print(std::cerr, true);
+     std::cerr << " is undefined" << std::endl;
+     exit(255);
+   }
+ }
+ args = args->rest;
+      }
+      if (!r->val) {
+ if (use_default_function_value) {
+   return default_function_value;
+ }
+ else {
+   std::cerr << "error: ";
+   this->print(std::cerr, true);
+   std::cerr << " has no value (2)" << std::endl;
+   exit(255);
+ }
+      }
+      return ((FInitAtom*)r->val)->val;
+    }
+  case exp_list:
+    {
+      std::cerr << "error: expression ";
+      print(std::cerr, false);
+      std::cerr << " can not be evaluated" << std::endl;
+      exit(255);
+    }
+  case exp_time:
+    {
+      TimeExpression* texp = (TimeExpression*)this;
+      if (texp->time_exp == 0) {
+ std::cerr << "error (eval_static): expression ";
+ print(std::cerr, false);
+ std::cerr << " can not be evaluated" << std::endl;
+ exit(255);
+      }
+      return texp->time_exp->eval_static();
+    }
+  case exp_const:
+    {
+      ConstantExpression* cexp = (ConstantExpression*)this;
+      return cexp->val;
+    }
+  case exp_add:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_static();
+      hsps::rational v2 = bexp->second->eval_static();
+      return v1 + v2;
+    }
+  case exp_sub:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_static();
+      hsps::rational v2 = bexp->second->eval_static();
+      return v1 - v2;
+    }
+  case exp_mul:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_static();
+      hsps::rational v2 = bexp->second->eval_static();
+      return v1 * v2;
+    }
+  case exp_div:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_static();
+      hsps::rational v2 = bexp->second->eval_static();
+      return v1 / v2;
+    }
+  case exp_preference:
+    {
+      return 0;
+    }
+  }
+  assert(0);
+}
+bool PDDL_Base::Expression::eval_partial(hsps::rational& val)
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      FunctionSymbol* fun = ((FunctionExpression*)this)->fun;
+      if (!fun->is_static()) {
+ return false;
+      }
+      ListExpression* args = ((FunctionExpression*)this)->args;
+      ptr_table* r = &(fun->init);
+      while (args && r) {
+ if (args->sym->sym_class == sym_variable) {
+   if (((VariableSymbol*)args->sym)->value == 0) {
+     std::cerr << "error: unbound variable "
+        << args->sym->print_name << " in ";
+     print(std::cerr, true);
+     std::cerr << " - uncompiled object function?"
+        << std::endl;
+     exit(255);
+   }
+   r = r->find_next(((VariableSymbol*)args->sym)->value);
+ }
+ else {
+   r = r->find_next(args->sym);
+ }
+ if (!r) {
+   return false;
+ }
+ args = args->rest;
+      }
+      if (!r->val) {
+ return false;
+      }
+      val = ((FInitAtom*)r->val)->val;
+      return true;
+    }
+  case exp_list:
+    {
+      std::cerr << "error: expression ";
+      print(std::cerr, false);
+      std::cerr << " can not be evaluated" << std::endl;
+      exit(255);
+    }
+  case exp_time:
+    {
+      TimeExpression* texp = (TimeExpression*)this;
+      if (texp->time_exp == 0) {
+ std::cerr << "error (eval_partial): expression ";
+ print(std::cerr, false);
+ std::cerr << " can not be evaluated" << std::endl;
+ exit(255);
+      }
+      return texp->time_exp->eval_partial(val);
+    }
+  case exp_const:
+    {
+      ConstantExpression* cexp = (ConstantExpression*)this;
+      val = cexp->val;
+      return true;
+    }
+  case exp_add:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1;
+      if (!bexp->first->eval_partial(v1)) return false;
+      hsps::rational v2;
+      if (!bexp->first->eval_partial(v2)) return false;
+      val = (v1 + v2);
+      return true;
+    }
+  case exp_sub:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1;
+      if (!bexp->first->eval_partial(v1)) return false;
+      hsps::rational v2;
+      if (!bexp->first->eval_partial(v2)) return false;
+      val = (v1 - v2);
+      return true;
+    }
+  case exp_mul:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1;
+      if (!bexp->first->eval_partial(v1)) return false;
+      hsps::rational v2;
+      if (!bexp->first->eval_partial(v2)) return false;
+      val = (v1 * v2);
+      return true;
+    }
+  case exp_div:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1;
+      if (!bexp->first->eval_partial(v1)) return false;
+      hsps::rational v2;
+      if (!bexp->first->eval_partial(v2)) return false;
+      val = (v1 / v2);
+      return true;
+    }
+  case exp_preference:
+    {
+      return false;
+    }
+  }
+  assert(0);
+}
+interval PDDL_Base::FunctionSymbol::eval_init_bounds
+(ptr_table* p, index_type i, ListExpression* r)
+{
+  if (!p) {
+    if (use_default_function_value) {
+      return interval(default_function_value);
+    }
+    else {
+      return interval(NEG_INF, POS_INF);
+    }
+  }
+  if (r == 0) {
+    if (!p->val) {
+      ptr_table::key_vec* k = p->key_sequence();
+      std::cerr << "error: key sequence " << k
+  << " stored without value in function ";
+      print(std::cerr);
+      std::cerr << " init table"
+  << std::endl;
+      exit(255);
+    }
+    return interval(((FInitAtom*)p->val)->val);
+  }
+  else if (r->sym->sym_class == sym_variable) {
+    if (((VariableSymbol*)r->sym)->value) {
+      return eval_init_bounds(p->find_next(((VariableSymbol*)r->sym)->value), i + 1, r->rest);
+    }
+    else {
+      hsps::rational v_min = POS_INF;
+      hsps::rational v_max = NEG_INF;
+      for (index_type k = 0; k < param[i]->sym_types.n_elements(); k++) {
+ interval v =
+   eval_init_bounds(p->find_next(param[i]->sym_types.get_element(k)),
+      i + 1, r->rest);
+ v_min = hsps::rational::min(v_min,v.first);
+ v_max = hsps::rational::max(v_max,v.second);
+      }
+      return interval(v_min, v_max);
+    }
+  }
+  else {
+    return eval_init_bounds(p->find_next(r->sym), i + 1, r->rest);
+  }
+}
+interval PDDL_Base::Expression::eval_bounds()
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      FunctionSymbol* fun = ((FunctionExpression*)this)->fun;
+      if (!fun->is_static()) {
+ return interval(NEG_INF, POS_INF);
+      }
+      ListExpression* args = ((FunctionExpression*)this)->args;
+      ptr_table* p = &(fun->init);
+      return fun->eval_init_bounds(p, 0, args);
+    }
+  case exp_list:
+    {
+      std::cerr << "error: expression ";
+      print(std::cerr, false);
+      std::cerr << " can not be evaluated" << std::endl;
+      exit(255);
+    }
+  case exp_time:
+    {
+      TimeExpression* texp = (TimeExpression*)this;
+      if (texp->time_exp == 0) {
+ std::cerr << "error (eval_bounds): expression ";
+ print(std::cerr, false);
+ std::cerr << " can not be evaluated" << std::endl;
+ exit(255);
+      }
+      return texp->time_exp->eval_bounds();
+    }
+  case exp_const:
+    {
+      ConstantExpression* cexp = (ConstantExpression*)this;
+      return interval(cexp->val);
+    }
+  case exp_add:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      interval v1 = bexp->first->eval_bounds();
+      interval v2 = bexp->second->eval_bounds();
+      return interval(v1.first + v2.first, v1.second + v2.second);
+    }
+  case exp_sub:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      interval v1 = bexp->first->eval_bounds();
+      interval v2 = bexp->second->eval_bounds();
+      return interval(v1.first - v2.second, v1.second - v2.first);
+    }
+  case exp_mul:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      interval v1 = bexp->first->eval_bounds();
+      interval v2 = bexp->second->eval_bounds();
+      return interval(hsps::rational::min(hsps::rational::min(v1.first * v2.first,v1.first * v2.second),hsps::rational::min(v1.second * v2.first,v1.second * v2.second)),
+        hsps::rational::max(hsps::rational::max(v1.first * v2.first,v1.first * v2.second),hsps::rational::max(v1.second * v2.first,v1.second * v2.second)));
+    }
+  case exp_div:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      if (bexp->second->is_static()) {
+ interval v1 = bexp->first->eval_bounds();
+ hsps::rational v2 = bexp->second->eval_static();
+ return interval(v1.first / v2, v1.second / v2);
+      }
+      else if (bexp->first->is_static()) {
+ hsps::rational v1 = bexp->first->eval_static();
+ interval v2 = bexp->second->eval_bounds();
+ return interval(v1 / v2.second, v1 / v2.first);
+      }
+      else {
+ std::cerr << "error: in eval_bounds(";
+ bexp->print(std::cerr, false);
+ std::cerr << "): interval division not implemented"
+    << std::endl;
+ exit(255);
+      }
+    }
+  case exp_preference:
+    {
+      std::cerr << "error: eval_bounds(PreferenceExpression) not implemented"
+  << std::endl;
+      exit(255);
+    }
+  }
+  assert(0);
+}
+hsps::rational PDDL_Base::Expression::eval_init()
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      FunctionSymbol* fun = ((FunctionExpression*)this)->fun;
+      ListExpression* args = ((FunctionExpression*)this)->args;
+      ptr_table* r = &(fun->init);
+      while (args && r) {
+ if (args->sym->sym_class == sym_variable) {
+   if (((VariableSymbol*)args->sym)->value == 0) {
+     std::cerr << "error: unbound variable "
+        << args->sym->print_name << " in ";
+     print(std::cerr, true);
+     std::cerr << " - uncompiled object function?"
+        << std::endl;
+     exit(255);
+   }
+   r = r->find_next(((VariableSymbol*)args->sym)->value);
+ }
+ else {
+   r = r->find_next(args->sym);
+ }
+ if (!r) {
+   if (use_default_function_value) {
+     return default_function_value;
+   }
+   else {
+     std::cerr << "error: ";
+     print(std::cerr, true);
+     std::cerr << " is undefined" << std::endl;
+     exit(255);
+   }
+ }
+ args = args->rest;
+      }
+      if (!r->val) {
+ if (use_default_function_value) {
+   return default_function_value;
+ }
+ else {
+   std::cerr << "error: ";
+   this->print(std::cerr, true);
+   std::cerr << " has no value (2)" << std::endl;
+   exit(255);
+ }
+      }
+      return ((FInitAtom*)r->val)->val;
+    }
+  case exp_list:
+    {
+      std::cerr << "error: expression ";
+      print(std::cerr, false);
+      std::cerr << " can not be evaluated" << std::endl;
+      exit(255);
+    }
+  case exp_time:
+    {
+      TimeExpression* texp = (TimeExpression*)this;
+      if (texp->time_exp == 0) {
+ std::cerr << "error (eval_static): expression ";
+ print(std::cerr, false);
+ std::cerr << " can not be evaluated" << std::endl;
+ exit(255);
+      }
+      return texp->time_exp->eval_static();
+    }
+  case exp_const:
+    {
+      ConstantExpression* cexp = (ConstantExpression*)this;
+      return cexp->val;
+    }
+  case exp_add:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_init();
+      hsps::rational v2 = bexp->second->eval_init();
+      return v1 + v2;
+    }
+  case exp_sub:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_init();
+      hsps::rational v2 = bexp->second->eval_init();
+      return v1 - v2;
+    }
+  case exp_mul:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_init();
+      hsps::rational v2 = bexp->second->eval_init();
+      return v1 * v2;
+    }
+  case exp_div:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_init();
+      hsps::rational v2 = bexp->second->eval_init();
+      return v1 / v2;
+    }
+  case exp_preference:
+    {
+      return 0;
+    }
+  }
+  assert(0);
+}
+hsps::rational PDDL_Base::Expression::eval_delta
+(ch_atom_vec& incs, ch_atom_vec& decs)
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      return ((FunctionExpression*)this)->eval_delta(incs, decs);
+    }
+  case exp_list:
+    {
+      std::cerr << "error (eval_delta): expression ";
+      print(std::cerr, false);
+      std::cerr << " can not be evaluated" << std::endl;
+      exit(255);
+    }
+  case exp_time:
+    {
+      return 0;
+    }
+  case exp_const:
+    {
+      return 0;
+    }
+  case exp_add:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_delta(incs, decs);
+      hsps::rational v2 = bexp->second->eval_delta(incs, decs);
+      return v1 + v2;
+    }
+  case exp_sub:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_delta(incs, decs);
+      hsps::rational v2 = bexp->second->eval_delta(incs, decs);
+      return v1 - v2;
+    }
+  case exp_mul:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      if (bexp->first->is_static()) {
+ if (bexp->second->is_static()) {
+   return 0;
+ }
+ else {
+   hsps::rational v1 = bexp->first->eval_static();
+   hsps::rational v2 = bexp->second->eval_delta(incs, decs);
+   return v1 * v2;
+ }
+      }
+      else if (bexp->second->is_static()) {
+ hsps::rational v1 = bexp->first->eval_delta(incs, decs);
+ hsps::rational v2 = bexp->second->eval_static();
+ return v1 * v2;
+      }
+      else {
+ std::cerr << "error (eval_delta): expression ";
+ print(std::cerr, false);
+ std::cerr << " is non-linear" << std::endl;
+ exit(255);
+      }
+    }
+  case exp_div:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      if (bexp->first->is_static()) {
+ if (bexp->second->is_static()) {
+   return 0;
+ }
+ else {
+   hsps::rational v1 = bexp->first->eval_static();
+   hsps::rational v2 = bexp->second->eval_delta(incs, decs);
+   return v1 / v2;
+ }
+      }
+      else if (bexp->second->is_static()) {
+ hsps::rational v1 = bexp->first->eval_delta(incs, decs);
+ hsps::rational v2 = bexp->second->eval_static();
+ return v1 / v2;
+      }
+      else {
+ std::cerr << "error (eval_delta): expression ";
+ print(std::cerr, false);
+ std::cerr << " is non-linear" << std::endl;
+ exit(255);
+      }
+    }
+  case exp_preference:
+    return 0;
+  }
+  assert(0);
+}
+hsps::rational PDDL_Base::Expression::eval_delta
+(Symbol* preference, hsps::rational p_value, hsps::rational d_value)
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      FunctionSymbol* fun = ((FunctionExpression*)this)->fun;
+      ListExpression* args = ((FunctionExpression*)this)->args;
+      ptr_table* r = &(fun->init);
+      while (args && r) {
+ if (args->sym->sym_class == sym_variable) {
+   if (((VariableSymbol*)args->sym)->value == 0) {
+     std::cerr << "error: unbound variable "
+        << args->sym->print_name << " in ";
+     print(std::cerr, true);
+     std::cerr << " - uncompiled object function?"
+        << std::endl;
+     exit(255);
+   }
+   r = r->find_next(((VariableSymbol*)args->sym)->value);
+ }
+ else {
+   r = r->find_next(args->sym);
+ }
+ if (!r) {
+   std::cerr << "error: ";
+   print(std::cerr, true);
+   std::cerr << " has no value (1)" << std::endl;
+   exit(255);
+ }
+ args = args->rest;
+      }
+      if (!r->val) {
+ std::cerr << "error: ";
+ this->print(std::cerr, true);
+ std::cerr << " has no value (2)" << std::endl;
+ exit(255);
+      }
+      return ((FInitAtom*)r->val)->val;
+    }
+  case exp_list:
+    {
+      std::cerr << "error (eval_delta): expression ";
+      print(std::cerr, false);
+      std::cerr << " can not be evaluated" << std::endl;
+      exit(255);
+    }
+  case exp_time:
+    {
+      TimeExpression* texp = (TimeExpression*)this;
+      if (texp->time_exp == 0) {
+ std::cerr << "error (eval_static): expression ";
+ print(std::cerr, false);
+ std::cerr << " can not be evaluated" << std::endl;
+ exit(255);
+      }
+      return texp->time_exp->eval_static();
+    }
+  case exp_const:
+    {
+      ConstantExpression* cexp = (ConstantExpression*)this;
+      return cexp->val;
+    }
+  case exp_add:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_delta(preference, p_value, d_value);
+      hsps::rational v2 = bexp->second->eval_delta(preference, p_value, d_value);
+      return v1 + v2;
+    }
+  case exp_sub:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      hsps::rational v1 = bexp->first->eval_delta(preference, p_value, d_value);
+      hsps::rational v2 = bexp->second->eval_delta(preference, p_value, d_value);
+      return v1 - v2;
+    }
+  case exp_mul:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      if (bexp->first->is_static()) {
+ if (bexp->second->is_static()) {
+   hsps::rational v1 = bexp->first->eval_static();
+   hsps::rational v2 = bexp->second->eval_static();
+   return v1 * v2;
+ }
+ else {
+   hsps::rational v1 = bexp->first->eval_static();
+   hsps::rational v2 = bexp->second->eval_delta(preference, p_value, d_value);
+   return v1 * v2;
+ }
+      }
+      else if (bexp->second->is_static()) {
+ hsps::rational v1 = bexp->first->eval_delta(preference, p_value, d_value);
+ hsps::rational v2 = bexp->second->eval_static();
+ return v1 * v2;
+      }
+      else {
+ std::cerr << "error (eval_delta): expression ";
+ print(std::cerr, false);
+ std::cerr << " is non-linear" << std::endl;
+ exit(255);
+      }
+    }
+  case exp_div:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      if (bexp->first->is_static()) {
+ if (bexp->second->is_static()) {
+   hsps::rational v1 = bexp->first->eval_static();
+   hsps::rational v2 = bexp->second->eval_static();
+   return v1 / v2;
+ }
+ else {
+   hsps::rational v1 = bexp->first->eval_static();
+   hsps::rational v2 = bexp->second->eval_delta(preference, p_value, d_value);
+   return v1 / v2;
+ }
+      }
+      else if (bexp->second->is_static()) {
+ hsps::rational v1 = bexp->first->eval_delta(preference, p_value, d_value);
+ hsps::rational v2 = bexp->second->eval_static();
+ return v1 / v2;
+      }
+      else {
+ std::cerr << "error (eval_delta): expression ";
+ print(std::cerr, false);
+ std::cerr << " is non-linear" << std::endl;
+ exit(255);
+      }
+    }
+  case exp_preference:
+    {
+      PreferenceExpression* pexp = (PreferenceExpression*)this;
+      if (pexp->name == preference) {
+ return p_value;
+      }
+      else {
+ return d_value;
+      }
+    }
+  }
+  assert(0);
+}
+bool PDDL_Base::Expression::equals(PDDL_Base::Expression* exp)
+{
+  if (!exp) return false;
+  if (exp_class != exp->exp_class) return false;
+  switch (exp_class) {
+  case exp_fun:
+    {
+      FunctionExpression* f_this = (FunctionExpression*)this;
+      FunctionExpression* f_exp = (FunctionExpression*)exp;
+      if (f_this->fun != f_exp->fun) return false;
+      if (f_this->args)
+ return f_this->args->equals(f_exp->args);
+      else
+ return f_exp->args == 0;
+    }
+  case exp_list:
+    {
+      ListExpression* l_this = (ListExpression*)this;
+      ListExpression* l_exp = (ListExpression*)exp;
+      if (l_this->sym != l_exp->sym) return false;
+      if (l_this->rest)
+ return l_this->rest->equals(l_exp->rest);
+      else
+ return l_exp->rest == 0;
+    }
+  case exp_const:
+    {
+      ConstantExpression* c_this = (ConstantExpression*)this;
+      ConstantExpression* c_exp = (ConstantExpression*)exp;
+      return c_this->val == c_exp->val;
+    }
+  case exp_time:
+    {
+      TimeExpression* t_this = (TimeExpression*)this;
+      TimeExpression* t_exp = (TimeExpression*)exp;
+      return t_this->time_exp == t_exp->time_exp;
+    }
+  case exp_add:
+  case exp_sub:
+  case exp_mul:
+  case exp_div:
+    {
+      BinaryExpression* b_this = (BinaryExpression*)this;
+      BinaryExpression* b_exp = (BinaryExpression*)exp;
+      return (b_this->first->equals(b_exp->first) &&
+       b_this->second->equals(b_exp->second));
+    }
+  }
+}
+PDDL_Base::Expression* PDDL_Base::Expression::simplify()
+{
+  switch (exp_class) {
+  case exp_fun:
+  case exp_list:
+  case exp_time:
+  case exp_const:
+  case exp_preference:
+    return this;
+  case exp_add:
+    {
+      if (is_static()) return new ConstantExpression(eval_static());
+      BinaryExpression* b_exp = (BinaryExpression*)this;
+      b_exp->first = b_exp->first->simplify();
+      b_exp->second = b_exp->second->simplify();
+      if ((b_exp->first->exp_class == exp_add) &&
+   (b_exp->second->exp_class == exp_add)) {
+ BinaryExpression* b1 = (BinaryExpression*)(b_exp->first);
+ BinaryExpression* b2 = (BinaryExpression*)(b_exp->second);
+ if (b1->first->is_static()) {
+   if (b2->first->is_static()) {
+     hsps::rational v1 = b1->first->eval_static();
+     hsps::rational v2 = b2->first->eval_static();
+     b1->first = b2->second;
+     b_exp->second = new ConstantExpression(v1 + v2);
+   }
+   else if (b2->second->is_static()) {
+     hsps::rational v1 = b1->first->eval_static();
+     hsps::rational v2 = b2->second->eval_static();
+     b1->first = b2->first;
+     b_exp->second = new ConstantExpression(v1 + v2);
+   }
+ }
+ else if (b1->second->is_static()) {
+   if (b2->first->is_static()) {
+     hsps::rational v1 = b1->second->eval_static();
+     hsps::rational v2 = b2->first->eval_static();
+     b1->second = b2->second;
+     b_exp->second = new ConstantExpression(v1 + v2);
+   }
+   else if (b2->second->is_static()) {
+     hsps::rational v1 = b1->second->eval_static();
+     hsps::rational v2 = b2->second->eval_static();
+     b1->second = b2->first;
+     b_exp->second = new ConstantExpression(v1 + v2);
+   }
+ }
+      }
+      else if ((b_exp->first->exp_class == exp_add) &&
+        (b_exp->second->is_static())) {
+ BinaryExpression* b1 = (BinaryExpression*)(b_exp->first);
+ if (b1->first->is_static()) {
+   hsps::rational v1 = b1->first->eval_static();
+   hsps::rational v2 = b_exp->second->eval_static();
+   b_exp->first = b1->second;
+   b_exp->second = new ConstantExpression(v1 + v2);
+ }
+ else if (b1->second->is_static()) {
+   hsps::rational v1 = b1->second->eval_static();
+   hsps::rational v2 = b_exp->second->eval_static();
+   b_exp->first = b1->first;
+   b_exp->second = new ConstantExpression(v1 + v2);
+ }
+      }
+      else if ((b_exp->second->exp_class == exp_add) &&
+        (b_exp->first->is_static())) {
+ BinaryExpression* b1 = (BinaryExpression*)(b_exp->second);
+ if (b1->first->is_static()) {
+   hsps::rational v1 = b1->first->eval_static();
+   hsps::rational v2 = b_exp->first->eval_static();
+   b_exp->first = b1->second;
+   b_exp->second = new ConstantExpression(v1 + v2);
+ }
+ else if (b1->second->is_static()) {
+   hsps::rational v1 = b1->second->eval_static();
+   hsps::rational v2 = b_exp->first->eval_static();
+   b_exp->first = b1->first;
+   b_exp->second = new ConstantExpression(v1 + v2);
+ }
+      }
+      return this;
+    }
+  case exp_sub:
+    {
+      if (is_static()) return new ConstantExpression(eval_static());
+      BinaryExpression* b_exp = (BinaryExpression*)this;
+      Expression* second =
+ new BinaryExpression(exp_mul,
+        new ConstantExpression(-1),
+        b_exp->second->simplify());
+      Expression* e =
+ new BinaryExpression(exp_add,
+        b_exp->first->simplify(),
+        second->simplify());
+      return e->simplify();
+    }
+  case exp_mul:
+    {
+      if (is_static()) return new ConstantExpression(eval_static());
+      BinaryExpression* b_exp = (BinaryExpression*)this;
+      b_exp->first = b_exp->first->simplify();
+      b_exp->second = b_exp->second->simplify();
+      if (b_exp->first->exp_class == exp_add) {
+ BinaryExpression* b1 = (BinaryExpression*)(b_exp->first);
+ Expression* e1 =
+   new BinaryExpression(exp_mul, b1->first, b_exp->second);
+ Expression* e2 =
+   new BinaryExpression(exp_mul, b1->second, b_exp->second);
+ Expression* e =
+   new BinaryExpression(exp_add, e1->simplify(), e2->simplify());
+ return e->simplify();
+      }
+      else if (b_exp->second->exp_class == exp_add) {
+ BinaryExpression* b1 = (BinaryExpression*)(b_exp->second);
+ Expression* e1 =
+   new BinaryExpression(exp_mul, b1->first, b_exp->first);
+ Expression* e2 =
+   new BinaryExpression(exp_mul, b1->second, b_exp->first);
+ Expression* e =
+   new BinaryExpression(exp_add, e1->simplify(), e2->simplify());
+ return e->simplify();
+      }
+      else {
+ if ((b_exp->first->exp_class == exp_mul) &&
+     (b_exp->second->exp_class == exp_mul)) {
+   BinaryExpression* b1 = (BinaryExpression*)(b_exp->first);
+   BinaryExpression* b2 = (BinaryExpression*)(b_exp->second);
+   if (b1->first->is_static()) {
+     if (b2->first->is_static()) {
+       hsps::rational v1 = b1->first->eval_static();
+       hsps::rational v2 = b2->first->eval_static();
+       if ((v1 * v2) == 1) {
+  b_exp->first = b1->second;
+  b_exp->second = b2->second;
+       }
+       else {
+  b1->first = b2->second;
+  b_exp->second = new ConstantExpression(v1 * v2);
+       }
+     }
+     else if (b2->second->is_static()) {
+       hsps::rational v1 = b1->first->eval_static();
+       hsps::rational v2 = b2->second->eval_static();
+       if ((v1 * v2) == 1) {
+  b_exp->first = b1->second;
+  b_exp->second = b2->first;
+       }
+       else {
+  b1->first = b2->first;
+  b_exp->second = new ConstantExpression(v1 * v2);
+       }
+     }
+   }
+   else if (b1->second->is_static()) {
+     if (b2->first->is_static()) {
+       hsps::rational v1 = b1->second->eval_static();
+       hsps::rational v2 = b2->first->eval_static();
+       if ((v1 * v2) == 1) {
+  b_exp->first = b1->first;
+  b_exp->second = b2->second;
+       }
+       else {
+  b1->second = b2->second;
+  b_exp->second = new ConstantExpression(v1 * v2);
+       }
+     }
+     else if (b2->second->is_static()) {
+       hsps::rational v1 = b1->second->eval_static();
+       hsps::rational v2 = b2->second->eval_static();
+       if ((v1 * v2) == 1) {
+  b_exp->first = b1->first;
+  b_exp->second = b2->first;
+       }
+       else {
+  b1->second = b2->first;
+  b_exp->second = new ConstantExpression(v1 * v2);
+       }
+     }
+   }
+ }
+ else if ((b_exp->first->exp_class == exp_mul) &&
+   (b_exp->second->is_static())) {
+   BinaryExpression* b1 = (BinaryExpression*)(b_exp->first);
+   if (b1->first->is_static()) {
+     hsps::rational v1 = b1->first->eval_static();
+     hsps::rational v2 = b_exp->second->eval_static();
+     if ((v1 * v2) == 1) {
+       return b1->second;
+     }
+     else {
+       b_exp->first = b1->second;
+       b_exp->second = new ConstantExpression(v1 * v2);
+     }
+   }
+   else if (b1->second->is_static()) {
+     hsps::rational v1 = b1->second->eval_static();
+     hsps::rational v2 = b_exp->second->eval_static();
+     if ((v1 * v2) == 1) {
+       return b1->first;
+     }
+     else {
+       b_exp->first = b1->first;
+       b_exp->second = new ConstantExpression(v1 * v2);
+     }
+   }
+ }
+ else if ((b_exp->second->exp_class == exp_mul) &&
+   (b_exp->first->is_static())) {
+   BinaryExpression* b1 = (BinaryExpression*)(b_exp->second);
+   if (b1->first->is_static()) {
+     hsps::rational v1 = b1->first->eval_static();
+     hsps::rational v2 = b_exp->first->eval_static();
+     if ((v1 * v2) == 1) {
+       return b1->second;
+     }
+     else {
+       b_exp->first = b1->second;
+       b_exp->second = new ConstantExpression(v1 * v2);
+     }
+   }
+   else if (b1->second->is_static()) {
+     hsps::rational v1 = b1->second->eval_static();
+     hsps::rational v2 = b_exp->first->eval_static();
+     if ((v1 * v2) == 1) {
+       return b1->first;
+     }
+     else {
+       b_exp->first = b1->first;
+       b_exp->second = new ConstantExpression(v1 * v2);
+     }
+   }
+ }
+ return this;
+      }
+    }
+  case exp_div:
+    {
+      if (is_static()) return new ConstantExpression(eval_static());
+      BinaryExpression* b_exp = (BinaryExpression*)this;
+      b_exp->first = b_exp->first->simplify();
+      b_exp->second = b_exp->second->simplify();
+      if (b_exp->first->exp_class == exp_add) {
+ BinaryExpression* b1 = (BinaryExpression*)(b_exp->first);
+ Expression* e1 =
+   new BinaryExpression(exp_div, b1->first, b_exp->second);
+ Expression* e2 =
+   new BinaryExpression(exp_div, b1->second, b_exp->second);
+ Expression* e =
+   new BinaryExpression(exp_add, e1->simplify(), e2->simplify());
+ return e->simplify();
+      }
+      else if (b_exp->second->exp_class == exp_add) {
+ BinaryExpression* b1 = (BinaryExpression*)(b_exp->second);
+ Expression* e1 =
+   new BinaryExpression(exp_div, b1->first, b_exp->first);
+ Expression* e2 =
+   new BinaryExpression(exp_div, b1->second, b_exp->first);
+ Expression* e =
+   new BinaryExpression(exp_add, e1->simplify(), e2->simplify());
+ return e->simplify();
+      }
+      else {
+ return this;
+      }
+    }
+  }
+  assert(0);
+}
+void PDDL_Base::Expression::collect_constants(exp_vec& c)
+{
+  switch (exp_class) {
+  case exp_const:
+    c.append(this);
+    break;
+  case exp_add:
+  case exp_sub:
+  case exp_mul:
+  case exp_div:
+    ((BinaryExpression*)this)->first->collect_constants(c);
+    ((BinaryExpression*)this)->second->collect_constants(c);
+    break;
+  }
+}
+void PDDL_Base::Expression::mark_functions_in_condition()
+{
+  switch (exp_class) {
+  case exp_fun:
+    ((FunctionExpression*)this)->fun->conditioned = true;
+    break;
+  case exp_add:
+  case exp_sub:
+  case exp_mul:
+  case exp_div:
+    ((BinaryExpression*)this)->first->mark_functions_in_condition();
+    ((BinaryExpression*)this)->second->mark_functions_in_condition();
+    break;
+  }
+}
+hsps::rational PDDL_Base::Expression::integrify()
+{
+  exp_vec cexp(0, 0);
+  collect_constants(cexp);
+  if (cexp.length() == 0) return 1;
+  svector<long> factors;
+  for (index_type k = 0; k < cexp.length(); k++)
+    factors.insert(((ConstantExpression*)cexp[k])->val.divisor());
+  long common_m = factors[0];
+  for (index_type k = 1; k < factors.length(); k++) {
+    std::cerr << "lcm(" << common_m << ", " << factors[k] << ") = "
+       << lcm(common_m, factors[k]) << std::endl;
+    common_m = lcm(common_m, factors[k]);
+  }
+  std::cerr << "factors = " << factors
+     << ", lcm = " << common_m
+     << std::endl;
+  for (index_type k = 0; k < cexp.length(); k++) {
+    hsps::rational v0 = ((ConstantExpression*)cexp[k])->val;
+    index_type i = factors.first(v0.divisor());
+    assert(i < factors.length());
+    hsps::rational v1(v0.numerator() * (common_m / v0.divisor()), 1);
+    std::cerr << "replacing " << v0 << " by " << v1 << std::endl;
+    ((ConstantExpression*)cexp[k])->val = v1;
+  }
+  return common_m;
+}
+bool PDDL_Base::ListExpression::match(AtomBase* atom)
+{
+  ListExpression* f = this;
+  index_type n = 0;
+  while (f && (n < atom->param.length())) {
+    if (f->sym->sym_class == sym_variable) {
+      if (atom->param[n]->sym_class == sym_variable) {
+ if (f->sym != atom->param[n]) return false;
+      }
+      else {
+ if (((VariableSymbol*)f->sym)->value != atom->param[n]) return false;
+      }
+    }
+    else {
+      if (atom->param[n]->sym_class == sym_variable) {
+ if (f->sym != ((VariableSymbol*)atom->param[n])->value) return false;
+      }
+      else {
+ if (f->sym != atom->param[n]) return false;
+      }
+    }
+    f = f->rest;
+    n += 1;
+  }
+  return ((f == 0) && (n == atom->param.length()));
+}
+bool PDDL_Base::FunctionExpression::match(FChangeAtom* atom)
+{
+  if (fun != atom->fun) return false;
+  if (args) {
+    return args->match(atom);
+  }
+  else {
+    return (atom->param.length() == 0);
+  }
+}
+hsps::rational PDDL_Base::FunctionExpression::eval_delta
+(ch_atom_vec& incs, ch_atom_vec& decs)
+{
+  hsps::rational delta(0);
+  for (index_type k = 0; k < incs.length(); k++) {
+    if (match(incs[k])) delta += incs[k]->val->eval_static();
+  }
+  for (index_type k = 0; k < decs.length(); k++) {
+    if (match(decs[k])) delta -= decs[k]->val->eval_static();
+  }
+  return delta;
+}
+PDDL_Base::FChangeAtom* PDDL_Base::FunctionExpression::make_atom_base()
+{
+  FChangeAtom* atom = new FChangeAtom(fun);
+  for (ListExpression* l = args; l != 0; l = l->rest) {
+    atom->param.append(l->sym);
+  }
+  return atom;
+}
+PDDL_Base::Expression* PDDL_Base::Relation::match_gteq_constant
+(FChangeAtom* atom)
+{
+  if ((at == md_all) && (rel == rel_greater_equal)) {
+    if (first->exp_class != exp_fun) return 0;
+    if (!((FunctionExpression*)first)->match(atom)) return 0;
+    if (!second->is_constant()) return 0;
+    return second;
+  }
+  else if ((at == md_all) && (rel == rel_greater_equal)) {
+    if (second->exp_class != exp_fun) return 0;
+    if (!((FunctionExpression*)second)->match(atom)) return 0;
+    if (!first->is_constant()) return 0;
+    return first;
+  }
+  else {
+    return 0;
+  }
+}
+PDDL_Base::FunctionExpression* PDDL_Base::Relation::match_lteq_fun
+(FChangeAtom* atom)
+{
+  if ((at == md_start) &&
+      (rel == rel_less_equal) &&
+      (first->exp_class == exp_fun) &&
+      (second->exp_class == exp_sub)) {
+    FunctionExpression* lhs = (FunctionExpression*)first;
+    BinaryExpression* rhs = (BinaryExpression*)second;
+    if (!lhs->match(atom)) return 0;
+    if (!rhs->second->equals(atom->val)) return 0;
+    if (rhs->first->exp_class != exp_fun) return 0;
+    return (FunctionExpression*)(rhs->first);
+  }
+  else if ((at == md_start) &&
+    (rel == rel_less) &&
+    (first->exp_class == exp_fun) &&
+    (second->exp_class == exp_fun)) {
+    FunctionExpression* lhs = (FunctionExpression*)first;
+    FunctionExpression* rhs = (FunctionExpression*)second;
+    if (!lhs->match(atom)) return 0;
+    if (!atom->fun->integral) return 0;
+    if (!atom->val->is_constant()) return 0;
+    if (!(atom->val->eval_static() == 1)) return 0;
+    return rhs;
+  }
+  else if ((at == md_all) &&
+    (rel == rel_less_equal) &&
+    (first->exp_class == exp_fun) &&
+    (second->exp_class == exp_fun)) {
+    FunctionExpression* lhs = (FunctionExpression*)first;
+    FunctionExpression* rhs = (FunctionExpression*)second;
+    if (!lhs->match(atom)) return 0;
+    return rhs;
+  }
+  else {
+    return 0;
+  }
+}
+bool PDDL_Base::Relation::is_static()
+{
+  return (first->is_static() && second->is_static());
+}
+PDDL_Base::partial_value PDDL_Base::Relation::partial_eval()
+{
+  hsps::rational v1;
+  if (!first->eval_partial(v1)) {
+    return p_unknown;
+  }
+  hsps::rational v2;
+  if (!second->eval_partial(v2)) {
+    return p_unknown;
+  }
+  switch (rel) {
+  case rel_equal:
+    {
+      if (v1 == v2)
+ return p_true;
+      else
+ return p_false;
+    }
+  case rel_greater:
+    {
+      if (v1 > v2)
+ return p_true;
+      else
+ return p_false;
+    }
+  case rel_greater_equal:
+    {
+      if (v1 >= v2)
+ return p_true;
+      else
+ return p_false;
+    }
+  case rel_less:
+    {
+      if (v1 < v2)
+ return p_true;
+      else
+ return p_false;
+    }
+  case rel_less_equal:
+    {
+      if (v1 <= v2)
+ return p_true;
+      else
+ return p_false;
+    }
+  default:
+    {
+      std::cerr << "program error: invalid relation " << rel
+  << " in ";
+      print(std::cerr, true);
+      std::cerr << std::endl;
+      exit(255);
+    }
+  }
+}
+PDDL_Base::AtomBase::AtomBase(AtomBase* b)
+  : param(b->param), at(b->at), at_time(b->at_time)
+{
+}
+bool PDDL_Base::AtomBase::equals(AtomBase& b)
+{
+  if (param.length() != b.param.length()) return false;
+  for (index_type k = 0; k < param.length(); k++) {
+    if (param[k] != b.param[k]) {
+      if ((param[k]->sym_class == sym_variable) &&
+   (b.param[k]->sym_class == sym_variable)) {
+ VariableSymbol* v1 = (VariableSymbol*)param[k];
+ VariableSymbol* v2 = (VariableSymbol*)b.param[k];
+ if ((v1->binding != 0) && (v2->binding != 0)) {
+   if (!(v1->binding->equals(*(v2->binding))))
+     return false;
+ }
+ else {
+   return false;
+ }
+      }
+      else {
+ return false;
+      }
+    }
+  }
+  return true;
+}
+void PDDL_Base::AtomBase::free_variables(variable_vec& v)
+{
+  for (index_type k = 0; k < param.length(); k++)
+    if (param[k]->sym_class == sym_variable)
+      v.append((VariableSymbol*)param[k]);
+}
+bool PDDL_Base::AtomBase::occurs(Symbol* s)
+{
+  for (index_type k = 0; k < param.length(); k++)
+    if (param[k] == s) return true;
+  return false;
+}
+void PDDL_Base::AtomBase::fill_in_args(AtomBase* b)
+{
+  b->param.set_length(0);
+  for (index_type k = 0; k < param.length(); k++)
+    if (param[k]->sym_class == sym_variable)
+      if (((VariableSymbol*)param[k])->value != 0)
+ b->param.append(((VariableSymbol*)param[k])->value);
+      else
+ b->param.append(param[k]);
+    else
+      b->param.append(param[k]);
+}
+void PDDL_Base::AtomBase::collect_bound_variables(variable_vec& v)
+{
+  for (index_type k = 0; k < param.length(); k++)
+    if (param[k]->sym_class == sym_variable)
+      if (((VariableSymbol*)param[k])->binding != 0) {
+ v.append((VariableSymbol*)param[k]);
+ ((VariableSymbol*)param[k])->binding->collect_bound_variables(v);
+      }
+}
+bool PDDL_Base::Atom::check()
+{
+  if (pred->param.length() != param.length()) {
+    if (write_warnings || !best_effort) {
+      std::cerr << "warning: wrong number of arguments for ";
+      pred->print(std::cerr);
+      std::cerr << " in ";
+      print(std::cerr);
+      std::cerr << std::endl;
+      if (!best_effort) exit(1);
+    }
+    return false;
+  }
+  for (index_type k = 0; k < pred->param.length(); k++)
+    if (!pred->param[k]->equality_type_check(param[k])) {
+      if (write_warnings || !best_effort) {
+ std::cerr << "warning: argument " << k << " in ";
+ print(std::cerr);
+ std::cerr << " has wrong type for ";
+ pred->print(std::cerr);
+ std::cerr << std::endl;
+ if (!best_effort) exit(1);
+      }
+      return false;
+    }
+  return true;
+}
+PDDL_Base::Atom* PDDL_Base::Atom::instantiate_partially()
+{
+  Atom* a = new Atom(pred, at);
+  fill_in_args(a);
+  return a;
+}
+bool PDDL_Base::Atom::equals(Atom& a)
+{
+  if (pred != a.pred) return false;
+  return AtomBase::equals(a);
+}
+PDDL_Base::partial_value PDDL_Base::Atom::partial_eval
+(ptr_table* r, index_type p)
+{
+  if (!r) return p_false;
+  if (p == param.length()) {
+    if (r->val) return p_true;
+    else return p_false;
+  }
+  if (param[p]->sym_class == sym_variable) {
+    VariableSymbol* v = (VariableSymbol*)param[p];
+    if (v->value) {
+      ptr_table* n = r->find_next(v->value);
+      if (n) return partial_eval(n, p+1);
+      else return p_false;
+    }
+    else {
+      bool poss_false = false;
+      bool poss_true = false;
+      for (index_type k = 0; k < v->sym_types.n_elements(); k++) {
+ ptr_table* n = r->find_next(v->sym_types.get_element(k));
+ if (n) {
+   partial_value nv = partial_eval(n, p+1);
+   if (nv == p_unknown) return p_unknown;
+   if (nv == p_false) {
+     poss_false = true;
+     if (poss_true) return p_unknown;
+   }
+   if (nv == p_true) {
+     poss_true = true;
+     if (poss_false) return p_unknown;
+   }
+ }
+ else {
+   poss_false = true;
+   if (poss_true) return p_unknown;
+ }
+      }
+      if (poss_true && !poss_false) return p_true;
+      else if (poss_false && !poss_true) return p_false;
+      else return p_unknown;
+    }
+  }
+  else {
+    ptr_table* n = r->find_next(param[p]);
+    if (n) return partial_eval(n, p+1);
+    else return p_false;
+  }
+  return p_false;
+}
+PDDL_Base::partial_value PDDL_Base::Atom::partial_eval()
+{
+  if (at == md_pos_goal) {
+    return partial_eval(&(pred->pos_goal), 0);
+  }
+  else if (at == md_neg_goal) {
+    return partial_eval(&(pred->neg_goal), 0);
+  }
+  else {
+    return partial_eval(&(pred->init), 0);
+  }
+}
+bool PDDL_Base::Atom::initial_value()
+{
+  ptr_table* r = &(pred->init);
+  for (index_type k = 0; (k < param.length()) && r; k++) {
+    if (param[k]->sym_class == sym_variable) {
+      if (((VariableSymbol*)param[k])->value == 0) {
+ std::cerr << "error: can't evaluate ";
+ print(std::cerr);
+ std::cerr << " in initial state because "
+    << param[k]->print_name << " not set"
+    << std::endl;
+ exit(255);
+      }
+      r = r->find_next(((VariableSymbol*)param[k])->value);
+    }
+    else {
+      r = r->find_next(param[k]);
+    }
+  }
+  if (r) {
+    if (r->val) return true;
+  }
+  return false;
+}
+Instance::Atom* PDDL_Base::Atom::find_prop
+(Instance& ins, bool neg, bool create)
+{
+  ptr_table* r = (neg ? &(pred->neg_prop) : &(pred->pos_prop));
+  for (index_type k = 0; k < param.length(); k++) {
+    if (param[k]->sym_class == sym_variable) {
+      if (((VariableSymbol*)param[k])->value == 0) {
+ std::cerr << "error: unbound variable "
+    << param[k]->print_name << " in ";
+ print(std::cerr);
+ std::cerr << " - uncompiled object function?"
+    << std::endl;
+ exit(255);
+      }
+      r = r->insert_next(((VariableSymbol*)param[k])->value);
+    }
+    else {
+      r = r->insert_next(param[k]);
+    }
+  }
+  if (!r->val) {
+    if (!create) return 0;
+    ptr_table* ri = &(pred->init);
+    PDDL_Name* a_name = new PDDL_Name(pred, neg);
+    for (index_type k = 0; k < param.length(); k++) {
+      if (param[k]->sym_class == sym_variable) {
+ assert(((VariableSymbol*)param[k])->value != 0);
+ a_name->add(((VariableSymbol*)param[k])->value);
+ if (ri) ri = ri->find_next(((VariableSymbol*)param[k])->value);
+      }
+      else {
+ a_name->add(param[k]);
+ if (ri) ri = ri->find_next(param[k]);
+      }
+    }
+    Instance::Atom& p = ins.new_atom(a_name);
+    bool init_val = false;
+    hsps::rational init_t = 0;
+    if (ri) {
+      if (ri->val) {
+ init_val = true;
+ init_t = ((Atom*)(ri->val))->at_time;
+      }
+    }
+    p.init = (init_val != neg);
+    p.init_t = init_t;
+    p.src = new ptr_pair(pred, r);
+    r->val = new Instance::atom_ref(ins.atoms, p.index);
+    Instance::Atom* not_p = find_prop(ins, !neg, false);
+    if (not_p) {
+      if (not_p->neg != no_such_index) {
+ std::cerr << "wierd error: negation of atom "
+    << not_p->index << "." << not_p->name << " is atom "
+    << not_p->neg << "." << ins.atoms[not_p->neg].name
+    << " and new atom " << p.index << "." << p.name
+    << std::endl;
+ exit(255);
+      }
+      p.neg = not_p->index;
+      not_p->neg = p.index;
+    }
+    for (index_type k = 0; k < pred->irr_ins.length(); k++)
+      if (pred->irr_ins[k]->included) {
+ if (pred->irr_ins[k]->context_is_static()) {
+   if (pred->irr_ins[k]->match(param)) {
+     if (write_info) {
+       std::cerr << "DKEL: atom " << a_name << " marked irrelevant by"
+   << std::endl;
+       pred->irr_ins[k]->print(std::cerr);
+     }
+     p.irrelevant = true;
+   }
+ }
+ else if (write_warnings || !best_effort) {
+   std::cerr << "warning: ignoring :irrelevant ";
+   pred->irr_ins[k]->entity->print(std::cerr);
+   std::cerr << " with non-static context" << std::endl;
+   if (!best_effort) exit(1);
+ }
+      }
+  }
+  Instance::atom_ref* a = (Instance::atom_ref*)r->val;
+  return *a;
+}
+bool PDDL_Base::FTerm::equals(FTerm& ft)
+{
+  if (fun != ft.fun) return false;
+  return AtomBase::equals(ft);
+}
+bool PDDL_Base::extend_substitution
+(Symbol* out, Symbol* in, symbol_pair_vec& u)
+{
+  for (index_type k = 0; k < u.length(); k++) if (u[k].first == out) {
+    if (u[k].second == in) {
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+  u.append(symbol_pair(out, in));
+  return true;
+}
+bool PDDL_Base::substitution_violates_inequality
+(const symbol_pair_vec& neq, const symbol_pair_vec& u)
+{
+  for (index_type k = 0; k < neq.length(); k++) {
+    Symbol* s1 = 0;
+    Symbol* s2 = 0;
+    for (index_type i = 0; i < u.length(); i++) {
+      if ((s1 == 0) && (u[i].first == neq[k].first)) s1 = u[i].second;
+      if ((s2 == 0) && (u[i].first == neq[k].second)) s2 = u[i].second;
+    }
+    if (s1 == 0) s1 = neq[k].first;
+    if (s2 == 0) s2 = neq[k].second;
+    if (s1 == s2) {
+      return true;
+    }
+  }
+  return false;
+}
+bool PDDL_Base::print_substitution
+(std::ostream& s, const symbol_pair_vec& u)
+{
+  s << "{";
+  for (index_type k = 0; k < u.length(); k++) {
+    if (k > 0) s << ", ";
+    s << u[k].first->print_name << "\\" << u[k].second->print_name;
+  }
+  s << "}";
+}
+bool PDDL_Base::print_inequality
+(std::ostream& s, const symbol_pair_vec& neq)
+{
+  s << "{";
+  for (index_type k = 0; k < neq.length(); k++) {
+    if (k > 0) s << ", ";
+    s << neq[k].first->print_name << " =/= " << neq[k].second->print_name;
+  }
+  s << "}";
+}
+bool PDDL_Base::Atom::instance_of(Atom* a, symbol_pair_vec& u)
+{
+  u.clear();
+  if (a->pred != pred) return false;
+  if (a->param.length() != param.length()) {
+    std::cerr << "error: atom ";
+    a->print(std::cerr);
+    std::cerr << " and atom schema ";
+    print(std::cerr);
+    std::cerr << " have same predicate and different number of arguments"
+       << std::endl;
+    return false;
+  }
+  for (index_type k = 0; k < param.length(); k++) if (param[k] != a->param[k]) {
+    if (param[k]->sym_class == sym_variable) {
+      if (a->param[k]->sym_class == sym_variable) {
+ if (param[k]->sym_types.subtype_or_equal(a->param[k]->sym_types)) {
+   if (!extend_substitution(a->param[k], param[k], u)) return false;
+ }
+ else {
+   return false;
+ }
+      }
+      else {
+ return false;
+      }
+    }
+    else {
+      if (a->param[k]->sym_class == sym_variable) {
+ if (((VariableSymbol*)a->param[k])->equality_type_check(param[k])) {
+   if (!extend_substitution(a->param[k], param[k], u)) return false;
+ }
+ else {
+   return false;
+ }
+      }
+      else {
+ if (a->param[k] != param[k]) return false;
+      }
+    }
+  }
+  return true;
+}
+bool PDDL_Base::Atom::instance_of
+(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u)
+{
+  if (!instance_of(a, u)) return false;
+  if (substitution_violates_inequality(neq, u)) return false;
+  return true;
+}
+bool PDDL_Base::Atom::unify
+(Atom* a, symbol_pair_vec& u)
+{
+  u.clear();
+  if (a->pred != pred) return false;
+  if (a->param.length() != param.length()) {
+    std::cerr << "error: atom ";
+    a->print(std::cerr);
+    std::cerr << " and atom ";
+    print(std::cerr);
+    std::cerr << " have same predicate but different #arguments"
+       << std::endl;
+    return false;
+  }
+  for (index_type k = 0; k < param.length(); k++) if (param[k] != a->param[k]) {
+    if (param[k]->sym_class == sym_variable) {
+      if (a->param[k]->sym_class == sym_variable) {
+ if (param[k]->sym_types.subtype_or_equal(a->param[k]->sym_types)) {
+   if (!extend_substitution(a->param[k], param[k], u)) return false;
+ }
+ else if (a->param[k]->sym_types.subtype_or_equal(param[k]->sym_types)) {
+   if (!extend_substitution(param[k], a->param[k], u)) return false;
+ }
+ else {
+   return false;
+ }
+      }
+      else {
+ if (((VariableSymbol*)param[k])->equality_type_check(a->param[k])) {
+   if (!extend_substitution(param[k], a->param[k], u)) return false;
+ }
+ else {
+   return false;
+ }
+      }
+    }
+    else {
+      if (a->param[k]->sym_class == sym_variable) {
+ if (((VariableSymbol*)a->param[k])->equality_type_check(param[k])) {
+   if (!extend_substitution(a->param[k], param[k], u)) return false;
+ }
+ else {
+   return false;
+ }
+      }
+      else {
+ if (a->param[k] != param[k]) return false;
+      }
+    }
+  }
+  return true;
+}
+bool PDDL_Base::Atom::unify
+(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u)
+{
+  if (!unify(a, u)) return false;
+  if (substitution_violates_inequality(neq, u)) return false;
+  return true;
+}
+bool PDDL_Base::CAtom::instance_of(Atom* a, symbol_pair_vec& u)
+{
+  return Atom::instance_of(a, u);
+}
+bool PDDL_Base::CAtom::instance_of(CAtom* a, symbol_pair_vec& u)
+{
+  return Atom::instance_of(a, a->neq, u);
+}
+bool PDDL_Base::CAtom::instance_of
+(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u)
+{
+  return Atom::instance_of(a, neq, u);
+}
+bool PDDL_Base::CAtom::unify(Atom* a, symbol_pair_vec& u)
+{
+  return Atom::unify(a, neq, u);
+}
+bool PDDL_Base::CAtom::unify(CAtom* a, symbol_pair_vec& u)
+{
+  if (!Atom::unify(a, u)) {
+    return false;
+  }
+  if (substitution_violates_inequality(a->neq, u)) {
+    return false;
+  }
+  if (substitution_violates_inequality(neq, u)) {
+    return false;
+  }
+  return true;
+}
+void PDDL_Base::CAtom::print(std::ostream& s)
+{
+  if (neq.length() > 0) {
+    s << "{";
+    Atom::print(s);
+    s << " |";
+    for (index_type k = 0; k < neq.length(); k++) {
+      s << " ";
+      neq[k].first->print(s);
+      s << " =/= ";
+      neq[k].second->print(s);
+    }
+    s << "}";
+  }
+  else {
+    Atom::print(s);
+  }
+}
+PDDL_Base::Formula* PDDL_Base::Formula::simplify()
+{
+  switch (fc) {
+  case fc_false:
+    {
+      return this;
+    }
+  case fc_true:
+    {
+      return this;
+    }
+  case fc_atom:
+    {
+      return this;
+    }
+  case fc_equality:
+    {
+      return this;
+    }
+  case fc_negation:
+    {
+      ((NFormula*)this)->f = ((NFormula*)this)->f->simplify();
+      if (((NFormula*)this)->f->fc == fc_true) {
+ return new Formula(fc_false);
+      }
+      else if (((NFormula*)this)->f->fc == fc_false) {
+ return new Formula(fc_true);
+      }
+      else if (((NFormula*)this)->f->fc == fc_negation) {
+ return ((NFormula*)((NFormula*)this)->f)->f;
+      }
+      else {
+ return this;
+      }
+    }
+  case fc_conjunction:
+    {
+      formula_vec sp(0, 0);
+      for (index_type k = 0; k < ((CFormula*)this)->parts.length(); k++)
+ sp.append(((CFormula*)this)->parts[k]->simplify());
+      ((CFormula*)this)->parts.assign_value(0, 0);
+      for (index_type k = 0; k < sp.length(); k++) {
+ if (sp[k]->fc == fc_false) {
+   return new Formula(fc_false);
+ }
+ else if (sp[k]->fc == fc_conjunction) {
+   for (index_type i = 0; i < ((CFormula*)sp[k])->parts.length(); i++)
+     sp.append(((CFormula*)sp[k])->parts[i]);
+ }
+ else if (sp[k]->fc != fc_true) {
+   ((CFormula*)this)->parts.append(sp[k]);
+ }
+      }
+      if (((CFormula*)this)->parts.length() == 0) {
+ return new Formula(fc_true);
+      }
+      else if (((CFormula*)this)->parts.length() == 1) {
+ return ((CFormula*)this)->parts[0];
+      }
+      else {
+ return this;
+      }
+    }
+  case fc_disjunction:
+    {
+      formula_vec sp(0, 0);
+      for (index_type k = 0; k < ((CFormula*)this)->parts.length(); k++)
+ sp.append(((CFormula*)this)->parts[k]->simplify());
+      ((CFormula*)this)->parts.assign_value(0, 0);
+      for (index_type k = 0; k < sp.length(); k++) {
+ if (sp[k]->fc == fc_true) {
+   return new Formula(fc_true);
+ }
+ else if (sp[k]->fc == fc_disjunction) {
+   for (index_type i = 0; i < ((CFormula*)sp[k])->parts.length(); i++)
+     sp.append(((CFormula*)sp[k])->parts[i]);
+ }
+ else if (sp[k]->fc != fc_false) {
+   ((CFormula*)this)->parts.append(sp[k]);
+ }
+      }
+      if (((CFormula*)this)->parts.length() == 0) {
+ return new Formula(fc_false);
+      }
+      else if (((CFormula*)this)->parts.length() == 1) {
+ return ((CFormula*)this)->parts[0];
+      }
+      else {
+ return this;
+      }
+    }
+  case fc_implication:
+    {
+      ((BFormula*)this)->f1 = ((BFormula*)this)->f1->simplify();
+      ((BFormula*)this)->f2 = ((BFormula*)this)->f2->simplify();
+      if (((BFormula*)this)->f1->fc == fc_true) {
+ return ((BFormula*)this)->f2;
+      }
+      else if (((BFormula*)this)->f1->fc == fc_false) {
+ return new Formula(fc_true);
+      }
+      else {
+ if (((BFormula*)this)->f2->fc == fc_true) {
+   return new Formula(fc_true);
+ }
+ else if (((BFormula*)this)->f2->fc == fc_false) {
+   if (((BFormula*)this)->f1->fc == fc_negation) {
+     return ((NFormula*)((BFormula*)this)->f1)->f;
+   }
+   else {
+     return new NFormula(((BFormula*)this)->f1);
+   }
+ }
+ else {
+   return this;
+ }
+      }
+    }
+  case fc_equivalence:
+    {
+      ((BFormula*)this)->f1 = ((BFormula*)this)->f1->simplify();
+      ((BFormula*)this)->f2 = ((BFormula*)this)->f2->simplify();
+      return this;
+    }
+  case fc_universal:
+    {
+      ((QFormula*)this)->f = ((QFormula*)this)->f->simplify();
+      return this;
+    }
+  case fc_existential:
+    {
+      ((QFormula*)this)->f = ((QFormula*)this)->f->simplify();
+      return this;
+    }
+  }
+  assert(0);
+}
+void PDDL_Base::Formula::rename_variables_1(symbol_pair_vec& sub)
+{
+  switch (fc) {
+  case fc_atom:
+    {
+      AFormula* f = (AFormula*)this;
+      for (index_type k = 0; k < f->param.length(); k++) {
+ bool found = false;
+ for (index_type i = 0; (i < sub.length()) && !found; i++)
+   if (f->param[k] == sub[i].first) {
+     f->param[k] = sub[i].second;
+     found = true;
+   }
+      }
+      return;
+    }
+  case fc_equality:
+    {
+      EqFormula* f = (EqFormula*)this;
+      bool found = false;
+      for (index_type i = 0; (i < sub.length()) && !found; i++)
+ if (f->t1 == sub[i].first) {
+   f->t1 = sub[i].second;
+   found = true;
+ }
+      found = false;
+      for (index_type i = 0; (i < sub.length()) && !found; i++)
+ if (f->t2 == sub[i].first) {
+   f->t2 = sub[i].second;
+   found = true;
+ }
+      return;
+    }
+  case fc_negation:
+    {
+      NFormula* f = (NFormula*)this;
+      f->f->rename_variables_1(sub);
+      return;
+    }
+  case fc_conjunction:
+  case fc_disjunction:
+    {
+      CFormula* f = (CFormula*)this;
+      for (index_type k = 0; k < f->parts.length(); k++) {
+ f->parts[k]->rename_variables_1(sub);
+      }
+      return;
+    }
+  case fc_implication:
+  case fc_equivalence:
+    {
+      BFormula* f = (BFormula*)this;
+      f->f1->rename_variables_1(sub);
+      f->f2->rename_variables_1(sub);
+      return;
+    }
+  case fc_universal:
+  case fc_existential:
+    {
+      QFormula* f = (QFormula*)this;
+      for (index_type k = 0; k < f->vars.length(); k++) {
+ bool found = false;
+ for (index_type i = 0; (i < sub.length()) && !found; i++)
+   if (f->vars[k] == sub[i].first) {
+     f->vars[k] = (VariableSymbol*)sub[i].second;
+     found = true;
+   }
+      }
+      f->f->rename_variables_1(sub);
+      return;
+    }
+  }
+  assert(0);
+}
+void PDDL_Base::Formula::rename_variables_2(symbol_pair_vec& sub)
+{
+  symbol_pair_vec rsub;
+  for (index_type i = 0; i < sub.length(); i++)
+    rsub.append(symbol_pair(sub[i].second, sub[i].first));
+  rename_variables_1(rsub);
+}
+void PDDL_Base::Formula::rename_predicates_1(symbol_pair_vec& sub)
+{
+  switch (fc) {
+  case fc_atom:
+    {
+      AFormula* f = (AFormula*)this;
+      for (index_type i = 0; i < sub.length(); i++)
+ if (f->pred == sub[i].first) {
+   f->pred = (PredicateSymbol*)sub[i].second;
+   return;
+ }
+      return;
+    }
+  case fc_negation:
+    {
+      NFormula* f = (NFormula*)this;
+      f->f->rename_predicates_1(sub);
+      return;
+    }
+  case fc_conjunction:
+  case fc_disjunction:
+    {
+      CFormula* f = (CFormula*)this;
+      for (index_type k = 0; k < f->parts.length(); k++) {
+ f->parts[k]->rename_predicates_1(sub);
+      }
+      return;
+    }
+  case fc_implication:
+  case fc_equivalence:
+    {
+      BFormula* f = (BFormula*)this;
+      f->f1->rename_predicates_1(sub);
+      f->f2->rename_predicates_1(sub);
+      return;
+    }
+  case fc_universal:
+  case fc_existential:
+    {
+      QFormula* f = (QFormula*)this;
+      f->f->rename_predicates_1(sub);
+      return;
+    }
+  }
+  assert(0);
+}
+void PDDL_Base::Formula::rename_predicates_2(symbol_pair_vec& sub)
+{
+  symbol_pair_vec rsub;
+  for (index_type i = 0; i < sub.length(); i++)
+    rsub.append(symbol_pair(sub[i].second, sub[i].first));
+  rename_predicates_1(rsub);
+}
+void PDDL_Base::Formula::print(std::ostream& s) const
+{
+  switch (fc) {
+  case fc_false:
+    {
+      s << "false";
+      return;
+    }
+  case fc_true:
+    {
+      s << "true";
+      return;
+    }
+  case fc_atom:
+    {
+      ((PDDL_Base::AFormula*)this)->print(s);
+      return;
+    }
+  case fc_equality:
+    {
+      s << "(= ";
+      ((EqFormula*)this)->t1->print(s);
+      s << " ";
+      ((EqFormula*)this)->t2->print(s);
+      s << ")";
+      return;
+    }
+  case fc_negation:
+    {
+      s << "(not ";
+      ((NFormula*)this)->f->print(s);
+      s << ")";
+      return;
+    }
+  case fc_conjunction:
+    {
+      s << "(and";
+      for (index_type k = 0; k < ((CFormula*)this)->parts.length(); k++) {
+ s << " ";
+ ((CFormula*)this)->parts[k]->print(s);
+      }
+      s << ")";
+      return;
+    }
+  case fc_disjunction:
+    {
+      s << "(or";
+      for (index_type k = 0; k < ((CFormula*)this)->parts.length(); k++) {
+ s << " ";
+ ((CFormula*)this)->parts[k]->print(s);
+      }
+      s << ")";
+      return;
+    }
+  case fc_implication:
+    {
+      s << "(imply ";
+      ((BFormula*)this)->f1->print(s);
+      s << " ";
+      ((BFormula*)this)->f2->print(s);
+      s << ")";
+      return;
+    }
+  case fc_equivalence:
+    {
+      s << "(iff ";
+      ((BFormula*)this)->f1->print(s);
+      s << " ";
+      ((BFormula*)this)->f2->print(s);
+      s << ")";
+      return;
+    }
+  case fc_universal:
+    {
+      s << "(forall (";
+      for (index_type k = 0; k < ((QFormula*)this)->vars.length(); k++) {
+ if (k > 0) s << " ";
+ ((QFormula*)this)->vars[k]->print(s);
+      }
+      s << ") ";
+      ((QFormula*)this)->f->print(s);
+      s << ")";
+      return;
+    }
+  case fc_existential:
+    {
+      s << "(exists (";
+      for (index_type k = 0; k < ((QFormula*)this)->vars.length(); k++) {
+ if (k > 0) s << " ";
+ ((QFormula*)this)->vars[k]->print(s);
+      }
+      s << ") ";
+      ((QFormula*)this)->f->print(s);
+      s << ")";
+      return;
+    }
+  }
+  assert(0);
+}
+void PDDL_Base::AFormula::print(std::ostream& s) const
+{
+  PDDL_Base::Atom::print(s, false);
+}
+void PDDL_Base::Formula::write_otter(std::ostream& s) const
+{
+  switch (fc) {
+  case fc_false:
+    {
+      s << "$F";
+      return;
+    }
+  case fc_true:
+    {
+      s << "$T";
+      return;
+    }
+  case fc_atom:
+    {
+      ((PDDL_Base::AFormula*)this)->write_otter(s);
+      return;
+    }
+  case fc_equality:
+    {
+      ((EqFormula*)this)->write_otter(s);
+      return;
+    }
+  case fc_negation:
+    {
+      s << "-(";
+      ((NFormula*)this)->f->write_otter(s);
+      s << ")";
+      return;
+    }
+  case fc_conjunction:
+  case fc_disjunction:
+    {
+      ((CFormula*)this)->write_otter(s);
+      return;
+    }
+  case fc_implication:
+    {
+      s << "->(";
+      ((BFormula*)this)->f1->write_otter(s);
+      s << ",";
+      ((BFormula*)this)->f2->write_otter(s);
+      s << ")";
+      return;
+    }
+  case fc_equivalence:
+    {
+      s << "<->(";
+      ((BFormula*)this)->f1->write_otter(s);
+      s << ",";
+      ((BFormula*)this)->f2->write_otter(s);
+      s << ")";
+      return;
+    }
+  case fc_universal:
+  case fc_existential:
+    {
+      ((QFormula*)this)->write_otter(s);
+      return;
+    }
+  }
+  assert(0);
+}
+void PDDL_Base::AFormula::write_otter(std::ostream& s) const
+{
+  s << pred->print_name << "(";
+  for (index_type k = 0; k < param.length(); k++) {
+    if (k > 0) s << ",";
+    if (param[k]->sym_class == sym_variable) {
+      s << (param[k]->print_name + 1);
+    }
+    else {
+      s << param[k]->print_name;
+    }
+  }
+  s << ")";
+}
+void PDDL_Base::EqFormula::write_otter(std::ostream& s) const
+{
+  s << "=(";
+  if (t1->sym_class == sym_variable) {
+    s << (t1->print_name + 1);
+  }
+  else {
+    s << t1->print_name;
+  }
+  s << ",";
+  if (t2->sym_class == sym_variable) {
+    s << (t2->print_name + 1);
+  }
+  else {
+    s << t2->print_name;
+  }
+  s << ")";
+}
+void PDDL_Base::CFormula::write_otter(std::ostream& s) const
+{
+  if (fc == fc_conjunction) s << "&(";
+  else if (fc == fc_disjunction) s << "|(";
+  else {
+    std::cerr << "error: invalide class " << fc
+       << " for composite formula"
+       << std::endl;
+    exit(255);
+  }
+  for (index_type k = 0; k < parts.length(); k++) {
+    if (k > 0) s << ",";
+    parts[k]->write_otter(s);
+  }
+  s << ")";
+}
+void PDDL_Base::QFormula::write_otter(std::ostream& s) const
+{
+  if (fc == fc_universal) s << "$Quantified(all";
+  else if (fc == fc_existential) s << "$Quantified(exists";
+  else {
+    std::cerr << "error: invalide class " << fc
+       << " for quantified formula"
+       << std::endl;
+    exit(255);
+  }
+  for (index_type k = 0; k < vars.length(); k++) {
+    s << "," << (vars[k]->print_name + 1);
+  }
+  s << ",";
+  f->write_otter(s);
+  s << ")";
+}
+PDDL_Base::FInitAtom::FInitAtom(FChangeAtom* a)
+  : AtomBase(a), fun(a->fun), val(0)
+{
+}
+bool PDDL_Base::FChangeAtom::equals(FChangeAtom& a)
+{
+  if (fun != a.fun) return false;
+  if (!AtomBase::equals(a)) return false;
+  return val->equals(a.val);
+}
+bool PDDL_Base::FChangeAtom::fluent_equals(FChangeAtom& a)
+{
+  if (fun != a.fun) return false;
+  if (!AtomBase::equals(a)) return false;
+  return true;
+}
+bool PDDL_Base::FChangeAtom::fluent_and_mode_equals(FChangeAtom& a)
+{
+  if (at != a.at) return false;
+  return fluent_equals(a);
+}
+PDDL_Base::FChangeAtom* PDDL_Base::FChangeAtom::find_fluent_equals
+(ch_atom_vec& vec)
+{
+  for (index_type k = 0; k < vec.length(); k++)
+    if (fluent_equals(*vec[k])) return vec[k];
+  return 0;
+}
+Instance::Resource* PDDL_Base::FChangeAtom::find_resource(Instance& ins)
+{
+  ptr_table* r = &(fun->init);
+  for (index_type k = 0; k < param.length(); k++) {
+    if (param[k]->sym_class == sym_variable) {
+      if (((VariableSymbol*)param[k])->value == 0) {
+ std::cerr << "error: unbound variable "
+    << param[k]->print_name << " in ";
+ print(std::cerr);
+ std::cerr << " - uncompiled object function?"
+    << std::endl;
+ exit(255);
+      }
+      r = r->insert_next(((VariableSymbol*)param[k])->value);
+    }
+    else {
+      r = r->insert_next(param[k]);
+    }
+  }
+  if (!r->val) {
+    r->val = new FInitAtom(this);
+  }
+  FInitAtom* a = (FInitAtom*)(r->val);
+  if (!a->res) {
+    PDDL_Name* fa_name = new PDDL_Name(fun, false);
+    for (index_type k = 0; k < param.length(); k++) {
+      if (param[k]->sym_class == sym_variable)
+ fa_name->add(((VariableSymbol*)param[k])->value);
+      else
+ fa_name->add(param[k]);
+    }
+    Instance::Resource& i = ins.new_resource(fa_name);
+    i.init = a->val;
+    i.src = new ptr_pair(fun, r);
+    a->res = Instance::resource_ref(ins.resources, i.index);
+  }
+  return (a->res);
+}
+void PDDL_Base::AtomBase::insert(ptr_table& t)
+{
+  ptr_table* r = &t;
+  for (index_type k = 0; k < param.length(); k++) {
+    assert(param[k] != 0);
+    r = r->insert_next(param[k]);
+  }
+  r->val = this;
+}
+index_type PDDL_Base::find_matching_atom(Atom* a, atom_vec& v)
+{
+  for (index_type i = 0; i < v.length(); i++)
+    if (a->equals(*v[i]))
+      return i;
+  return no_such_index;
+}
+index_type PDDL_Base::find_matching_atom(Atom* a, mode_keyword m, atom_vec& v)
+{
+  for (index_type i = 0; i < v.length(); i++)
+    if (a->equals(*v[i]) && (v[i]->at == m))
+      return i;
+  return no_such_index;
+}
+index_type PDDL_Base::find_matching_fluent_atom
+(FChangeAtom* a, mode_keyword m, ch_atom_vec& v)
+{
+  for (index_type i = 0; i < v.length(); i++)
+    if (a->equals(*v[i]) && (v[i]->at == m))
+      return i;
+  return no_such_index;
+}
+void PDDL_Base::ActionSymbol::post_process()
+{
+  if (write_trace) {
+    std::cerr << "post processing action " << print_name << "..." << std::endl;
+  }
+  for (index_type k = 0; k < pos_pre.length(); k++)
+    pos_pre[k]->pred->pos_pre = true;
+  for (index_type k = 0; k < neg_pre.length(); k++)
+    neg_pre[k]->pred->neg_pre = true;
+  for (index_type k = 0; k < set_eff.length(); k++)
+    if (!set_eff[k]->context_is_static()) {
+      cond_eff.append(set_eff[k]);
+      set_eff.remove(k);
+      k -= 1;
+    }
+  for (index_type k = 0; k < dels.length(); k++)
+    if (dels[k]->at == md_start) {
+      index_type add_i = find_matching_atom(dels[k], md_end, adds);
+      index_type pre_i = find_matching_atom(dels[k], md_start, pos_pre);
+      if ((add_i != no_such_index) && (pre_i != no_such_index)) {
+ locks.append(dels[k]);
+ locks[locks.length() - 1]->at = md_all;
+ dels.remove(k);
+ adds.remove(add_i);
+      }
+    }
+  for (index_type k = 0; k < adds.length(); k++)
+    if (adds[k]->at == md_start) {
+      index_type del_i = find_matching_atom(adds[k], md_end, dels);
+      if (del_i != no_such_index) {
+ enables.append(adds[k]);
+ enables[enables.length() - 1]->at = md_all;
+ adds.remove(k);
+ dels.remove(del_i);
+      }
+    }
+  cons.set_length(0);
+  for (index_type k = 0; k < dels.length(); k++) {
+    index_type pre_i = find_matching_atom(dels[k], pos_pre);
+    if (pre_i != no_such_index)
+      cons.append(dels[k]);
+  }
+  for (index_type k = 0; k < adds.length(); k++)
+    adds[k]->pred->added = true;
+  for (index_type k = 0; k < dels.length(); k++)
+    dels[k]->pred->deleted = true;
+  for (index_type k = 0; k < locks.length(); k++)
+    locks[k]->pred->locked = true;
+  if (compact_resource_effects) {
+    for (index_type k = 0; k < decs.length(); k++)
+      if (decs[k]->val->exp_class == exp_const) {
+ index_type i = k + 1;
+ while (i < decs.length()) {
+   if (decs[i]->fluent_and_mode_equals(*decs[k]) &&
+       (decs[i]->val->exp_class == exp_const)) {
+     if (write_info) {
+       std::cerr << "info: collapsing effects decrease ";
+       decs[k]->print(std::cerr);
+       std::cerr << " and decrease ";
+       decs[i]->print(std::cerr);
+       std::cerr << " in action " << print_name
+   << std::endl;
+     }
+     ((ConstantExpression*)decs[k]->val)->val +=
+       ((ConstantExpression*)decs[i]->val)->val;
+     decs.remove(i);
+   }
+   else {
+     if (write_trace) {
+       std::cerr << "debug: effects ";
+       decs[k]->print(std::cerr);
+       std::cerr << " and ";
+       decs[i]->print(std::cerr);
+       std::cerr << " in action " << print_name << " do not match"
+   << std::endl;
+     }
+     i += 1;
+   }
+ }
+ i = 0;
+ while (i < incs.length()) {
+   if (incs[i]->fluent_and_mode_equals(*decs[k]) &&
+       (incs[i]->val->exp_class == exp_const)) {
+     if (((ConstantExpression*)decs[k]->val)->val >
+  ((ConstantExpression*)incs[i]->val)->val) {
+       if (write_info) {
+  std::cerr << "info: collapsing effects decrease ";
+  decs[k]->print(std::cerr);
+  std::cerr << " and increase ";
+  incs[i]->print(std::cerr);
+  std::cerr << " in action " << print_name
+     << std::endl;
+       }
+       ((ConstantExpression*)decs[k]->val)->val -=
+  ((ConstantExpression*)incs[i]->val)->val;
+       decs.remove(i);
+     }
+     else {
+       if (write_trace) {
+  std::cerr << "debug: effects decrease ";
+  decs[k]->print(std::cerr);
+  std::cerr << " and increase ";
+  incs[i]->print(std::cerr);
+  std::cerr << " in action " << print_name
+     << " should not be collapsed to a decrease effect"
+     << std::endl;
+       }
+       i += 1;
+     }
+   }
+   else {
+     if (write_trace) {
+       std::cerr << "debug: effects ";
+       decs[k]->print(std::cerr);
+       std::cerr << " and ";
+       incs[i]->print(std::cerr);
+       std::cerr << " in action " << print_name << " do not match"
+   << std::endl;
+     }
+     i += 1;
+   }
+ }
+      }
+    for (index_type k = 0; k < incs.length(); k++)
+      if (incs[k]->val->exp_class == exp_const) {
+ index_type i = k + 1;
+ while (i < incs.length()) {
+   if (incs[i]->fluent_and_mode_equals(*incs[k]) &&
+       (incs[i]->val->exp_class == exp_const)) {
+     if (write_info) {
+       std::cerr << "info: collapsing effects increase ";
+       incs[k]->print(std::cerr);
+       std::cerr << " and increase ";
+       incs[i]->print(std::cerr);
+       std::cerr << " in action " << print_name
+   << std::endl;
+     }
+     ((ConstantExpression*)incs[k]->val)->val +=
+       ((ConstantExpression*)incs[i]->val)->val;
+     incs.remove(i);
+   }
+   else {
+     if (write_trace) {
+       std::cerr << "debug: effects ";
+       incs[k]->print(std::cerr);
+       std::cerr << " and ";
+       incs[i]->print(std::cerr);
+       std::cerr << " in action " << print_name << " do not match"
+   << std::endl;
+     }
+     i += 1;
+   }
+ }
+ i = 0;
+ while (i < decs.length()) {
+   if (decs[i]->fluent_and_mode_equals(*incs[k]) &&
+       (decs[i]->val->exp_class == exp_const)) {
+     if (((ConstantExpression*)incs[k]->val)->val >
+  ((ConstantExpression*)decs[i]->val)->val) {
+       if (write_info) {
+  std::cerr << "info: collapsing effects increase ";
+  incs[k]->print(std::cerr);
+  std::cerr << " and decrease ";
+  decs[i]->print(std::cerr);
+  std::cerr << " in action " << print_name
+     << std::endl;
+       }
+       ((ConstantExpression*)incs[k]->val)->val -=
+  ((ConstantExpression*)decs[i]->val)->val;
+       decs.remove(i);
+     }
+     else {
+       if (write_trace) {
+  std::cerr << "debug: effects increase ";
+  incs[k]->print(std::cerr);
+  std::cerr << " and decrease ";
+  decs[i]->print(std::cerr);
+  std::cerr << " in action " << print_name
+     << " should not be collapsed to an increase effect"
+     << std::endl;
+       }
+       i += 1;
+     }
+   }
+   else {
+     if (write_trace) {
+       std::cerr << "debug: effects ";
+       incs[k]->print(std::cerr);
+       std::cerr << " and ";
+       decs[i]->print(std::cerr);
+       std::cerr << " in action " << print_name << " do not match"
+   << std::endl;
+     }
+     i += 1;
+   }
+ }
+      }
+  }
+  for (index_type k = 0; k < decs.length(); k++)
+    if (decs[k]->at == md_start) {
+      index_type inc_i = find_matching_fluent_atom(decs[k], md_end, incs);
+      if (inc_i != no_such_index) {
+ if (use_strict_borrow_definition) {
+   bool check = false;
+   for (index_type i = 0; (i < num_pre.length()) && check; i++) {
+     Expression* f = num_pre[i]->match_gteq_constant(decs[k]);
+     if (f) {
+       if (f->eval_static() == 0) check = true;
+     }
+   }
+   if (!check) inc_i = no_such_index;
+ }
+ if (inc_i != no_such_index) {
+   decs[k]->at = md_all;
+   reqs.append(decs[k]);
+   decs.remove(k);
+   incs.remove(inc_i);
+   k -= 1;
+ }
+      }
+      else if (decs[k]->val->exp_class == exp_const) {
+ for (index_type i = 0;
+      ((i < incs.length()) && (inc_i == no_such_index)); i++)
+   if (decs[k]->fluent_equals(*incs[i]) &&
+       (incs[i]->at == md_end) &&
+       (incs[i]->val->exp_class == exp_const))
+     if (((ConstantExpression*)incs[i]->val)->val <
+  ((ConstantExpression*)decs[k]->val)->val) {
+       inc_i = i;
+     }
+ if (inc_i != no_such_index) {
+   if (use_strict_borrow_definition) {
+     bool check = false;
+     for (index_type i = 0; (i < num_pre.length()) && check; i++) {
+       Expression* f = num_pre[i]->match_gteq_constant(decs[k]);
+       if (f) {
+  if (f->eval_static() == 0) check = true;
+       }
+     }
+     if (!check) inc_i = no_such_index;
+   }
+   if (inc_i != no_such_index) {
+     hsps::rational c = (((ConstantExpression*)decs[k]->val)->val -
+         ((ConstantExpression*)incs[inc_i]->val)->val);
+     hsps::rational u = ((ConstantExpression*)incs[inc_i]->val)->val;
+     FChangeAtom* r_atom = new FChangeAtom(decs[k], u);
+     r_atom->at = md_all;
+     reqs.append(r_atom);
+     ((ConstantExpression*)decs[k]->val)->val = c;
+     incs.remove(inc_i);
+   }
+ }
+      }
+    }
+  if (use_extended_borrow_definition) {
+    for (index_type k = 0; k < incs.length(); k++)
+      if (incs[k]->at == md_start) {
+ index_type dec_i = find_matching_fluent_atom(incs[k], md_end, decs);
+ FunctionExpression* f = 0;
+ if (dec_i != no_such_index) {
+   for (index_type i = 0; (i < num_pre.length()) && (f == 0); i++)
+     f = num_pre[i]->match_lteq_fun(incs[k]);
+ }
+ if ((dec_i != no_such_index) && (f != 0)) {
+   FChangeAtom* r_atom = f->make_atom_base();
+   r_atom->at = md_all;
+   r_atom->val = incs[k]->val;
+   reqs.append(r_atom);
+   incs.remove(k);
+   decs.remove(dec_i);
+   k -= 1;
+ }
+      }
+  }
+  for (index_type k = 0; k < reqs.length(); k++) {
+    reqs[k]->fun->borrowed = true;
+    if (!reqs[k]->val->is_static())
+      reqs[k]->fun->linear = false;
+  }
+  for (index_type k = 0; k < incs.length(); k++) {
+    incs[k]->fun->increased = true;
+    if (!incs[k]->val->is_static())
+      incs[k]->fun->linear = false;
+  }
+  for (index_type k = 0; k < decs.length(); k++) {
+    decs[k]->fun->decreased = true;
+    if (!decs[k]->val->is_static())
+      decs[k]->fun->linear = false;
+  }
+  for (index_type k = 0; k < fass.length(); k++) {
+    fass[k]->fun->assigned = true;
+    fass[k]->fun->linear = false;
+  }
+}
+void PDDL_Base::post_process()
+{
+  if (compile_away_object_functions) {
+    compile_object_functions();
+  }
+  if (write_trace) {
+    std::cerr << "trace: post processing PDDL definition..." << std::endl;
+  }
+  dom_base_types.assign_value(0, 0);
+  for (index_type k = 0; k < dom_types.length(); k++) {
+    dom_types[k]->is_base_type = true;
+    for (index_type i = 0;
+  (i < dom_types.length()) && dom_types[k]->is_base_type; i++)
+      if (dom_types[i]->sym_types.contains(dom_types[k]))
+ dom_types[k]->is_base_type = false;
+    if (dom_types[k]->is_base_type)
+      dom_base_types.append(dom_types[k]);
+  }
+  for (index_type k = 0; k < dom_actions.length(); k++) {
+    dom_actions[k]->post_process();
+  }
+  ready_to_instantiate = true;
+}
+bool PDDL_Base::Goal::makeCPG(CPG& g)
+{
+  if ((g_class == goal_pos_atom) || (g_class == goal_neg_atom)) {
+    AtomicGoal* a = (AtomicGoal*)this;
+    g.atoms.append(a->atom);
+    if (g_class == goal_neg_atom)
+      g.neg.append(true);
+    else
+      g.neg.append(false);
+    g.atom_first_arg.append(g.args.length());
+    assert((g.atoms.length() == g.neg.length()) &&
+    (g.atoms.length() == g.atom_first_arg.length()));
+    assert(a->atom->param.length() == a->atom->pred->param.length());
+    for (index_type k = 0; k < a->atom->param.length(); k++) {
+      g.args.append(a->atom->param[k]);
+      assert(a->atom->param[k]->sym_types.length() == 1);
+      g.arg_types.append(a->atom->param[k]->sym_types[0]);
+    }
+    assert(g.args.length() == g.arg_types.length());
+    return true;
+  }
+  else if (g_class == goal_conjunction) {
+    ConjunctiveGoal* c = (ConjunctiveGoal*)this;
+    for (index_type i = 0; i < c->goals.length(); i++) {
+      if (!c->goals[i]->makeCPG(g)) return false;
+    }
+    return true;
+  }
+  std::cerr << "error: can't make CPG from goal ";
+  print(std::cerr);
+  std::cerr << std::endl;
+  return false;
+}
+bool PDDL_Base::Goal::makeCPG(CPG& g, index_vec& s)
+{
+  if ((g_class == goal_pos_atom) || (g_class == goal_neg_atom)) {
+    AtomicGoal* a = (AtomicGoal*)this;
+    index_type i = no_such_index;
+    for (index_type k = 0; (k < g.atoms.length()) && (i == no_such_index); k++)
+      if ((g.atoms[k]->equals(*(a->atom))) &&
+   (((g_class == goal_pos_atom) && !g.neg[k]) ||
+    ((g_class == goal_neg_atom) && g.neg[k])))
+ i = k;
+    if (i == no_such_index) {
+      g.atoms.append(a->atom);
+      if (g_class == goal_neg_atom)
+ g.neg.append(true);
+      else
+ g.neg.append(false);
+      g.atom_first_arg.append(g.args.length());
+      assert((g.atoms.length() == g.neg.length()) &&
+      (g.atoms.length() == g.atom_first_arg.length()));
+      assert(a->atom->param.length() == a->atom->pred->param.length());
+      for (index_type k = 0; k < a->atom->param.length(); k++) {
+ g.args.append(a->atom->param[k]);
+ assert(a->atom->param[k]->sym_types.length() == 1);
+ g.arg_types.append(a->atom->param[k]->sym_types[0]);
+      }
+      assert(g.args.length() == g.arg_types.length());
+      s.append(g.atoms.length() - 1);
+    }
+    else {
+      s.append(i);
+    }
+    return true;
+  }
+  else if (g_class == goal_conjunction) {
+    ConjunctiveGoal* c = (ConjunctiveGoal*)this;
+    for (index_type i = 0; i < c->goals.length(); i++) {
+      if (!c->goals[i]->makeCPG(g)) return false;
+    }
+    return true;
+  }
+  std::cerr << "error: can't make CPG from goal ";
+  print(std::cerr);
+  std::cerr << std::endl;
+  return false;
+}
+PDDL_Base::CPG::CPG(CPG& g, index_vec& s)
+  : atoms(0, 0), neg(false, 0), args(g.args), arg_types(g.arg_types)
+{
+  for (index_type k = 0; k < s.length(); k++) {
+    assert(s[k] < g.atoms.length());
+    atoms.append(g.atoms[s[k]]);
+    assert(s[k] < g.atom_first_arg.length());
+    atom_first_arg.append(g.atom_first_arg[s[k]]);
+    assert(s[k] < g.neg.length());
+    neg.append(g.neg[s[k]]);
+  }
+}
+void PDDL_Base::CPG::make_key(ptr_table::key_vec& key)
+{
+  key.clear();
+  for (index_type k = 0; k < atoms.length(); k++)
+    key.append(atoms[k]->pred);
+}
+void PDDL_Base::CPG::make_typed_key(ptr_table::key_vec& key)
+{
+  key.clear();
+  for (index_type k = 0; k < atoms.length(); k++)
+    key.append(atoms[k]->pred);
+  for (index_type k = 0; k < args.length(); k++) {
+    assert(args[k]->sym_types.length() == 1);
+    key.append(args[k]->sym_types[0]);
+  }
+}
+void PDDL_Base::CPG::make_parameters(variable_vec& param)
+{
+  param.set_length(args.length());
+  for (index_type k = 0; k < args.length(); k++) {
+    EnumName v_name("?arg", k);
+    VariableSymbol* v = new VariableSymbol(v_name.to_cstring());
+    v->sym_types.assign_value(arg_types[k]);
+    param[k] = v;
+  }
+}
+PDDL_Base::ListExpression* PDDL_Base::CPG::make_argument_list
+(index_type first)
+{
+  if (first < args.length()) {
+    return new ListExpression(args[first], make_argument_list(first + 1));
+  }
+  else {
+    return 0;
+  }
+}
+bool PDDL_Base::CPG::initial_value()
+{
+  for (index_type k = 0; k < atoms.length(); k++) {
+    bool atom_init_val = atoms[k]->initial_value();
+    if (atom_init_val == neg[k]) return false;
+  }
+  return true;
+}
+void PDDL_Base::CPG::add_effect_conditions
+(Context* e, ParamSymbol* pf, bool_vec& sat, symbol_vec& subs,
+ symbol_pair_vec& eq, symbol_pair_vec& neq)
+{
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type p = pf->param.first((VariableSymbol*)eq[k].first);
+    assert(p != no_such_index);
+    Atom* eq_atom = new Atom(PDDL_Base::current_eq_predicate);
+    if (subs[p]) {
+      eq_atom->param.append(subs[p]);
+    }
+    else {
+      eq_atom->param.append(eq[k].first);
+    }
+    eq_atom->param.append(eq[k].second);
+    e->pos_con.append(eq_atom);
+  }
+  for (index_type k = 0; k < neq.length(); k++) {
+    index_type p = pf->param.first((VariableSymbol*)neq[k].first);
+    assert(p != no_such_index);
+    Atom* neq_atom = new Atom(PDDL_Base::current_eq_predicate);
+    if (subs[p]) {
+      neq_atom->param.append(subs[p]);
+    }
+    else {
+      neq_atom->param.append(neq[k].first);
+    }
+    neq_atom->param.append(neq[k].second);
+    e->neg_con.append(neq_atom);
+  }
+  for (index_type k = 0; k < atoms.length(); k++) if (!sat[k]) {
+    PredicateSymbol* pred = atoms[k]->pred;
+    Atom* atom = new Atom(pred);
+    atom->param.set_length(pred->param.length());
+    for (index_type i = 0; i < pred->param.length(); i++) {
+      if (subs[atom_first_arg[k] + i]) {
+ atom->param[i] = subs[atom_first_arg[k] + i];
+      }
+      else {
+ atom->param[i] = pf->param[atom_first_arg[k] + i];
+      }
+    }
+    if (neg[k]) {
+      e->neg_con.append(atom);
+    }
+    else {
+      e->pos_con.append(atom);
+    }
+  }
+}
+void PDDL_Base::CPG::add_asserting_effects
+(ActionSymbol* act, PredicateSymbol* p, bool p_val, PredicateSymbol* g,
+ FunctionSymbol* f, Expression* f_val, bool strict)
+{
+  bool_vec sat(false, atoms.length());
+  symbol_pair_vec eq;
+  symbol_pair_vec neq;
+  add_asserting_effects(0, act, 0, sat, p, p_val, g, f, f_val,
+   eq, neq, strict);
+}
+void PDDL_Base::CPG::add_asserting_effects
+(index_type c_atom, ActionSymbol* act, index_type c_eff, bool_vec& sat,
+ PredicateSymbol* p, bool p_val, PredicateSymbol* g,
+ FunctionSymbol* f, Expression* f_val,
+ symbol_pair_vec& eq, symbol_pair_vec& neq, bool strict)
+{
+  assert((p == 0) || (f == 0));
+  ParamSymbol* pf = (p ? (ParamSymbol*)p : (ParamSymbol*)f);
+  assert(pf != 0);
+  if (c_atom < atoms.length()) {
+    if (c_eff < act->adds.length()) {
+      if (atoms[c_atom]->pred == act->adds[c_eff]->pred) {
+ if (neg[c_atom]) {
+   bool threat = true;
+   for (index_type k = 0; k < act->adds[c_eff]->param.length(); k++)
+     if (!pf->param[atom_first_arg[c_atom] + k]->
+  equality_type_check(act->adds[c_eff]->param[k]))
+       threat = false;
+   if (threat) {
+     for (index_type k = 0; k < act->adds[c_eff]->param.length(); k++) {
+       bool poss = true;
+       for (index_type i = 0; i < eq.length(); i++)
+  if ((eq[i].first == pf->param[atom_first_arg[c_atom] + k]) &&
+      (eq[i].second == act->adds[c_eff]->param[k]))
+    poss = false;
+       if (poss) {
+  neq.append(symbol_pair(pf->param[atom_first_arg[c_atom] + k],
+           act->adds[c_eff]->param[k]));
+  add_asserting_effects(c_atom, act, c_eff + 1, sat,
+          p, p_val, g, f, f_val, eq, neq, strict);
+  neq.dec_length();
+       }
+     }
+   }
+   else {
+     add_asserting_effects(c_atom, act, c_eff + 1, sat,
+      p, p_val, g, f, f_val, eq, neq, strict);
+   }
+ }
+ else {
+   if (!sat[c_atom]) {
+     bool poss = true;
+     for (index_type k = 0; (k < act->adds[c_eff]->param.length()) && poss; k++) {
+       for (index_type i = 0; (i < neq.length()) && poss; i++)
+  if ((neq[i].first == pf->param[atom_first_arg[c_atom] + k]) &&
+      (neq[i].second == act->adds[c_eff]->param[k]))
+    poss = false;
+       if (!pf->param[atom_first_arg[c_atom] + k]->
+    equality_type_check(act->adds[c_eff]->param[k]))
+  poss = false;
+     }
+     if (poss) {
+       for (index_type k = 0; k < act->adds[c_eff]->param.length(); k++)
+  eq.append(symbol_pair(pf->param[atom_first_arg[c_atom] + k],
+          act->adds[c_eff]->param[k]));
+       sat[c_atom] = true;
+       add_asserting_effects(c_atom, act, c_eff + 1, sat,
+        p, p_val, g, f, f_val, eq, neq, strict);
+       sat[c_atom] = false;
+       eq.dec_length(act->adds[c_eff]->param.length());
+     }
+   }
+   add_asserting_effects(c_atom, act, c_eff + 1, sat,
+    p, p_val, g, f, f_val, eq, neq, strict);
+ }
+      }
+      else {
+ add_asserting_effects(c_atom, act, c_eff + 1, sat,
+         p, p_val, g, f, f_val, eq, neq, strict);
+      }
+    }
+    else if (c_eff < (act->adds.length() + act->dels.length())) {
+      index_type d_eff = c_eff - act->adds.length();
+      if (atoms[c_atom]->pred == act->dels[d_eff]->pred) {
+ if (!neg[c_atom]) {
+   bool threat = true;
+   for (index_type k = 0; k < act->dels[d_eff]->param.length(); k++)
+     if (!pf->param[atom_first_arg[c_atom] + k]->
+  equality_type_check(act->dels[d_eff]->param[k]))
+       threat = false;
+   if (threat) {
+     for (index_type k = 0; k < act->dels[d_eff]->param.length(); k++) {
+       bool poss = true;
+       for (index_type i = 0; i < eq.length(); i++)
+  if ((eq[i].first == pf->param[atom_first_arg[c_atom] + k]) &&
+      (eq[i].second == act->dels[d_eff]->param[k]))
+    poss = false;
+       if (poss) {
+  neq.append(symbol_pair(pf->param[atom_first_arg[c_atom] + k],
+           act->dels[d_eff]->param[k]));
+  add_asserting_effects(c_atom, act, c_eff + 1, sat,
+          p, p_val, g, f, f_val, eq, neq, strict);
+  neq.dec_length();
+       }
+     }
+   }
+   else {
+     add_asserting_effects(c_atom, act, c_eff + 1, sat,
+      p, p_val, g, f, f_val, eq, neq, strict);
+   }
+ }
+ else {
+   if (!sat[c_atom]) {
+     bool poss = true;
+     for (index_type k = 0; (k < act->dels[d_eff]->param.length()) && poss; k++) {
+       for (index_type i = 0; (i < neq.length()) && poss; i++)
+  if ((neq[i].first == pf->param[atom_first_arg[c_atom] + k]) &&
+      (neq[i].second == act->dels[d_eff]->param[k]))
+    poss = false;
+       if (!pf->param[atom_first_arg[c_atom] + k]->
+    equality_type_check(act->adds[c_eff]->param[k]))
+  poss = false;
+     }
+     if (poss) {
+       for (index_type k = 0; k < act->dels[d_eff]->param.length(); k++)
+  eq.append(symbol_pair(pf->param[atom_first_arg[c_atom] + k],
+          act->dels[d_eff]->param[k]));
+       sat[c_atom] = true;
+       add_asserting_effects(c_atom, act, c_eff + 1, sat,
+        p, p_val, g, f, f_val, eq, neq, strict);
+       sat[c_atom] = false;
+       eq.dec_length(act->dels[d_eff]->param.length());
+     }
+   }
+   add_asserting_effects(c_atom, act, c_eff + 1, sat,
+    p, p_val, g, f, f_val, eq, neq, strict);
+ }
+      }
+      else {
+ add_asserting_effects(c_atom, act, c_eff + 1, sat,
+         p, p_val, g, f, f_val, eq, neq, strict);
+      }
+    }
+    else {
+      add_asserting_effects(c_atom + 1, act, 0, sat,
+       p, p_val, g, f, f_val, eq, neq, strict);
+    }
+  }
+  else {
+    index_type n_sat = sat.count(true);
+    if (n_sat > 0) {
+      symbol_vec subs(0, args.length());
+      index_type n_sub = 0;
+      symbol_pair_vec rem_eq;
+      for (index_type k = 0; k < eq.length(); k++) {
+ index_type i = pf->param.first((VariableSymbol*)eq[k].first);
+ assert(i != no_such_index);
+ assert(i < subs.length());
+ if (subs[i] == 0) {
+   subs[i] = eq[k].second;
+   n_sub += 1;
+ }
+ else {
+   rem_eq.append(eq[k]);
+ }
+      }
+      if (p) {
+ index_type i = sat.first(true);
+ bool done = false;
+ while (!done) {
+   SetOf* e = new SetOf();
+   Atom* a = new Atom(p);
+   a->param.set_length(args.length());
+   for (index_type k = 0; k < args.length(); k++) {
+     if (subs[k]) {
+       a->param[k] = subs[k];
+     }
+     else {
+       a->param[k] = p->param[k];
+       e->param.append(p->param[k]);
+     }
+   }
+   if (p_val)
+     e->neg_atoms.append(a);
+   else
+     e->pos_atoms.append(a);
+   add_effect_conditions(e, p, sat, subs, rem_eq, neq);
+   if (strict) {
+     PredicateSymbol* pred = atoms[i]->pred;
+     Atom* atom = new Atom(pred);
+     atom->param.set_length(pred->param.length());
+     for (index_type j = 0; j < pred->param.length(); j++) {
+       if (subs[atom_first_arg[i] + j]) {
+  atom->param[j] = subs[atom_first_arg[i] + j];
+       }
+       else {
+  atom->param[j] = p->param[atom_first_arg[i] + j];
+       }
+     }
+     if (neg[i]) {
+       e->pos_con.append(atom);
+     }
+     else {
+       e->neg_con.append(atom);
+     }
+   }
+   if (g) {
+     Atom* g_atom = new Atom(g);
+     g_atom->param.set_length(args.length());
+     for (index_type k = 0; k < args.length(); k++) {
+       if (subs[k]) {
+  g_atom->param[k] = subs[k];
+       }
+       else {
+  g_atom->param[k] = p->param[k];
+       }
+     }
+     e->pos_con.append(g_atom);
+   }
+   if (e->context_is_static()) {
+     act->set_eff.append(e);
+     if (write_info) {
+       std::cerr << "info: added set effect ";
+       e->print(std::cerr);
+       std::cerr << " to action " << act->print_name << std::endl;
+     }
+   }
+   else {
+     act->cond_eff.append(e);
+     if (write_info) {
+       std::cerr << "info: added conditional effect ";
+       e->print(std::cerr);
+       std::cerr << " to action " << act->print_name << std::endl;
+     }
+   }
+   if (strict) {
+     i = sat.next(true, i);
+     if (i == no_such_index) done = true;
+   }
+   else {
+     done = true;
+   }
+ }
+      }
+      if (f) {
+ FChangeAtom* a = new FChangeAtom(f);
+ QCNumericEffect* e = new QCNumericEffect(a);
+ a->param.set_length(args.length());
+ for (index_type k = 0; k < args.length(); k++) {
+   if (subs[k]) {
+     a->param[k] = subs[k];
+   }
+   else {
+     a->param[k] = f->param[k];
+     e->param.append(f->param[k]);
+   }
+ }
+ a->val = f_val->copy();
+ add_effect_conditions(e, p, sat, subs, rem_eq, neq);
+ act->qc_fass.append(e);
+ if (write_info) {
+   std::cerr << "info: added assignment ";
+   e->print(std::cerr);
+   std::cerr << " to action " << act->print_name << std::endl;
+ }
+      }
+    }
+  }
+}
+void PDDL_Base::CPG::add_propositional_effect
+(ActionSymbol* act, PredicateSymbol* p, bool p_val,
+ index_type c_atom, Atom* a_eff, bool strict)
+{
+  SetOf* e = new SetOf();
+  Atom* a = new Atom(p);
+  a->param.set_length(args.length());
+  for (index_type k = 0; k < atoms.length(); k++) {
+    if (k == c_atom) {
+      for (index_type i = 0; i < atoms[k]->param.length(); i++)
+ a->param[atom_first_arg[k] + i] = a_eff->param[i];
+    }
+    else {
+      for (index_type i = 0; i < atoms[k]->param.length(); i++) {
+ a->param[atom_first_arg[k] + i] =
+   p->param[atom_first_arg[k] + i];
+ e->param.append(p->param[atom_first_arg[k] + i]);
+      }
+    }
+  }
+  if (p_val)
+    e->neg_atoms.append(a);
+  else
+    e->pos_atoms.append(a);
+  if (strict) {
+    for (index_type k = 0; k < atoms.length(); k++) {
+      a = new Atom(atoms[k]->pred);
+      a->param.set_length(args.length());
+      if (k == c_atom) {
+ for (index_type i = 0; i < atoms[k]->param.length(); i++)
+   a->param[atom_first_arg[k] + i] = a_eff->param[i];
+      }
+      else {
+ for (index_type i = 0; i < atoms[k]->param.length(); i++) {
+   a->param[atom_first_arg[k] + i] = p->param[atom_first_arg[k] + i];
+ }
+      }
+      if (neg[k]) {
+ e->neg_con.append(a);
+      }
+      else {
+ e->pos_con.append(a);
+      }
+    }
+  }
+  if (!e->context_is_static()) {
+    act->cond_eff.append(e);
+    if (write_info) {
+      std::cerr << "info: added conditional effect ";
+      e->print(std::cerr);
+      std::cerr << " to action " << act->print_name << std::endl;
+    }
+  }
+  else {
+    act->set_eff.append(e);
+    if (write_info) {
+      std::cerr << "info: added set effect ";
+      e->print(std::cerr);
+      std::cerr << " to action " << act->print_name << std::endl;
+    }
+  }
+}
+void PDDL_Base::CPG::add_fluent_effect
+(ActionSymbol* act, FunctionSymbol* f, Expression* f_val,
+ index_type c_atom, Atom* a_eff)
+{
+  FChangeAtom* a = new FChangeAtom(f);
+  a->param.set_length(args.length());
+  QCNumericEffect* e = new QCNumericEffect(a);
+  for (index_type k = 0; k < atoms.length(); k++) {
+    if (k == c_atom) {
+      for (index_type i = 0; i < atoms[k]->param.length(); i++)
+ a->param[atom_first_arg[k] + i] = a_eff->param[i];
+    }
+    else {
+      for (index_type i = 0; i < atoms[k]->param.length(); i++) {
+ a->param[atom_first_arg[k] + i] =
+   f->param[atom_first_arg[k] + i];
+ e->param.append(f->param[atom_first_arg[k] + i]);
+      }
+    }
+  }
+  a->val = f_val->copy();
+  act->qc_fass.append(e);
+  if (write_info) {
+    std::cerr << "info: added assignment ";
+    e->print(std::cerr);
+    std::cerr << " to action " << act->print_name << std::endl;
+  }
+}
+void PDDL_Base::CPG::add_destroying_effects
+(ActionSymbol* act, ParamSymbol* pf,
+ PredicateSymbol* p, bool p_val, PredicateSymbol* g,
+ FunctionSymbol* f, Expression* f_val, bool strict)
+{
+  for (index_type c_atom = 0; c_atom < atoms.length(); c_atom++) {
+    if (neg[c_atom]) {
+      for (index_type c_eff = 0; c_eff < act->adds.length(); c_eff++)
+ if (atoms[c_atom]->pred == act->adds[c_eff]->pred) {
+   bool poss = true;
+   for (index_type k = 0; k < act->adds[c_eff]->param.length(); k++)
+     if (!pf->param[atom_first_arg[c_atom] + k]->
+  equality_type_check(act->adds[c_eff]->param[k]))
+       poss = false;
+   if (poss) {
+     if (p) {
+       add_propositional_effect(act, p, p_val, c_atom, act->adds[c_eff], strict);
+     }
+     if (f) {
+       assert(!strict);
+       add_fluent_effect(act, f, f_val, c_atom, act->adds[c_eff]);
+     }
+   }
+ }
+    }
+    else {
+      for (index_type c_eff = 0; c_eff < act->dels.length(); c_eff++)
+ if (atoms[c_atom]->pred == act->dels[c_eff]->pred) {
+   bool poss = true;
+   for (index_type k = 0; k < act->dels[c_eff]->param.length(); k++)
+     if (!pf->param[atom_first_arg[c_atom] + k]->
+  equality_type_check(act->dels[c_eff]->param[k]))
+       poss = false;
+   if (poss) {
+     if (p) {
+       add_propositional_effect(act, p, p_val, c_atom, act->dels[c_eff], strict);
+     }
+     if (f) {
+       assert(!strict);
+       add_fluent_effect(act, f, f_val, c_atom, act->dels[c_eff]);
+     }
+   }
+ }
+    }
+  }
+}
+PDDL_Base::Expression* PDDL_Base::replace_violations_1
+(Expression* exp, CPG* cpg[], FunctionSymbol* f_violated[])
+{
+  switch (exp->exp_class) {
+  case exp_fun:
+  case exp_list:
+  case exp_const:
+    return exp;
+  case exp_add:
+  case exp_sub:
+  case exp_mul:
+  case exp_div:
+    {
+      BinaryExpression* b_exp = (BinaryExpression*)exp;
+      Expression* first =
+ replace_violations_1(b_exp->first, cpg, f_violated);
+      Expression* second =
+ replace_violations_1(b_exp->second, cpg, f_violated);
+      return new BinaryExpression(exp->exp_class, first, second);
+    }
+  case exp_time:
+    return exp;
+  case exp_preference:
+    {
+      PreferenceExpression* p_exp = (PreferenceExpression*)exp;
+      index_type p = no_such_index;
+      for (index_type k = 0;
+    (k < dom_preferences.length()) && (p == no_such_index); k++)
+ if (dom_preferences[k]->name == p_exp->name) p = k;
+      if (p == no_such_index) {
+ std::cerr << "error: undefined preference in expression ";
+ p_exp->print(std::cerr, false);
+ std::cerr << std::endl;
+ exit(255);
+      }
+      if (cpg[p]) {
+ ListExpression* args = cpg[p]->make_argument_list(0);
+ FunctionExpression* f_exp =
+   new FunctionExpression(f_violated[p], args);
+ if (write_info) {
+   std::cerr << "info: replaced ";
+   p_exp->print(std::cerr, false);
+   std::cerr << " by ";
+   f_exp->print(std::cerr, false);
+   std::cerr << " in :metric" << std::endl;
+ }
+ return f_exp;
+      }
+      else {
+ return p_exp;
+      }
+    }
+  default:
+    std::cerr << "error: invalid expression class (" << exp->exp_class << ")"
+       << std::endl;
+    exit(255);
+  }
+}
+void PDDL_Base::compile_preferences()
+{
+  if (dom_preferences.length() == 0) return;
+  current_eq_predicate = dom_eq_pred;
+  CPG* cpg[dom_preferences.length()];
+  FunctionSymbol* f_violated[dom_preferences.length()];
+  ptr_table signatures;
+  ptr_table* signature[dom_preferences.length()];
+  bool_vec compilable(false, dom_preferences.length());
+  index_type n_compilable = 0;
+  index_type n_signatures = 0;
+  for (index_type p = 0; p < dom_preferences.length(); p++) {
+    CPG* g = new CPG();
+    if (dom_preferences[p]->goal->makeCPG(*g)) {
+      cpg[p] = g;
+      ptr_table::key_vec sig;
+      g->make_key(sig);
+      signature[p] = signatures.insert(sig);
+      compilable[p] = true;
+      n_compilable += 1;
+    }
+    else {
+      cpg[p] = 0;
+      signature[p] = 0;
+    }
+    f_violated[p] = 0;
+  }
+  if (write_info) {
+    std::cerr << "info: " << n_compilable << " compilable preferences found"
+       << std::endl;
+  }
+  if ((n_compilable < dom_preferences.length()) &&
+      (write_warnings || !best_effort)) {
+    std::cerr << "warning: " << (dom_preferences.length() - n_compilable)
+       << " preferences can not be compiled"
+       << std::endl;
+    if (!best_effort) exit(1);
+  }
+  if (n_compilable == 0) return;
+  for (index_type p = 0; p < dom_preferences.length(); p++) if (cpg[p]) {
+    if (write_info) {
+      std::cerr << "info: compiling ";
+      dom_preferences[p]->print(std::cerr);
+      std::cerr << std::endl;
+    }
+    if (f_violated[p] == 0) {
+      EnumName f_name("violated", n_signatures);
+      f_violated[p] = new FunctionSymbol(f_name.to_cstring());
+      index_type f_arity = cpg[p]->args.length();
+      type_vec f_types(cpg[p]->arg_types);
+      for (index_type q = p + 1; q < dom_preferences.length(); q++)
+ if (signature[q] == signature[p])
+   if (merge_type_vectors(f_types, cpg[q]->arg_types))
+     f_violated[q] = f_violated[p];
+      make_parameters(f_types, "?arg", f_violated[p]->param);
+      f_violated[p]->modified = true;
+      f_violated[p]->integral = true;
+      f_violated[p]->linear = false;
+      f_violated[p]->assigned = true;
+      dom_functions.append(f_violated[p]);
+      if (write_info) {
+ std::cerr << "info: created CPG function ";
+ f_violated[p]->print(std::cerr);
+      }
+      Expression* exp0 = new ConstantExpression(0);
+      Expression* exp1 = new ConstantExpression(1);
+      for (index_type a = 0; a < dom_actions.length(); a++) {
+ bool_vec sat(false, cpg[p]->atoms.length());
+ symbol_pair_vec eq;
+ symbol_pair_vec neq;
+ cpg[p]->add_asserting_effects(0, dom_actions[a], 0, sat,
+          0, false, 0, f_violated[p], exp0,
+          eq, neq, false);
+ cpg[p]->add_destroying_effects(dom_actions[a], f_violated[p],
+           0, false, 0, f_violated[p], exp1, false);
+      }
+      n_signatures += 1;
+    }
+    FInitAtom* f_init = new FInitAtom(f_violated[p]);
+    f_init->param = cpg[p]->args;
+    if (cpg[p]->initial_value()) {
+      f_init->val = 0;
+    }
+    else {
+      f_init->val = 1;
+    }
+    f_init->insert(f_violated[p]->init);
+    dom_fun_init.append(f_init);
+  }
+  else {
+    if (write_info) {
+      std::cerr << "info: ";
+      dom_preferences[p]->print(std::cerr);
+      std::cerr << " can not be compiled" << std::endl;
+    }
+  }
+  metric = replace_violations_1(metric, cpg, f_violated);
+  dom_preferences.remove(compilable);
+  if (write_info) {
+    std::cerr << "info: "
+       << n_compilable << " preferences compiled, "
+       << n_signatures << " CPG functions created, "
+       << dom_preferences.length() << " preferences remain"
+       << std::endl;
+  }
+}
+void PDDL_Base::add_precondition_formula
+(ActionSymbol* a, CPG* f, bool is_neg)
+{
+  assert(f);
+  if (is_neg) {
+    if (f->atoms.length() > 1) {
+      SetOf* d = new SetOf();
+      for (index_type k = 0; k < f->atoms.length(); k++) {
+ if (f->neg[k])
+   d->pos_atoms.append(new Atom(f->atoms[k]));
+ else
+   d->neg_atoms.append(new Atom(f->atoms[k]));
+      }
+      a->dis_pre.append(d);
+    }
+    else if (f->atoms.length() == 1) {
+      if (f->neg[0])
+ a->pos_pre.append(new Atom(f->atoms[0]));
+      else
+ a->neg_pre.append(new Atom(f->atoms[0]));
+    }
+  }
+  else {
+    for (index_type k = 0; k < f->atoms.length(); k++) {
+      if (f->neg[k])
+ a->neg_pre.append(new Atom(f->atoms[k]));
+      else
+ a->pos_pre.append(new Atom(f->atoms[k]));
+    }
+  }
+}
+void PDDL_Base::make_automaton_transition
+(Symbol* s_from, Symbol* s_to, bool is_accept,
+ CPG* f, bool neg_f, CPG* g, bool neg_g,
+ PredicateSymbol* p_state, PredicateSymbol* p_accept,
+ PredicateSymbol* p_synch)
+{
+  ActionSymbol* a_trans = (ActionSymbol*)gensym(sym_action, "trans", 0);
+  a_trans->pos_pre.append(new Atom(p_state, s_from));
+  a_trans->neg_pre.append(new Atom(p_synch));
+  if (f) {
+    add_precondition_formula(a_trans, f, neg_f);
+  }
+  if (g) {
+    add_precondition_formula(a_trans, g, neg_g);
+  }
+  if (s_to != s_from) {
+    a_trans->dels.append(new Atom(p_state, s_from));
+    a_trans->adds.append(new Atom(p_state, s_to));
+  }
+  if (is_accept)
+    a_trans->adds.append(new Atom(p_accept));
+  else
+    a_trans->dels.append(new Atom(p_accept));
+  a_trans->adds.append(new Atom(p_synch));
+  dom_actions.append(a_trans);
+}
+PDDL_Base::AtomicGoal* PDDL_Base::make_automaton_type_a
+(CPG& f, index_type i, const Symbol* n, symbol_vec& aut_state, index_type n_ra)
+{
+  assert(aut_state.length() >= 2);
+  assert(n_ra <= dom_actions.length());
+  PredicateSymbol* p_state = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "state-", n, 0) :
+     gensym_i(sym_predicate, "state-c", i, 0));
+  VariableSymbol* param0 =
+    (VariableSymbol*)gensym(sym_variable, "?s", aut_state[0]->sym_types);
+  p_state->param.append(param0);
+  p_state->pos_pre = true;
+  p_state->added = true;
+  p_state->deleted = true;
+  p_state->modded = true;
+  PredicateSymbol* p_accept = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "accepting-", n, 0) :
+     gensym_i(sym_predicate, "accepting-c", i, 0));
+  p_accept->pos_pre = true;
+  p_accept->added = true;
+  p_accept->deleted = true;
+  p_accept->modded = true;
+  PredicateSymbol* p_synch = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "updated-", n, 0) :
+     gensym_i(sym_predicate, "updated-c", i, 0));
+  p_synch->pos_pre = true;
+  p_synch->neg_pre = true;
+  p_synch->added = true;
+  p_synch->deleted = true;
+  p_synch->modded = true;
+  dom_predicates.append(p_state);
+  dom_predicates.append(p_accept);
+  dom_predicates.append(p_synch);
+  make_automaton_transition(aut_state[0], aut_state[1], true,
+       &f, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[0], aut_state[2], false,
+       0, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[1], true,
+       &f, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[2], false,
+       0, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[2], aut_state[2], false,
+       0, false, 0, false,
+       p_state, p_accept, p_synch);
+  for (index_type k = 0; k < n_ra; k++) {
+    dom_actions[k]->pos_pre.append(new Atom(p_synch));
+    dom_actions[k]->dels.append(new Atom(p_synch));
+  }
+  Atom* a_synch = new Atom(p_synch);
+  a_synch->insert(p_synch->pos_goal);
+  dom_goals.append(new AtomicGoal(a_synch, false));
+  Atom* a_init = new Atom(p_state);
+  a_init->param.append(aut_state[0]);
+  a_init->insert(p_state->init);
+  dom_init.append(a_init);
+  Atom* a_accept = new Atom(p_accept);
+  a_accept->insert(p_accept->pos_goal);
+  return new AtomicGoal(a_accept, false);
+}
+PDDL_Base::AtomicGoal* PDDL_Base::make_automaton_type_e
+(CPG& f, index_type i, const Symbol* n, symbol_vec& aut_state, index_type n_ra)
+{
+  assert(aut_state.length() >= 2);
+  assert(n_ra <= dom_actions.length());
+  PredicateSymbol* p_state = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "state-", n, 0) :
+     gensym_i(sym_predicate, "state-c", i, 0));
+  VariableSymbol* param0 =
+    (VariableSymbol*)gensym(sym_variable, "?s", aut_state[0]->sym_types);
+  p_state->param.append(param0);
+  p_state->pos_pre = true;
+  p_state->added = true;
+  p_state->deleted = true;
+  p_state->modded = true;
+  PredicateSymbol* p_accept = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "accepting-", n, 0) :
+     gensym_i(sym_predicate, "accepting-c", i, 0));
+  p_accept->pos_pre = true;
+  p_accept->added = true;
+  p_accept->deleted = true;
+  p_accept->modded = true;
+  PredicateSymbol* p_synch = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "updated-", n, 0) :
+     gensym_i(sym_predicate, "updated-c", i, 0));
+  p_synch->pos_pre = true;
+  p_synch->neg_pre = true;
+  p_synch->added = true;
+  p_synch->deleted = true;
+  p_synch->modded = true;
+  dom_predicates.append(p_state);
+  dom_predicates.append(p_accept);
+  dom_predicates.append(p_synch);
+  make_automaton_transition(aut_state[0], aut_state[1], false,
+       0, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[0], aut_state[2], true,
+       &f, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[1], false,
+       0, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[2], true,
+       &f, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[2], aut_state[3], true,
+       0, false, 0, false,
+       p_state, p_accept, p_synch);
+  for (index_type k = 0; k < n_ra; k++) {
+    dom_actions[k]->pos_pre.append(new Atom(p_synch));
+    dom_actions[k]->dels.append(new Atom(p_synch));
+  }
+  Atom* a_synch = new Atom(p_synch);
+  a_synch->insert(p_synch->pos_goal);
+  dom_goals.append(new AtomicGoal(a_synch, false));
+  Atom* a_init = new Atom(p_state);
+  a_init->param.append(aut_state[0]);
+  a_init->insert(p_state->init);
+  dom_init.append(a_init);
+  Atom* a_accept = new Atom(p_accept);
+  a_accept->insert(p_accept->pos_goal);
+  return new AtomicGoal(a_accept, false);
+}
+PDDL_Base::AtomicGoal* PDDL_Base::make_automaton_type_o
+(CPG& f, index_type i, const Symbol* n, symbol_vec& aut_state, index_type n_ra)
+{
+  assert(aut_state.length() >= 2);
+  assert(n_ra <= dom_actions.length());
+  PredicateSymbol* p_state = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "state-", n, 0) :
+     gensym_i(sym_predicate, "state-c", i, 0));
+  VariableSymbol* param0 =
+    (VariableSymbol*)gensym(sym_variable, "?s", aut_state[0]->sym_types);
+  p_state->param.append(param0);
+  p_state->pos_pre = true;
+  p_state->added = true;
+  p_state->deleted = true;
+  p_state->modded = true;
+  PredicateSymbol* p_accept = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "accepting-", n, 0) :
+     gensym_i(sym_predicate, "accepting-c", i, 0));
+  p_accept->pos_pre = true;
+  p_accept->added = true;
+  p_accept->deleted = true;
+  p_accept->modded = true;
+  PredicateSymbol* p_synch = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "updated-", n, 0) :
+     gensym_i(sym_predicate, "updated-c", i, 0));
+  p_synch->pos_pre = true;
+  p_synch->neg_pre = true;
+  p_synch->added = true;
+  p_synch->deleted = true;
+  p_synch->modded = true;
+  dom_predicates.append(p_state);
+  dom_predicates.append(p_accept);
+  dom_predicates.append(p_synch);
+  make_automaton_transition(aut_state[0], aut_state[1], true,
+       &f, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[0], aut_state[2], true,
+       &f, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[1], true,
+       &f, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[2], true,
+       &f, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[2], aut_state[2], true,
+       &f, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[2], aut_state[3], true,
+       &f, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[3], aut_state[3], true,
+       &f, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[3], aut_state[4], false,
+       0, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[4], aut_state[4], false,
+       0, false, 0, false,
+       p_state, p_accept, p_synch);
+  for (index_type k = 0; k < n_ra; k++) {
+    dom_actions[k]->pos_pre.append(new Atom(p_synch));
+    dom_actions[k]->dels.append(new Atom(p_synch));
+  }
+  Atom* a_synch = new Atom(p_synch);
+  a_synch->insert(p_synch->pos_goal);
+  dom_goals.append(new AtomicGoal(a_synch, false));
+  Atom* a_init = new Atom(p_state);
+  a_init->param.append(aut_state[0]);
+  a_init->insert(p_state->init);
+  dom_init.append(a_init);
+  Atom* a_accept = new Atom(p_accept);
+  a_accept->insert(p_accept->pos_goal);
+  return new AtomicGoal(a_accept, false);
+}
+PDDL_Base::AtomicGoal* PDDL_Base::make_automaton_type_sb
+(CPG& f, CPG& g, index_type i, const Symbol* n, symbol_vec& aut_state,
+ index_type n_ra)
+{
+  assert(aut_state.length() >= 2);
+  assert(n_ra <= dom_actions.length());
+  PredicateSymbol* p_state = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "state-", n, 0) :
+     gensym_i(sym_predicate, "state-c", i, 0));
+  VariableSymbol* param0 =
+    (VariableSymbol*)gensym(sym_variable, "?s", aut_state[0]->sym_types);
+  p_state->param.append(param0);
+  p_state->pos_pre = true;
+  p_state->added = true;
+  p_state->deleted = true;
+  p_state->modded = true;
+  PredicateSymbol* p_accept = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "accepting-", n, 0) :
+     gensym_i(sym_predicate, "accepting-c", i, 0));
+  p_accept->pos_pre = true;
+  p_accept->added = true;
+  p_accept->deleted = true;
+  p_accept->modded = true;
+  PredicateSymbol* p_synch = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "updated-", n, 0) :
+     gensym_i(sym_predicate, "updated-c", i, 0));
+  p_synch->pos_pre = true;
+  p_synch->neg_pre = true;
+  p_synch->added = true;
+  p_synch->deleted = true;
+  p_synch->modded = true;
+  dom_predicates.append(p_state);
+  dom_predicates.append(p_accept);
+  dom_predicates.append(p_synch);
+  make_automaton_transition(aut_state[0], aut_state[1], true,
+       &f, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[0], aut_state[2], true,
+       &f, true, &g, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[0], aut_state[4], false,
+       0, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[1], true,
+       &f, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[2], true,
+       &f, true, &g, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[4], false,
+       0, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[2], aut_state[3], true,
+       0, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[3], aut_state[3], true,
+       0, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[4], aut_state[4], false,
+       0, true, 0, false,
+       p_state, p_accept, p_synch);
+  for (index_type k = 0; k < n_ra; k++) {
+    dom_actions[k]->pos_pre.append(new Atom(p_synch));
+    dom_actions[k]->dels.append(new Atom(p_synch));
+  }
+  Atom* a_synch = new Atom(p_synch);
+  a_synch->insert(p_synch->pos_goal);
+  dom_goals.append(new AtomicGoal(a_synch, false));
+  Atom* a_init = new Atom(p_state);
+  a_init->param.append(aut_state[0]);
+  a_init->insert(p_state->init);
+  dom_init.append(a_init);
+  Atom* a_accept = new Atom(p_accept);
+  a_accept->insert(p_accept->pos_goal);
+  return new AtomicGoal(a_accept, false);
+}
+PDDL_Base::AtomicGoal* PDDL_Base::make_automaton_type_sa
+(CPG& f, CPG& g, index_type i, const Symbol* n, symbol_vec& aut_state,
+ index_type n_ra)
+{
+  assert(aut_state.length() >= 2);
+  assert(n_ra <= dom_actions.length());
+  PredicateSymbol* p_state = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "state-", n, 0) :
+     gensym_i(sym_predicate, "state-c", i, 0));
+  VariableSymbol* param0 =
+    (VariableSymbol*)gensym(sym_variable, "?s", aut_state[0]->sym_types);
+  p_state->param.append(param0);
+  p_state->pos_pre = true;
+  p_state->added = true;
+  p_state->deleted = true;
+  p_state->modded = true;
+  PredicateSymbol* p_accept = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "accepting-", n, 0) :
+     gensym_i(sym_predicate, "accepting-c", i, 0));
+  p_accept->pos_pre = true;
+  p_accept->added = true;
+  p_accept->deleted = true;
+  p_accept->modded = true;
+  PredicateSymbol* p_synch = (PredicateSymbol*)
+    (n ? gensym_s(sym_predicate, "updated-", n, 0) :
+     gensym_i(sym_predicate, "updated-c", i, 0));
+  p_synch->pos_pre = true;
+  p_synch->neg_pre = true;
+  p_synch->added = true;
+  p_synch->deleted = true;
+  p_synch->modded = true;
+  dom_predicates.append(p_state);
+  dom_predicates.append(p_accept);
+  dom_predicates.append(p_synch);
+  make_automaton_transition(aut_state[0], aut_state[1], true,
+       0, false, &g, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[0], aut_state[2], false,
+       &f, false, &g, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[0], aut_state[3], true,
+       &f, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[1], true,
+       0, false, &g, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[2], false,
+       0, false, &g, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[1], aut_state[3], true,
+       &f, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[2], aut_state[1], true,
+       0, false, &g, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[2], aut_state[4], false,
+       0, false, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[3], aut_state[1], true,
+       0, false, &g, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[3], aut_state[2], false,
+       0, false, &g, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[3], aut_state[3], true,
+       &f, true, 0, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[4], aut_state[1], true,
+       0, false, &g, false,
+       p_state, p_accept, p_synch);
+  make_automaton_transition(aut_state[2], aut_state[4], false,
+       0, false, 0, false,
+       p_state, p_accept, p_synch);
+  for (index_type k = 0; k < n_ra; k++) {
+    dom_actions[k]->pos_pre.append(new Atom(p_synch));
+    dom_actions[k]->dels.append(new Atom(p_synch));
+  }
+  Atom* a_synch = new Atom(p_synch);
+  a_synch->insert(p_synch->pos_goal);
+  dom_goals.append(new AtomicGoal(a_synch, false));
+  Atom* a_init = new Atom(p_state);
+  a_init->param.append(aut_state[0]);
+  a_init->insert(p_state->init);
+  dom_init.append(a_init);
+  Atom* a_accept = new Atom(p_accept);
+  a_accept->insert(p_accept->pos_goal);
+  return new AtomicGoal(a_accept, false);
+}
+PDDL_Base::Goal* PDDL_Base::compile_constraint_1
+(PDDL_Base::Goal* g, index_type i, const Symbol* n,
+ symbol_vec& aut_states, index_type n_ra)
+{
+  if (g->g_class == goal_always) {
+    SimpleSequenceGoal* g1 = (SimpleSequenceGoal*)g;
+    CPG f;
+    bool ok = g1->constraint->makeCPG(f);
+    if (!ok) {
+      if (write_warnings || !best_effort) {
+ std::cerr << "warning: can't compile goal ";
+ g->print(std::cerr);
+ std::cerr << std::endl;
+ if (!best_effort) exit(1);
+      }
+      return g;
+    }
+    return make_automaton_type_a(f, i, n, aut_states, n_ra);
+  }
+  else if (g->g_class == goal_sometime) {
+    SimpleSequenceGoal* g1 = (SimpleSequenceGoal*)g;
+    CPG f;
+    bool ok = g1->constraint->makeCPG(f);
+    if (!ok) {
+      if (write_warnings || !best_effort) {
+ std::cerr << "warning: can't compile goal ";
+ g->print(std::cerr);
+ std::cerr << std::endl;
+ if (!best_effort) exit(1);
+      }
+      return g;
+    }
+    return make_automaton_type_e(f, i, n, aut_states, n_ra);
+  }
+  else if (g->g_class == goal_at_most_once) {
+    SimpleSequenceGoal* g1 = (SimpleSequenceGoal*)g;
+    CPG f;
+    bool ok = g1->constraint->makeCPG(f);
+    if (!ok) {
+      if (write_warnings || !best_effort) {
+ std::cerr << "warning: can't compile goal ";
+ g->print(std::cerr);
+ std::cerr << std::endl;
+ if (!best_effort) exit(1);
+      }
+      return g;
+    }
+    return make_automaton_type_o(f, i, n, aut_states, n_ra);
+  }
+  else if (g->g_class == goal_sometime_before) {
+    TriggeredSequenceGoal* g1 = (TriggeredSequenceGoal*)g;
+    CPG f1;
+    bool ok = g1->trigger->makeCPG(f1);
+    CPG f2;
+    ok = (ok && g1->constraint->makeCPG(f2));
+    if (!ok) {
+      if (write_warnings || !best_effort) {
+ std::cerr << "warning: can't compile goal ";
+ g->print(std::cerr);
+ std::cerr << std::endl;
+ if (!best_effort) exit(1);
+      }
+      return g;
+    }
+    return make_automaton_type_sb(f1, f2, i, n, aut_states, n_ra);
+  }
+  else if (g->g_class == goal_sometime_after) {
+    TriggeredSequenceGoal* g1 = (TriggeredSequenceGoal*)g;
+    CPG f1;
+    bool ok = g1->trigger->makeCPG(f1);
+    CPG f2;
+    ok = (ok && g1->constraint->makeCPG(f2));
+    if (!ok) {
+      if (write_warnings || !best_effort) {
+ std::cerr << "warning: can't compile goal ";
+ g->print(std::cerr);
+ std::cerr << std::endl;
+ if (!best_effort) exit(1);
+      }
+      return g;
+    }
+    return make_automaton_type_sa(f1, f2, i, n, aut_states, n_ra);
+  }
+  else if (!g->is_state()) {
+    if (write_warnings || !best_effort) {
+      std::cerr << "warning: can't compile goal ";
+      g->print(std::cerr);
+      std::cerr << std::endl;
+      if (!best_effort) exit(1);
+    }
+  }
+  return g;
+}
+void PDDL_Base::compile_constraints_1()
+{
+  index_type n_regular_actions = dom_actions.length();
+  symbol_vec aut_states;
+  aut_states.append(gensym(sym_object, "aut-state-s0", 0));
+  aut_states.append(gensym(sym_object, "aut-state-s1", 0));
+  aut_states.append(gensym(sym_object, "aut-state-s2", 0));
+  aut_states.append(gensym(sym_object, "aut-state-s3", 0));
+  aut_states.append(gensym(sym_object, "aut-state-s4", 0));
+  index_type n_goals = dom_goals.length();
+  for (index_type k = 0; k < n_goals; k++) {
+    dom_goals[k] =
+      compile_constraint_1(dom_goals[k], k, 0, aut_states, n_regular_actions);
+  }
+  for (index_type k = 0; k < dom_preferences.length(); k++) {
+    dom_preferences[k]->goal =
+      compile_constraint_1(dom_preferences[k]->goal,
+      dom_goals.length() + k,
+      dom_preferences[k]->name,
+      aut_states, n_regular_actions);
+  }
+  dom_constants.append(aut_states);
+  for (index_type k = 0; k < dom_constants.length(); k++)
+    dom_constants[k]->defined_in_problem = false;
+}
+PDDL_Base::Goal* PDDL_Base::compile_always_constraint
+(SimpleSequenceGoal* g, const Symbol* n)
+{
+  current_eq_predicate = dom_eq_pred;
+  if (write_info) {
+    std::cerr << "info: compiling constraint ";
+    g->print(std::cerr);
+    std::cerr << std::endl;
+  }
+  CPG f;
+  if (!g->constraint->makeCPG(f)) {
+    if (write_warnings || !best_effort) {
+      std::cerr << "warning: can't compile goal ";
+      g->print(std::cerr);
+      std::cerr << std::endl;
+      if (!best_effort) exit(1);
+    }
+    return g;
+  }
+  PredicateSymbol* p_ok =
+    (PredicateSymbol*)gensym_s(sym_predicate, "ok-", n, 0);
+  make_parameters(f.arg_types, "?arg", p_ok->param);
+  p_ok->pos_pre = true;
+  dom_predicates.append(p_ok);
+  if (write_info) {
+    std::cerr << "info: created predicate ";
+    p_ok->print(std::cerr);
+    std::cerr << std::endl;
+  }
+  Atom* a_ok = new Atom(p_ok);
+  a_ok->param = f.args;
+  a_ok->insert(p_ok->pos_goal);
+  if (f.initial_value()) {
+    Atom* a_init = new Atom(p_ok);
+    a_init->param = f.args;
+    a_init->insert(p_ok->init);
+    dom_init.append(a_init);
+    p_ok->deleted = true;
+    p_ok->modded = true;
+    for (index_type k = 0; k < dom_actions.length(); k++) {
+      f.add_destroying_effects(dom_actions[k], p_ok, p_ok, false, 0, 0, 0, false);
+    }
+  }
+  return new AtomicGoal(a_ok, false);
+}
+PDDL_Base::Goal* PDDL_Base::compile_sometime_constraint
+(SimpleSequenceGoal* g, const Symbol* n)
+{
+  current_eq_predicate = dom_eq_pred;
+  if (write_info) {
+    std::cerr << "info: compiling constraint ";
+    g->print(std::cerr);
+    std::cerr << std::endl;
+  }
+  CPG f;
+  if (!g->constraint->makeCPG(f)) {
+    if (write_warnings || !best_effort) {
+      std::cerr << "warning: can't compile goal ";
+      g->print(std::cerr);
+      std::cerr << std::endl;
+      if (!best_effort) exit(1);
+    }
+    return g;
+  }
+  PredicateSymbol* p_ok =
+    (PredicateSymbol*)gensym_s(sym_predicate, "ok-", n, 0);
+  make_parameters(f.arg_types, "?arg", p_ok->param);
+  p_ok->pos_pre = true;
+  dom_predicates.append(p_ok);
+  if (write_info) {
+    std::cerr << "info: created predicate ";
+    p_ok->print(std::cerr);
+    std::cerr << std::endl;
+  }
+  Atom* a_ok = new Atom(p_ok);
+  a_ok->param = f.args;
+  a_ok->insert(p_ok->pos_goal);
+  if (f.initial_value()) {
+    Atom* a_init = new Atom(p_ok);
+    a_init->param = f.args;
+    a_init->insert(p_ok->init);
+    dom_init.append(a_init);
+  }
+  else {
+    p_ok->added = true;
+    p_ok->modded = true;
+    for (index_type k = 0; k < dom_actions.length(); k++) {
+      f.add_asserting_effects(dom_actions[k], p_ok, true, 0, 0, 0, false);
+    }
+  }
+  return new AtomicGoal(a_ok, false);
+}
+PDDL_Base::Goal* PDDL_Base::compile_at_most_once_constraint
+(SimpleSequenceGoal* g, const Symbol* n)
+{
+  current_eq_predicate = dom_eq_pred;
+  if (write_info) {
+    std::cerr << "info: compiling constraint ";
+    g->print(std::cerr);
+    std::cerr << std::endl;
+  }
+  CPG f;
+  if (!g->constraint->makeCPG(f)) {
+    if (write_warnings || !best_effort) {
+      std::cerr << "warning: can't compile goal ";
+      g->print(std::cerr);
+      std::cerr << std::endl;
+      if (!best_effort) exit(1);
+    }
+    return g;
+  }
+  PredicateSymbol* p_once =
+    (PredicateSymbol*)gensym_s(sym_predicate, "once-", n, 0);
+  make_parameters(f.arg_types, "?arg", p_once->param);
+  p_once->pos_pre = true;
+  p_once->added = true;
+  p_once->modded = true;
+  dom_predicates.append(p_once);
+  PredicateSymbol* p_ok =
+    (PredicateSymbol*)gensym_s(sym_predicate, "ok-", n, 0);
+  make_parameters(f.arg_types, "?arg", p_ok->param);
+  p_ok->pos_pre = true;
+  p_ok->deleted = true;
+  p_ok->modded = true;
+  dom_predicates.append(p_ok);
+  if (write_info) {
+    std::cerr << "info: created predicates ";
+    p_once->print(std::cerr);
+    std::cerr << " and ";
+    p_ok->print(std::cerr);
+    std::cerr << std::endl;
+  }
+  Atom* a_ok = new Atom(p_ok);
+  a_ok->param = f.args;
+  a_ok->insert(p_ok->pos_goal);
+  Atom* a_init = new Atom(p_ok);
+  a_init->param = f.args;
+  a_init->insert(p_ok->init);
+  dom_init.append(a_init);
+  for (index_type k = 0; k < dom_actions.length(); k++) {
+    f.add_destroying_effects(dom_actions[k], p_once, p_once, true, 0, 0, 0, true);
+  }
+  for (index_type k = 0; k < dom_actions.length(); k++) {
+    bool_vec sat(false, f.atoms.length());
+    symbol_pair_vec eq;
+    symbol_pair_vec neq;
+    f.add_asserting_effects(dom_actions[k], p_ok, false, p_once, 0, 0, true);
+  }
+  return new AtomicGoal(a_ok, false);
+}
+PDDL_Base::Goal* PDDL_Base::compile_sometime_before_constraint
+(TriggeredSequenceGoal* g, const Symbol* n)
+{
+  current_eq_predicate = dom_eq_pred;
+  if (write_info) {
+    std::cerr << "info: compiling constraint ";
+    g->print(std::cerr);
+    std::cerr << std::endl;
+  }
+  CPG m;
+  index_vec s1;
+  bool ok = g->trigger->makeCPG(m, s1);
+  index_vec s2;
+  ok = (ok && g->constraint->makeCPG(m, s2));
+  if (!ok) {
+    if (write_warnings || !best_effort) {
+      std::cerr << "warning: can't compile goal ";
+      g->print(std::cerr);
+      std::cerr << std::endl;
+      if (!best_effort) exit(1);
+    }
+    return g;
+  }
+  CPG f_tr(m, s1);
+  CPG f_c(m, s2);
+  PredicateSymbol* p_not_safe =
+    (PredicateSymbol*)gensym_s(sym_predicate, "not-safe-", n, 0);
+  make_parameters(f_c.arg_types, "?arg", p_not_safe->param);
+  p_not_safe->pos_pre = true;
+  p_not_safe->deleted = true;
+  p_not_safe->modded = true;
+  dom_predicates.append(p_not_safe);
+  PredicateSymbol* p_ok =
+    (PredicateSymbol*)gensym_s(sym_predicate, "ok-", n, 0);
+  make_parameters(f_tr.arg_types, "?arg", p_ok->param);
+  p_ok->pos_pre = true;
+  p_ok->deleted = true;
+  p_ok->modded = true;
+  dom_predicates.append(p_ok);
+  if (write_info) {
+    std::cerr << "info: created predicates ";
+    p_not_safe->print(std::cerr);
+    std::cerr << " and ";
+    p_ok->print(std::cerr);
+    std::cerr << std::endl;
+  }
+  Atom* a_ok = new Atom(p_ok);
+  a_ok->param = f_tr.args;
+  a_ok->insert(p_ok->pos_goal);
+  if (!f_tr.initial_value()) {
+    Atom* a_init = new Atom(p_ok);
+    a_init->param = f_tr.args;
+    a_init->insert(p_ok->init);
+    dom_init.append(a_init);
+  }
+  if (!f_c.initial_value()) {
+    Atom* a_init = new Atom(p_not_safe);
+    a_init->param = f_c.args;
+    a_init->insert(p_not_safe->init);
+    dom_init.append(a_init);
+  }
+  for (index_type k = 0; k < dom_actions.length(); k++) {
+    bool_vec sat(false, f_c.atoms.length());
+    symbol_pair_vec eq;
+    symbol_pair_vec neq;
+    f_c.add_asserting_effects(dom_actions[k], p_not_safe, false, 0, 0, 0, false);
+  }
+  for (index_type k = 0; k < dom_actions.length(); k++) {
+    bool_vec sat(false, f_c.atoms.length());
+    symbol_pair_vec eq;
+    symbol_pair_vec neq;
+    f_tr.add_asserting_effects(dom_actions[k], p_ok, false, p_not_safe, 0, 0, false);
+  }
+  return new AtomicGoal(a_ok, false);
+}
+PDDL_Base::Goal* PDDL_Base::compile_constraint_2
+(PDDL_Base::Goal* g, const Symbol* n)
+{
+  if (g->g_class == goal_always) {
+    return compile_always_constraint((SimpleSequenceGoal*)g, n);
+  }
+  else if (g->g_class == goal_sometime) {
+    return compile_sometime_constraint((SimpleSequenceGoal*)g, n);
+  }
+  else if (g->g_class == goal_at_most_once) {
+    return compile_at_most_once_constraint((SimpleSequenceGoal*)g, n);
+  }
+  else if (g->g_class == goal_sometime_before) {
+    return compile_sometime_before_constraint((TriggeredSequenceGoal*)g, n);
+  }
+  else if (g->g_class == goal_sometime_after) {
+    if (write_warnings || !best_effort) {
+      std::cerr << "warning: compilation of goal ";
+      g->print(std::cerr);
+      std::cerr << " not implemented" << std::endl;
+      if (!best_effort) exit(1);
+    }
+    return g;
+  }
+  else if (!g->is_state()) {
+    if (write_warnings || !best_effort) {
+      std::cerr << "warning: can't compile goal ";
+      g->print(std::cerr);
+      std::cerr << std::endl;
+      if (!best_effort) exit(1);
+    }
+  }
+  return g;
+}
+void PDDL_Base::compile_constraints_2()
+{
+  for (index_type k = 0; k < dom_goals.length(); k++) {
+    Symbol* c_name = gensym_i(sym_misc, "c", k, 0);
+    dom_goals[k] = compile_constraint_2(dom_goals[k], c_name);
+  }
+  for (index_type k = 0; k < dom_preferences.length(); k++) {
+    Symbol* c_name = (dom_preferences[k]->name ?
+        dom_preferences[k]->name :
+        gensym_i(sym_misc, "p", k, 0));
+    dom_preferences[k]->goal =
+      compile_constraint_2(dom_preferences[k]->goal, c_name);
+  }
+}
+void PDDL_Base::metric_to_goal(hsps::rational bound)
+{
+  if ((metric_type == metric_minimize) ||
+      (metric_type == metric_maximize)) {
+    Relation* r = new Relation((metric_type == metric_minimize ?
+    rel_less : rel_greater),
+          metric,
+          new ConstantExpression(bound));
+    dom_goals.append(new NumericGoal(r));
+    metric_type = metric_none;
+    metric = 0;
+  }
+  else if (write_warnings || !best_effort) {
+    std::cerr << "warning: metric type " << metric_type
+       << " can not be converted to bounded goal"
+       << std::endl;
+    if (!best_effort) exit(1);
+  }
+}
+void PDDL_Base::select_preferences(const bool_vec& sel)
+{
+  for (index_type k = 0; k < dom_preferences.length(); k++) {
+    if (sel[k]) {
+      dom_goals.append(dom_preferences[k]->goal);
+    }
+    if (dom_preferences[k]->name && metric) {
+      Expression* e = new ConstantExpression(sel[k] ? 0 : 1);
+      metric = metric->substitute_for_preference(dom_preferences[k]->name, e);
+    }
+  }
+  dom_preferences.assign_value(0, 0);
+}
+void PDDL_Base::compile_set_conditions_and_effects
+(ActionSymbol* act, variable_vec& i_param, variable_vec& d_param, index_type p)
+{
+  if (p < d_param.length()) {
+    for (index_type k = 0; k < d_param[p]->sym_types.n_elements(); k++) {
+      d_param[p]->value = d_param[p]->sym_types.get_element(k);
+      bool pass = true;
+      for (index_type k = 0; (k < act->pos_pre.length()) && pass; k++)
+ if (act->pos_pre[k]->is_static()) {
+   partial_value v = act->pos_pre[k]->partial_eval();
+   if (v == p_false) pass = false;
+ }
+      for (index_type k = 0; (k < act->neg_pre.length()) && pass; k++)
+ if (act->neg_pre[k]->is_static()) {
+   partial_value v = act->neg_pre[k]->partial_eval();
+   if (v == p_true) pass = false;
+ }
+      for (index_type k = 0; (k < act->num_pre.length()) && pass; k++) {
+ partial_value v = act->num_pre[k]->partial_eval();
+ if (v == p_false) pass = false;
+      }
+      if (pass)
+ compile_set_conditions_and_effects(act, i_param, d_param, p + 1);
+    }
+    d_param[p]->value = 0;
+  }
+  else {
+    if (d_param.length() == 0) {
+      for (index_type k = 0; k < act->pos_pre.length(); k++)
+ if (act->pos_pre[k]->is_static()) {
+   partial_value v = act->pos_pre[k]->partial_eval();
+   if (v == p_false) return;
+ }
+      for (index_type k = 0; k < act->neg_pre.length(); k++)
+ if (act->neg_pre[k]->is_static()) {
+   partial_value v = act->neg_pre[k]->partial_eval();
+   if (v == p_true) return;
+ }
+    }
+    ActionSymbol* new_act =
+      (ActionSymbol*)gensym(sym_action, act->print_name, 0);
+    new_act->param = i_param;
+    for (index_type k = 0; k < act->pos_pre.length(); k++)
+      new_act->pos_pre.append(act->pos_pre[k]->instantiate_partially());
+    for (index_type k = 0; k < act->neg_pre.length(); k++)
+      new_act->neg_pre.append(act->neg_pre[k]->instantiate_partially());
+    for (index_type k = 0; k < act->dis_pre.length(); k++)
+      new_act->dis_pre.append(act->dis_pre[k]->instantiate_partially());
+    for (index_type k = 0; k < act->set_pre.length(); k++) {
+      if (act->set_pre[k]->context_is_static()) {
+ act->set_pre[k]->compile(new_act->pos_pre, new_act->neg_pre, 0);
+      }
+      else {
+ act->set_pre[k]->compile_non_static(new_act->dis_pre, 0);
+      }
+    }
+    for (index_type k = 0; k < act->adds.length(); k++)
+      new_act->adds.append(act->adds[k]->instantiate_partially());
+    for (index_type k = 0; k < act->dels.length(); k++)
+      new_act->dels.append(act->dels[k]->instantiate_partially());
+    for (index_type k = 0; k < act->set_eff.length(); k++) {
+      assert(act->set_eff[k]->context_is_static());
+      act->set_pre[k]->compile(new_act->pos_pre, new_act->neg_pre, 0);
+    }
+    for (index_type k = 0; k < act->cond_eff.length(); k++)
+      new_act->cond_eff.append(act->cond_eff[k]->instantiate_partially());
+    for (index_type k = 0; k < act->locks.length(); k++)
+      new_act->locks.append(act->locks[k]->instantiate_partially());
+    for (index_type k = 0; k < act->enables.length(); k++)
+      new_act->enables.append(act->enables[k]->instantiate_partially());
+    new_act->dmin = act->dmin;
+    new_act->dmax = act->dmax;
+    for (index_type k = 0; k < act->irr_ins.length(); k++)
+      new_act->irr_ins.append(act->irr_ins[k]->instantiate_partially());
+    for (index_type k = 0; k < act->refs.length(); k++)
+      new_act->refs.append(act->refs[k]->instantiate_partially());
+    if (act->part)
+      new_act->part = act->part->instantiate_partially();
+    new_act->assoc = act->assoc;
+    new_act->post_process();
+    dom_actions.append(new_act);
+  }
+}
+void PDDL_Base::compile_set_conditions_and_effects(ActionSymbol* act)
+{
+  variable_vec dp(0, 0);
+  variable_vec ip(0, 0);
+  for (index_type k = 0; k < act->param.length(); k++) {
+    bool found = false;
+    for (index_type i = 0; (i < act->set_pre.length()) && !found; i++)
+      if (act->set_pre[i]->occurs_in_context(act->param[k])) {
+ dp.append(act->param[k]);
+ found = true;
+      }
+    for (index_type i = 0; (i < act->set_eff.length()) && !found; i++)
+      if (act->set_eff[i]->occurs_in_context(act->param[k])) {
+ dp.append(act->param[k]);
+ found = true;
+      }
+    if (!found)
+      ip.append(act->param[k]);
+  }
+  act->clear_arguments();
+  compile_set_conditions_and_effects(act, ip, dp, 0);
+}
+void PDDL_Base::compile_set_conditions_and_effects()
+{
+  lvector<ActionSymbol*> acts(dom_actions);
+  dom_actions.clear();
+  for (index_type k = 0; k < acts.length(); k++) {
+    if ((acts[k]->set_pre.length() > 0) ||
+ (acts[k]->set_eff.length() > 0))
+      compile_set_conditions_and_effects(acts[k]);
+    else
+      dom_actions.append(acts[k]);
+  }
+}
+PDDL_Base::Atom* PDDL_Base::make_binding_atom(VariableSymbol* v)
+{
+  FTerm* bt = v->binding;
+  assert(bt != 0);
+  hsps::StringTable::Cell* c =
+    (hsps::StringTable::Cell*)tab.find(bt->fun->print_name);
+  assert(c != 0);
+  PredicateSymbol* p = (PredicateSymbol*)c->val;
+  assert(p->sym_class == sym_predicate);
+  assert(p->param.length() == (bt->fun->param.length() + 1));
+  assert(bt->param.length() == bt->fun->param.length());
+  Atom* a = new Atom(p);
+  for (index_type i = 0; i < bt->param.length(); i++)
+    a->param.append(bt->param[i]);
+  a->param.append(v);
+  return a;
+}
+void PDDL_Base::compile_object_functions
+(ActionSymbol* act, Symbol* undefined_value)
+{
+  variable_vec pre_omsk_vars(0, 0);
+  for (index_type k = 0; k < act->pos_pre.length(); k++)
+    act->pos_pre[k]->collect_bound_variables(pre_omsk_vars);
+  for (index_type k = 0; k < act->neg_pre.length(); k++)
+    act->neg_pre[k]->collect_bound_variables(pre_omsk_vars);
+  for (index_type k = 0; k < act->adds.length(); k++) {
+    if (act->adds[k]->pred == dom_assign_pred) {
+      assert(act->adds[k]->param[0]->sym_class == sym_variable);
+      assert(((VariableSymbol*)(act->adds[k]->param[0]))->binding != 0);
+      ((VariableSymbol*)(act->adds[k]->param[0]))->binding->collect_bound_variables(pre_omsk_vars);
+      if (act->adds[k]->param[1]->sym_class == sym_variable) {
+ if (((VariableSymbol*)(act->adds[k]->param[1]))->binding != 0) {
+   pre_omsk_vars.append((VariableSymbol*)act->adds[k]->param[1]);
+   ((VariableSymbol*)(act->adds[k]->param[1]))->binding->collect_bound_variables(pre_omsk_vars);
+ }
+      }
+    }
+    else {
+      act->adds[k]->collect_bound_variables(pre_omsk_vars);
+    }
+  }
+  for (index_type k = 0; k < act->dels.length(); k++)
+    act->dels[k]->collect_bound_variables(pre_omsk_vars);
+  for (index_type k = 0; k < pre_omsk_vars.length(); k++) {
+    act->pos_pre.append(make_binding_atom(pre_omsk_vars[k]));
+  }
+  index_set assigns;
+  index_type n_adds = act->adds.length();
+  for (index_type k = 0; k < n_adds; k++)
+    if (act->adds[k]->pred == dom_assign_pred) {
+      assigns.insert(k);
+      assert(act->adds[k]->param[0]->sym_class == sym_variable);
+      assert(((VariableSymbol*)(act->adds[k]->param[0]))->binding != 0);
+      FTerm* bt = ((VariableSymbol*)(act->adds[k]->param[0]))->binding;
+      hsps::StringTable::Cell* c =
+ (hsps::StringTable::Cell*)tab.find(bt->fun->print_name);
+      assert(c != 0);
+      PredicateSymbol* p = (PredicateSymbol*)c->val;
+      assert(p->sym_class == sym_predicate);
+      assert(p->param.length() == (bt->fun->param.length() + 1));
+      assert(bt->param.length() == bt->fun->param.length());
+      VariableSymbol* m = 0;
+      for (index_type i = 0; (i < pre_omsk_vars.length()) && (m == 0); i++)
+ if (pre_omsk_vars[i]->binding->equals(*bt))
+   m = pre_omsk_vars[i];
+      if (m != 0) {
+ Atom* a_out = new Atom(p);
+ for (index_type i = 0; i < bt->param.length(); i++)
+   a_out->param.append(bt->param[i]);
+ a_out->param.append(m);
+ act->dels.append(a_out);
+      }
+      else {
+ VariableSymbol* v_pre =
+   (VariableSymbol*)gensym(sym_variable, "?fval",
+      p->param[p->param.length() - 1]->sym_types);
+ v_pre->visible = false;
+ Atom* a_pre = new Atom(p);
+ for (index_type i = 0; i < bt->param.length(); i++)
+   a_pre->param.append(bt->param[i]);
+ a_pre->param.append(v_pre);
+ act->param.append(v_pre);
+ act->pos_pre.append(a_pre);
+ act->dels.append(a_pre);
+      }
+      Atom* a_in = new Atom(p);
+      for (index_type i = 0; i < bt->param.length(); i++)
+ a_in->param.append(bt->param[i]);
+      if (act->adds[k]->param[1] == dom_undefined_obj)
+ a_in->param.append(undefined_value);
+      else
+ a_in->param.append(act->adds[k]->param[1]);
+      act->adds.append(a_in);
+    }
+  act->adds.remove(assigns);
+  for (index_type k = 0; k < pre_omsk_vars.length(); k++) {
+    act->param.append(pre_omsk_vars[k]);
+    pre_omsk_vars[k]->visible = false;
+    pre_omsk_vars[k]->binding = 0;
+  }
+}
+void PDDL_Base::compile_object_functions_for_validator(ActionSymbol* act)
+{
+  index_set rm_pos_pre;
+  for (index_type k = 0; k < act->pos_pre.length(); k++) {
+    variable_vec pre_omsk_vars(0, 0);
+    act->pos_pre[k]->collect_bound_variables(pre_omsk_vars);
+    if (pre_omsk_vars.length() > 0) {
+      SetOf* q = new SetOf();
+      for (index_type i = 0; i < pre_omsk_vars.length(); i++) {
+ q->param.append(pre_omsk_vars[i]);
+ q->pos_con.append(make_binding_atom(pre_omsk_vars[i]));
+ pre_omsk_vars[i]->binding = 0;
+      }
+      q->pos_atoms.append(act->pos_pre[k]);
+      act->dis_pre.append(q);
+      rm_pos_pre.insert(k);
+    }
+  }
+  act->pos_pre.remove(rm_pos_pre);
+  index_set rm_neg_pre;
+  for (index_type k = 0; k < act->neg_pre.length(); k++) {
+    variable_vec pre_omsk_vars(0, 0);
+    act->neg_pre[k]->collect_bound_variables(pre_omsk_vars);
+    if (pre_omsk_vars.length() > 0) {
+      SetOf* q = new SetOf();
+      for (index_type i = 0; i < pre_omsk_vars.length(); i++) {
+ q->param.append(pre_omsk_vars[i]);
+ q->pos_con.append(make_binding_atom(pre_omsk_vars[i]));
+ pre_omsk_vars[i]->binding = 0;
+      }
+      q->neg_atoms.append(act->neg_pre[k]);
+      act->dis_pre.append(q);
+      rm_neg_pre.insert(k);
+    }
+  }
+  act->neg_pre.remove(rm_neg_pre);
+  index_set rm_adds;
+  for (index_type k = 0; k < act->adds.length(); k++) {
+    if (act->adds[k]->pred == dom_assign_pred) {
+      variable_vec omsk_vars(0, 0);
+      assert(act->adds[k]->param[0]->sym_class == sym_variable);
+      assert(((VariableSymbol*)(act->adds[k]->param[0]))->binding != 0);
+      ((VariableSymbol*)(act->adds[k]->param[0]))->binding->collect_bound_variables(omsk_vars);
+      if (act->adds[k]->param[1]->sym_class == sym_variable) {
+ if (((VariableSymbol*)(act->adds[k]->param[1]))->binding != 0) {
+   omsk_vars.append((VariableSymbol*)act->adds[k]->param[1]);
+   ((VariableSymbol*)(act->adds[k]->param[1]))->binding->collect_bound_variables(omsk_vars);
+ }
+      }
+      FTerm* bt = ((VariableSymbol*)(act->adds[k]->param[0]))->binding;
+      hsps::StringTable::Cell* c =
+ (hsps::StringTable::Cell*)tab.find(bt->fun->print_name);
+      assert(c != 0);
+      PredicateSymbol* p = (PredicateSymbol*)c->val;
+      assert(p->sym_class == sym_predicate);
+      assert(p->param.length() == (bt->fun->param.length() + 1));
+      assert(bt->param.length() == bt->fun->param.length());
+      SetOf* s_out = new SetOf();
+      VariableSymbol* v_nb =
+ new VariableSymbol(act->adds[k]->param[0]->print_name);
+      v_nb->sym_types.assign_copy(act->adds[k]->param[0]->sym_types);
+      s_out->param.append(v_nb);
+      if (act->adds[k]->param[1] != dom_undefined_obj) {
+ Atom* a_neq = new Atom(dom_eq_pred);
+ a_neq->param.append(v_nb);
+ a_neq->param.append(act->adds[k]->param[1]);
+ s_out->neg_con.append(a_neq);
+      }
+      for (index_type i = 0; i < omsk_vars.length(); i++) {
+ s_out->param.append(omsk_vars[i]);
+ s_out->pos_con.append(make_binding_atom(omsk_vars[i]));
+      }
+      Atom* a_out = new Atom(p);
+      for (index_type i = 0; i < bt->param.length(); i++)
+ a_out->param.append(bt->param[i]);
+      a_out->param.append(v_nb);
+      s_out->neg_atoms.append(a_out);
+      act->cond_eff.append(s_out);
+      if (act->adds[k]->param[1] != dom_undefined_obj) {
+ if (omsk_vars.length() > 0) {
+   SetOf* s_in = new SetOf();
+   for (index_type i = 0; i < omsk_vars.length(); i++) {
+     s_in->param.append(omsk_vars[i]);
+     s_in->pos_con.append(make_binding_atom(omsk_vars[i]));
+   }
+   Atom* a_in = new Atom(p);
+   for (index_type i = 0; i < bt->param.length(); i++)
+     a_in->param.append(bt->param[i]);
+   a_in->param.append(act->adds[k]->param[1]);
+   s_in->pos_atoms.append(a_in);
+   act->cond_eff.append(s_in);
+ }
+ else {
+   Atom* a_in = new Atom(p);
+   for (index_type i = 0; i < bt->param.length(); i++)
+     a_in->param.append(bt->param[i]);
+   a_in->param.append(act->adds[k]->param[1]);
+   act->adds.append(a_in);
+ }
+      }
+      for (index_type i = 0; i < omsk_vars.length(); i++)
+ omsk_vars[i]->binding = 0;
+      rm_adds.insert(k);
+    }
+    else {
+      variable_vec omsk_vars(0, 0);
+      act->adds[k]->collect_bound_variables(omsk_vars);
+      if (omsk_vars.length() > 0) {
+ SetOf* q = new SetOf();
+ for (index_type i = 0; i < omsk_vars.length(); i++) {
+   q->param.append(omsk_vars[i]);
+   q->pos_con.append(make_binding_atom(omsk_vars[i]));
+   omsk_vars[i]->binding = 0;
+ }
+ q->pos_atoms.append(act->adds[k]);
+ act->cond_eff.append(q);
+ rm_adds.insert(k);
+      }
+    }
+  }
+  act->adds.remove(rm_adds);
+  index_set rm_dels;
+  for (index_type k = 0; k < act->dels.length(); k++) {
+    variable_vec omsk_vars(0, 0);
+    act->dels[k]->collect_bound_variables(omsk_vars);
+    if (omsk_vars.length() > 0) {
+      SetOf* q = new SetOf();
+      for (index_type i = 0; i < omsk_vars.length(); i++) {
+ q->param.append(omsk_vars[i]);
+ q->pos_con.append(make_binding_atom(omsk_vars[i]));
+ omsk_vars[i]->binding = 0;
+      }
+      q->neg_atoms.append(act->dels[k]);
+      act->cond_eff.append(q);
+      rm_dels.insert(k);
+    }
+  }
+  act->dels.remove(rm_dels);
+}
+PDDL_Base::Goal* PDDL_Base::compile_object_functions(Goal* g)
+{
+  if ((g->g_class == goal_pos_atom) ||
+      (g->g_class == goal_neg_atom)) {
+    AtomicGoal* ag = (AtomicGoal*)g;
+    if (ag->atom->pred == dom_eq_pred) {
+      assert(ag->atom->param.length() == 2);
+      if ((ag->atom->param[0]->sym_class == sym_variable) &&
+   (ag->atom->param[1]->sym_class == sym_object)) {
+ if (((VariableSymbol*)ag->atom->param[0])->binding != 0) {
+   VariableSymbol* v = (VariableSymbol*)ag->atom->param[0];
+   Symbol* co = ag->atom->param[1];
+   FTerm* bt = v->binding;
+   assert(bt != 0);
+   hsps::StringTable::Cell* c =
+     (hsps::StringTable::Cell*)tab.find(bt->fun->print_name);
+   assert(c != 0);
+   PredicateSymbol* p = (PredicateSymbol*)c->val;
+   assert(p->sym_class == sym_predicate);
+   assert(p->param.length() == (bt->fun->param.length() + 1));
+   assert(bt->param.length() == bt->fun->param.length());
+   Atom* a = new Atom(p);
+   for (index_type i = 0; i < bt->param.length(); i++)
+     a->param.append(bt->param[i]);
+   a->param.append(co);
+   ag->atom = a;
+   return g;
+ }
+      }
+      if ((ag->atom->param[1]->sym_class == sym_variable) &&
+   (ag->atom->param[0]->sym_class == sym_object)) {
+ if (((VariableSymbol*)ag->atom->param[1])->binding != 0) {
+   VariableSymbol* v = (VariableSymbol*)ag->atom->param[1];
+   Symbol* co = ag->atom->param[0];
+   FTerm* bt = v->binding;
+   assert(bt != 0);
+   hsps::StringTable::Cell* c =
+     (hsps::StringTable::Cell*)tab.find(bt->fun->print_name);
+   assert(c != 0);
+   PredicateSymbol* p = (PredicateSymbol*)c->val;
+   assert(p->sym_class == sym_predicate);
+   assert(p->param.length() == (bt->fun->param.length() + 1));
+   assert(bt->param.length() == bt->fun->param.length());
+   Atom* a = new Atom(p);
+   for (index_type i = 0; i < bt->param.length(); i++)
+     a->param.append(bt->param[i]);
+   a->param.append(co);
+   ag->atom = a;
+   return g;
+ }
+      }
+    }
+    variable_vec omsk_vars(0, 0);
+    ag->atom->collect_bound_variables(omsk_vars);
+    if (omsk_vars.length() > 0) {
+      QuantifiedGoal* qg = new QuantifiedGoal(goal_exists);
+      for (index_type k = 0; k < omsk_vars.length(); k++) {
+ qg->param.append(omsk_vars[k]);
+ FTerm* bt = omsk_vars[k]->binding;
+ omsk_vars[k]->binding = 0;
+ assert(bt != 0);
+ hsps::StringTable::Cell* c =
+   (hsps::StringTable::Cell*)tab.find(bt->fun->print_name);
+ assert(c != 0);
+ PredicateSymbol* p = (PredicateSymbol*)c->val;
+ assert(p->sym_class == sym_predicate);
+ assert(p->param.length() == (bt->fun->param.length() + 1));
+ assert(bt->param.length() == bt->fun->param.length());
+ Atom* a = new Atom(p);
+ for (index_type i = 0; i < bt->param.length(); i++)
+   a->param.append(bt->param[i]);
+ a->param.append(omsk_vars[k]);
+ qg->pos_con.append(a);
+      }
+      qg->goal = g;
+      return qg;
+    }
+    else {
+      return g;
+    }
+  }
+  else if ((g->g_class == goal_conjunction) ||
+    (g->g_class == goal_disjunction)) {
+    ConjunctiveGoal* cg = (ConjunctiveGoal*)this;
+    for (index_type k = 0; k < cg->goals.length(); k++)
+      cg->goals[k] = compile_object_functions(cg->goals[k]);
+    return g;
+  }
+  else {
+    if (write_warnings || !best_effort) {
+      std::cerr << "warning: compilation of object functions in goal ";
+      print(std::cerr);
+      std::cerr << " not implemented" << std::endl;
+      if (!best_effort) exit(1);
+    }
+    return g;
+  }
+}
+void PDDL_Base::compile_object_functions()
+{
+  Symbol* undefined_value = 0;
+  TypeSymbol* undefined_type = 0;
+  if (!compile_for_validator) {
+    undefined_type =
+      (TypeSymbol*)gensym(sym_typename, "undefined-type", dom_top_type);
+    dom_types.append(undefined_type);
+    undefined_value =
+      gensym(sym_object, "undefined-value", undefined_type);
+    undefined_type->add_element(undefined_value);
+    dom_constants.append(undefined_value);
+  }
+  lvector<PredicateSymbol*> fpred(0, 0);
+  for (index_type k = 0; k < dom_object_functions.length(); k++) {
+    ObjectFunctionSymbol* f = dom_object_functions[k];
+    PredicateSymbol* p = new PredicateSymbol(f->print_name);
+    p->param = f->param;
+    VariableSymbol* vf =
+      (VariableSymbol*)gensym(sym_variable, "?fval", f->sym_types);
+    if (!compile_for_validator)
+      vf->sym_types.append(undefined_type);
+    p->param.append(vf);
+    if (f->modded) {
+      p->added = true;
+      p->deleted = true;
+      p->modded = true;
+    }
+    p->pos_pre = true;
+    hsps::StringTable::Cell* c =
+      (hsps::StringTable::Cell*)tab.find(f->print_name);
+    if (c == 0) {
+      std::cerr << "very bad error: object function " << f->print_name
+  << " declared but not found in string table!"
+  << std::endl;
+      exit(255);
+    }
+    c->val = p;
+    dom_predicates.append(p);
+    fpred.append(p);
+    if (!p->is_static()) {
+      SetConstraint* f_inv = new SetConstraint();
+      if (!compile_for_validator)
+ f_inv->sc_type = sc_exactly;
+      else
+ f_inv->sc_type = sc_at_most;
+      f_inv->sc_count = 1;
+      f_inv->param = f->param;
+      SetOf* s_inv = new SetOf();
+      s_inv->param.append(vf);
+      Atom* a_inv = new Atom(p);
+      for (index_type i = 0; i < f_inv->param.length(); i++)
+ a_inv->param.append(f_inv->param[i]);
+      a_inv->param.append(vf);
+      s_inv->pos_atoms.append(a_inv);
+      f_inv->atom_sets.append(s_inv);
+      dom_sc_invariants.append(f_inv);
+    }
+  }
+  for (index_type k = 0; k < dom_obj_init.length(); k++) {
+    ObjectFunctionSymbol* f = dom_obj_init[k]->fun;
+    hsps::StringTable::Cell* c =
+      (hsps::StringTable::Cell*)tab.find(f->print_name);
+    assert(c != 0);
+    PredicateSymbol* p = (PredicateSymbol*)c->val;
+    assert(p->sym_class == sym_predicate);
+    assert(p->param.length() == (f->param.length() + 1));
+    Atom* a = new Atom(p);
+    for (index_type i = 0; i < dom_obj_init[k]->param.length(); i++)
+      a->param.append(dom_obj_init[k]->param[i]);
+    a->param.append(dom_obj_init[k]->val);
+    a->at_time = dom_obj_init[k]->at_time;
+    a->insert(p->init);
+    dom_init.append(a);
+  }
+  if (!compile_for_validator)
+    for (index_type k = 0; k < fpred.length(); k++) {
+      symbol_vec pattern(0, fpred[k]->param.length());
+      pattern[pattern.length() - 1] = undefined_value;
+      fpred[k]->initialise_missing(pattern, &dom_init);
+    }
+  dom_object_functions.clear();
+  dom_obj_init.clear();
+  for (index_type k = 0; k < dom_actions.length(); k++) {
+    if (compile_for_validator)
+      compile_object_functions_for_validator(dom_actions[k]);
+    else
+      compile_object_functions(dom_actions[k], undefined_value);
+  }
+  for (index_type k = 0;k < dom_goals.length(); k++) {
+    dom_goals[k] = compile_object_functions(dom_goals[k]);
+  }
+  for (index_type k = 0;k < dom_preferences.length(); k++) {
+    dom_preferences[k]->goal =
+      compile_object_functions(dom_preferences[k]->goal);
+  }
+}
+void PDDL_Base::Atom::build(Instance& ins, bool neg, index_type p)
+{
+  if (p < param.length()) {
+    if (param[p]->sym_class == sym_variable) {
+      for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+ ((VariableSymbol*)param[p])->value =
+   param[p]->sym_types.get_element(k);
+ build(ins, neg, p + 1);
+      }
+      ((VariableSymbol*)param[p])->value = 0;
+    }
+    else {
+      build(ins, neg, p + 1);
+    }
+  }
+  else {
+    find_prop(ins, neg, true);
+  }
+}
+void PDDL_Base::PredicateSymbol::instantiate(Instance& ins)
+{
+  Atom* a = new Atom(this, param, false);
+  a->build(ins, false, 0);
+  a->build(ins, true, 0);
+  delete a;
+}
+void PDDL_Base::PredicateSymbol::initialise_missing
+(const symbol_vec& p, atom_vec* created, index_type i)
+{
+  assert(p.length() == param.length());
+  if (i < param.length()) {
+    if (p[i] == 0) {
+      for (index_type k = 0; k < param[i]->sym_types.n_elements(); k++) {
+ param[i]->value = param[i]->sym_types.get_element(k);
+ initialise_missing(p, created, i + 1);
+      }
+      param[i]->value = 0;
+    }
+    else {
+      param[i]->value = 0;
+      initialise_missing(p, created, i + 1);
+    }
+  }
+  else {
+    Atom a(this, param, false);
+    partial_value v = a.partial_eval(&init, 0);
+    if (v == p_false) {
+      Atom* b = new Atom(this);
+      for (index_type k = 0; k < param.length(); k++) {
+ if (param[k]->value == 0) {
+   assert(p[k] != 0);
+   b->param.append(p[k]);
+ }
+ else {
+   b->param.append(param[k]->value);
+ }
+      }
+      b->insert(init);
+      if (created) {
+ created->append(b);
+      }
+    }
+  }
+}
+void* PDDL_Base::ActionSymbol::find_instance()
+{
+  ptr_table* r = &instances;
+  for (index_type k = 0; (k < param.length()) && r; k++) {
+    r = r->find_next(param[k]->value);
+  }
+  if (r) {
+    if (r->val) return r->val;
+  }
+  return 0;
+}
+void PDDL_Base::ActionSymbol::build
+(Instance& ins, index_type p, Expression* cost_exp)
+{
+  if (p < param.length()) {
+    for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+      param[p]->value = param[p]->sym_types.get_element(k);
+      bool pass = true;
+      if (!create_all_actions) {
+ for (index_type k = 0; (k < pos_pre.length()) && pass; k++)
+   if (pos_pre[k]->is_static()) {
+     partial_value v = pos_pre[k]->partial_eval();
+     if (v == p_false) pass = false;
+   }
+ for (index_type k = 0; (k < neg_pre.length()) && pass; k++)
+   if (neg_pre[k]->is_static()) {
+     partial_value v = neg_pre[k]->partial_eval();
+     if (v == p_true) pass = false;
+   }
+ for (index_type k = 0; (k < num_pre.length()) && pass; k++) {
+   partial_value v = num_pre[k]->partial_eval();
+   if (v == p_false) pass = false;
+ }
+ for (index_type k = 0; (k < set_pre.length()) && pass; k++)
+   if (set_pre[k]->is_static()) {
+     partial_value v = set_pre[k]->partial_eval();
+     if (v == p_false) pass = false;
+   }
+  for (index_type k = 0; (k < dis_pre.length()) && pass; k++)
+    if (dis_pre[k]->is_static()) {
+      partial_value v = dis_pre[k]->partial_eval(true);
+      if (v == p_false) pass = false;
+   }
+      }
+      if (pass) build(ins, p + 1, cost_exp);
+    }
+    param[p]->value = 0;
+  }
+  else {
+    if ((param.length() == 0) && !create_all_actions) {
+      for (index_type k = 0; k < pos_pre.length(); k++)
+ if (pos_pre[k]->is_static()) {
+   partial_value v = pos_pre[k]->partial_eval();
+   if (v == p_false) return;
+ }
+      for (index_type k = 0; k < neg_pre.length(); k++)
+ if (neg_pre[k]->is_static()) {
+   partial_value v = neg_pre[k]->partial_eval();
+   if (v == p_true) return;
+ }
+      for (index_type k = 0; k < set_pre.length(); k++)
+ if (set_pre[k]->is_static()) {
+   partial_value v = set_pre[k]->partial_eval();
+   if (v == p_false) return;
+ }
+      for (index_type k = 0; k < dis_pre.length(); k++)
+ if (dis_pre[k]->is_static()) {
+   partial_value v = dis_pre[k]->partial_eval(true);
+   if (v == p_false) return;
+ }
+    }
+    for (index_type k = 0; k < irr_ins.length(); k++)
+      if (irr_ins[k]->included) {
+ if (irr_ins[k]->context_is_static()) {
+   if (irr_ins[k]->match(param)) {
+     if (write_info) {
+       std::cerr << "DKEL: action instance " << print_name;
+       for (index_type i = 0; i < param.length(); i++)
+  std::cerr << " " << param[i]->print_name << "\\"
+     << param[i]->value->print_name;
+       std::cerr << " excluded by" << std::endl;
+       irr_ins[k]->print(std::cerr);
+       std::cerr << std::endl;
+     }
+     return;
+   }
+ }
+ else if (write_warnings) {
+   std::cerr << "warning: ignoring :irrelevant ";
+   irr_ins[k]->entity->print(std::cerr);
+   std::cerr << " with non-static context" << std::endl;
+ }
+      }
+    PDDL_Name* name = new PDDL_Name(this, param, false);
+    index_type count_name = 0;
+    index_set ac_pre;
+    index_set ac_add;
+    index_set_vec ac_dc(EMPTYSET, 0);
+    index_set ac_del;
+    index_set ac_lck;
+    index_cost_vec ac_use(index_cost_pair(0, 0), 0);
+    index_cost_vec ac_cons(index_cost_pair(0, 0), 0);
+    hsps::rational ac_dmin = 1;
+    hsps::rational ac_dmax = 1;
+    hsps::rational ac_dur = 1;
+    hsps::rational ac_cost = 1;
+    for (index_type k = 0; k < pos_pre.length(); k++)
+      if (!pos_pre[k]->is_static() ||
+   (create_all_actions && !pos_pre[k]->pred->is_equality())) {
+ Instance::Atom* pp = pos_pre[k]->find_prop(ins, false, true);
+ ac_pre.insert(pp->index);
+      }
+    for (index_type k = 0; k < neg_pre.length(); k++)
+      if (!neg_pre[k]->is_static() ||
+   (create_all_actions && !neg_pre[k]->pred->is_equality())) {
+ Instance::Atom* np = neg_pre[k]->find_prop(ins, true, true);
+ ac_pre.insert(np->index);
+      }
+    for (index_type k = 0; k < set_pre.length(); k++) {
+      if (!set_pre[k]->is_static() || create_all_actions) {
+ index_set s;
+ set_pre[k]->instantiate_as_set(ins, s);
+ ac_pre.insert(s);
+      }
+    }
+    for (index_type k = 0; k < adds.length(); k++) {
+      Instance::Atom* pp = adds[k]->find_prop(ins, false, true);
+      ac_add.insert(pp->index);
+      if (adds[k]->pred->neg_pre) {
+ Instance::Atom* np = adds[k]->find_prop(ins, true, true);
+ ac_del.insert(np->index);
+      }
+    }
+    for (index_type k = 0; k < dels.length(); k++) {
+      Instance::Atom* pp = dels[k]->find_prop(ins, false, true);
+      ac_del.insert(pp->index);
+      if (dels[k]->pred->neg_pre) {
+ Instance::Atom* np = dels[k]->find_prop(ins, true, true);
+ ac_add.insert(np->index);
+      }
+    }
+    for (index_type k = 0; k < set_eff.length(); k++) {
+      index_set s_add;
+      index_set s_del;
+      set_eff[k]->instantiate_as_effect(ins, s_add, s_del);
+      ac_add.insert(s_add);
+      ac_del.insert(s_del);
+    }
+    for (index_type k = 0; k < locks.length(); k++) {
+      Instance::Atom* lp = locks[k]->find_prop(ins, false, true);
+      ac_lck.insert(lp->index);
+    }
+    if ((!enables.empty() || !incs.empty() || !fass.empty() ||
+  !qc_incs.empty() || !qc_decs.empty() || !qc_fass.empty()) &&
+ (write_warnings || !best_effort)) {
+      bool is_ok = true;
+      std::cerr << "warning: effects of action " << print_name
+  << " ignored in instantiation:" << std::endl;
+      for (index_type k = 0; k < enables.length(); k++) {
+ std::cerr << " - temporary add atom ";
+ enables[k]->print(std::cerr);
+ std::cerr << std::endl;
+      }
+      for (index_type k = 0; k < incs.length(); k++) {
+ std::cerr << " - fluent increase ";
+ incs[k]->print(std::cerr);
+ if (!incs[k]->fun->conditioned)
+   std::cerr << " (but no condition on this function, so ok)";
+ else
+   is_ok = false;
+ std::cerr << std::endl;
+      }
+      for (index_type k = 0; k < fass.length(); k++) {
+ std::cerr << " - fluent assignment ";
+ fass[k]->print(std::cerr);
+ std::cerr << std::endl;
+      }
+      for (index_type k = 0; k < qc_incs.length(); k++) {
+ std::cerr << " - quantified/conditional fluent increase ";
+ qc_incs[k]->print(std::cerr);
+ std::cerr << std::endl;
+      }
+      for (index_type k = 0; k < qc_decs.length(); k++) {
+ std::cerr << " - quantified/conditional fluent decrease ";
+ qc_decs[k]->print(std::cerr);
+ std::cerr << std::endl;
+      }
+      for (index_type k = 0; k < qc_fass.length(); k++) {
+ std::cerr << " - quantified/conditional fluent assignment ";
+ qc_fass[k]->print(std::cerr);
+ std::cerr << std::endl;
+      }
+      if (!best_effort && !is_ok) exit(1);
+    }
+    for (index_type k = 0; k < reqs.length(); k++) {
+      Instance::Resource* rc = reqs[k]->find_resource(ins);
+      ac_use.append(index_cost_pair(rc->index, reqs[k]->val->eval_static()));
+    }
+    for (index_type k = 0; k < decs.length(); k++) {
+      Instance::Resource* rc = decs[k]->find_resource(ins);
+      ac_cons.append(index_cost_pair(rc->index, decs[k]->val->eval_static()));
+    }
+    if (dmin) {
+      ac_dmin = dmin->eval_static();
+      if ((ac_dmin <= 0) && PDDL_Base::write_warnings) {
+ std::cerr << "warning: action instance " << name
+    << " has (min) duration " << ac_dmin << " <= 0"
+    << std::endl;
+      }
+    }
+    if (dmax) {
+      ac_dmax = dmax->eval_static();
+      if ((ac_dmax <= 0) && PDDL_Base::write_warnings) {
+ std::cerr << "warning: action instance " << name
+    << " has (max) duration " << ac_dmax << " <= 0"
+    << std::endl;
+      }
+    }
+    if (dmax) {
+      ac_dur = ac_dmax;
+    }
+    else if (dmin) {
+      ac_dur = ac_dmin;
+    }
+    if (cost_exp) {
+      ac_cost = cost_exp->eval_delta(incs, decs);
+      if ((ac_cost <= 0) && PDDL_Base::write_warnings) {
+ std::cerr << "warning: action instance " << name
+    << " has cost " << ac_cost << " <= 0" << std::endl;
+      }
+    }
+    atom_set_vec ns_dis_pre(0, 0);
+    for (index_type k = 0; k < dis_pre.length(); k++)
+      if (!dis_pre[k]->is_static())
+ ns_dis_pre.append(dis_pre[k]);
+    if ((cond_eff.length() > 0) &&
+ compile_away_conditional_effects) {
+      if ((ns_dis_pre.length() > 0) &&
+   compile_away_disjunctive_preconditions) {
+ ac_dc.set_length(ns_dis_pre.length());
+ for (index_type k = 0; k < ns_dis_pre.length(); k++)
+   ns_dis_pre[k]->instantiate_as_set(ins, ac_dc[k]);
+      }
+      rule_set pce;
+      rule_set nce;
+      for (index_type k = 0; k < cond_eff.length(); k++) {
+ cond_eff[k]->instantiate_conditional(ins, pce, nce);
+      }
+      SubsetEnumerator se(pce.length() + nce.length());
+      bool more = se.first();
+      if (write_info) {
+ std::cerr << "info: compiling " << pce.length() + nce.length()
+    << " conditional effects in action "
+    << print_name << "..." << std::endl;
+ if (write_trace) {
+   std::cerr << "debug: instantiated conditional effects of action "
+      << print_name << " are:" << std::endl;
+   for (index_type k = 0; k < pce.length(); k++)
+     std::cerr << "add: " << pce[k] << std::endl;
+   for (index_type k = 0; k < nce.length(); k++)
+     std::cerr << "del: " << nce[k] << std::endl;
+ }
+      }
+      while (more) {
+ build_actions_with_dc_and_ce(ins, name, count_name, ac_pre, ac_add,
+         ac_del, ac_lck, ac_use, ac_cons, ac_dmin,
+         ac_dmax, ac_dur, ac_cost, ac_dc, pce, nce,
+         se.current_set());
+ more = se.next();
+      }
+    }
+    else if ((ns_dis_pre.length() > 0) &&
+      compile_away_disjunctive_preconditions) {
+      if ((cond_eff.length() > 0) && (write_warnings || !best_effort)) {
+ std::cerr << "warning: conditional effects of action " << print_name
+    << " ignored in instantiation" << std::endl;
+ if (!best_effort) exit(1);
+      }
+      ac_dc.set_length(dis_pre.length());
+      for (index_type k = 0; k < ns_dis_pre.length(); k++)
+ ns_dis_pre[k]->instantiate_as_set(ins, ac_dc[k]);
+      build_actions_with_dc(ins, name, count_name, ac_pre, ac_add, ac_del,
+       ac_lck, ac_use, ac_cons, ac_dmin, ac_dmax, ac_dur,
+       ac_cost, ac_dc);
+    }
+    else {
+      if ((cond_eff.length() > 0) && (write_warnings || !best_effort)) {
+ std::cerr << "warning: conditional effects of action " << print_name
+    << " ignored in instantiation" << std::endl;
+ if (!best_effort) exit(1);
+      }
+      if ((ns_dis_pre.length() > 0) && (write_warnings || !best_effort)) {
+ std::cerr << "warning: disjunctive preconditions of action "
+    << print_name << " ignored in instantiation" << std::endl;
+ if (!best_effort) exit(1);
+      }
+      build_action(ins, name, count_name, ac_pre, ac_add, ac_del, ac_lck,
+     ac_use, ac_cons, ac_dmin, ac_dmax, ac_dur, ac_cost);
+    }
+  }
+}
+Instance::Action& PDDL_Base::ActionSymbol::build_action
+(Instance& ins, PDDL_Name* name, index_type& count,
+ const index_set& pre, const index_set& add, const index_set& del,
+ const index_set& lck, const index_cost_vec& r_use,
+ const index_cost_vec& r_cons, hsps::rational dmin, hsps::rational dmax, hsps::rational d, hsps::rational c)
+{
+  ptr_table* r = &instances;
+  for (index_type k = 0; k < name->argc(); k++) {
+    r = r->insert_next(name->args()[k]);
+  }
+  if (r->val) {
+    if (write_warnings && (count >= 1)) {
+      std::cerr << "warning: multiple instances of (" << print_name;
+      for (index_type i = 0; i < param.length(); i++)
+ std::cerr << " " << param[i]->print_name << "\\"
+    << param[i]->value->print_name;
+      std::cerr << ")" << std::endl;
+    }
+    if (number_multiple_action_instances) {
+      if (count == 1) {
+ ((Instance::Action*)r->val)->name = new Numbered_PDDL_Name(name, 0);
+      }
+      name = new Numbered_PDDL_Name(name, count++);
+    }
+  }
+  Instance::Action& act = ins.new_action(name);
+  act.src = new ptr_pair(this, r);
+  if (r->val == 0) {
+    r->val = new Instance::action_ref(ins.actions, act.index);
+    count = 1;
+  }
+  for (index_type k = 0; k < refs.length(); k++) {
+    if (refs[k]->match(param)) {
+      if (write_info) {
+ std::cerr << "info: action reference ";
+ refs[k]->print(std::cerr);
+ std::cerr << " matched to "
+    << act.index << "." << act.name
+    << std::endl;
+      }
+      if (write_warnings && !refs[k]->index.empty()) {
+ std::cerr << "warning: action reference ";
+ refs[k]->print(std::cerr);
+ std::cerr << " has multiple matches" << std::endl;
+      }
+      refs[k]->index.insert(act.index);
+    }
+  }
+  if (part) {
+    index_set* s = part->find();
+    s->insert(act.index);
+  }
+  act.pre = pre;
+  act.add = add;
+  act.del = del;
+  act.lck = lck;
+  if (del_before_add_semantics) {
+    index_set x(del);
+    x.intersect(add);
+    if (!x.empty()) {
+      act.del.subtract(x);
+      act.lck.insert(x);
+    }
+  }
+  for (index_type k = 0; k < r_use.length(); k++) {
+    act.use.inc_length_to(r_use[k].first + 1, 0);
+    act.use[r_use[k].first] += r_use[k].second;
+  }
+  for (index_type k = 0; k < r_cons.length(); k++) {
+    act.cons.inc_length_to(r_cons[k].first + 1, 0);
+    act.cons[r_cons[k].first] += r_cons[k].second;
+  }
+  act.dmin = dmin;
+  act.dmax = dmax;
+  act.dur = d;
+  act.cost = c;
+  act.assoc = assoc;
+  return act;
+}
+void PDDL_Base::ActionSymbol::build_actions_with_dc
+(Instance& ins, PDDL_Name* name, index_type& count,
+ const index_set& pre, const index_set& add, const index_set& del,
+ const index_set& lck, const index_cost_vec& r_use,
+ const index_cost_vec& r_cons, hsps::rational dmin, hsps::rational dmax, hsps::rational d, hsps::rational c,
+ const index_set_vec& dc, index_vec& s, index_type p)
+{
+  if (p < dc.length()) {
+    if ((dc[p].first_common_element(s) != no_such_index) ||
+ (dc[p].first_common_element(pre) != no_such_index)) {
+      build_actions_with_dc(ins, name, count, pre, add, del, lck, r_use,
+       r_cons, dmin, dmax, d, c, dc, s, p + 1);
+    }
+    else {
+      for (index_type k = 0; k < dc[p].length(); k++) {
+ bool consistent = true;
+ if (check_precondition_consistency) {
+   index_type not_dk = ins.atoms[dc[p][k]].neg;
+   if (not_dk != no_such_index) {
+     if (s.first(not_dk) != no_such_index) consistent = false;
+     if (pre.contains(not_dk)) consistent = false;
+   }
+ }
+ if (consistent) {
+   s.append(dc[p][k]);
+   build_actions_with_dc(ins, name, count, pre, add, del, lck, r_use,
+    r_cons, dmin, dmax, d, c, dc, s, p + 1);
+   s.dec_length();
+ }
+      }
+    }
+  }
+  else {
+    Instance::Action& act =
+      build_action(ins, name, count, pre, add, del, lck, r_use, r_cons,
+     dmin, dmax, d, c);
+    for (index_type k = 0; k < s.length(); k++)
+      act.pre.insert(s[k]);
+  }
+}
+void PDDL_Base::ActionSymbol::build_actions_with_dc
+(Instance& ins, PDDL_Name* name, index_type& count,
+ const index_set& pre, const index_set& add, const index_set& del,
+ const index_set& lck, const index_cost_vec& r_use,
+ const index_cost_vec& r_cons, hsps::rational dmin, hsps::rational dmax, hsps::rational d, hsps::rational c,
+ const index_set_vec& dc)
+{
+  index_vec s(no_such_index, 0);
+  build_actions_with_dc(ins, name, count, pre, add, del, lck, r_use, r_cons,
+   dmin, dmax, d, c, dc, s, 0);
+}
+void PDDL_Base::ActionSymbol::build_actions_with_dc_and_ce
+(Instance& ins, PDDL_Name* name, index_type& count,
+ const index_set& pre, const index_set& add, const index_set& del,
+ const index_set& lck, const index_cost_vec& r_use,
+ const index_cost_vec& r_cons, hsps::rational dmin, hsps::rational dmax, hsps::rational d, hsps::rational c,
+ const index_set_vec& dc, const rule_set& pce, const rule_set& nce,
+ const bool_vec& ece)
+{
+  index_set x_pre(pre);
+  index_set x_add(add);
+  index_set x_del(del);
+  index_set_vec x_dc(dc);
+  for (index_type k = 0; k < pce.length(); k++) {
+    if (ece[k]) {
+      x_pre.insert(pce[k].antecedent);
+      x_add.insert(pce[k].consequent);
+      index_type not_c = ins.atoms[pce[k].consequent].neg;
+      if (not_c != no_such_index)
+ x_del.insert(not_c);
+    }
+    else {
+      if (pce[k].antecedent.length() == 1) {
+ index_type not_a = ins.atoms[pce[k].antecedent[0]].neg;
+ if (not_a == no_such_index) {
+   std::cerr << "error (compiling conditional effects): negation of "
+      << ins.atoms[pce[k].antecedent[0]].name
+      << " not defined" << std::endl;
+   exit(255);
+ }
+ x_pre.insert(not_a);
+      }
+      else {
+ index_set all_not_a;
+ for (index_type i = 0; i < pce[k].antecedent.length(); i++) {
+   index_type not_a = ins.atoms[pce[k].antecedent[i]].neg;
+   if (not_a == no_such_index) {
+     std::cerr << "error (compiling conditional effects): negation of "
+        << ins.atoms[pce[k].antecedent[i]].name
+        << " not defined" << std::endl;
+     exit(255);
+   }
+   all_not_a.insert(not_a);
+ }
+ x_dc.append(all_not_a);
+      }
+    }
+  }
+  for (index_type k = 0; k < nce.length(); k++) {
+    if (ece[pce.length() + k]) {
+      x_pre.insert(nce[k].antecedent);
+      x_del.insert(nce[k].consequent);
+      index_type not_c = ins.atoms[nce[k].consequent].neg;
+      if (not_c != no_such_index)
+ x_add.insert(not_c);
+    }
+    else {
+      if (nce[k].antecedent.length() == 1) {
+ index_type not_a = ins.atoms[nce[k].antecedent[0]].neg;
+ if (not_a == no_such_index) {
+   std::cerr << "error (compiling conditional effects): negation of "
+      << ins.atoms[nce[k].antecedent[0]].name
+      << " not defined" << std::endl;
+   exit(255);
+ }
+ x_pre.insert(not_a);
+      }
+      else {
+ index_set all_not_a;
+ for (index_type i = 0; i < nce[k].antecedent.length(); i++) {
+   index_type not_a = ins.atoms[nce[k].antecedent[i]].neg;
+   if (not_a == no_such_index) {
+     std::cerr << "error (compiling conditional effects): negation of "
+        << ins.atoms[nce[k].antecedent[i]].name
+        << " not defined" << std::endl;
+     exit(255);
+   }
+   all_not_a.insert(not_a);
+ }
+ x_dc.append(all_not_a);
+      }
+    }
+  }
+  index_vec s(no_such_index, 0);
+  build_actions_with_dc(ins, name, count, x_pre, x_add, x_del, lck, r_use,
+   r_cons, dmin, dmax, d, c, x_dc, s, 0);
+}
+index_type PDDL_Base::ActionSymbol::param_index(VariableSymbol* p)
+{
+  return param.first(p);
+}
+void PDDL_Base::ActionSymbol::get_param_inequalities(symbol_pair_vec& neq)
+{
+  neq.clear();
+  for (index_type k = 0; k < neg_pre.length(); k++)
+    if (neg_pre[k]->pred->is_equality()) {
+      assert(neg_pre[k]->param.length() == 2);
+      neq.append(symbol_pair(neg_pre[k]->param[0], neg_pre[k]->param[1]));
+    }
+}
+void PDDL_Base::ActionSymbol::set_arguments(const symbol_vec& args)
+{
+  if (args.length() != param.length()) {
+    std::cerr << "error: can't set arguments of (" << print_name;
+    for (index_type i = 0; i < param.length(); i++)
+      std::cerr << " " << param[i]->print_name;
+    std::cerr << ") with ";
+    for (index_type i = 0; i < args.length(); i++) {
+      std::cerr << args[i]->print_name;
+      if (i + 1 < args.length()) std::cerr << ";";
+    }
+    std::cerr << " -- wrong number!" << std::endl;
+    exit(255);
+  }
+  for (index_type k = 0; k < param.length(); k++) param[k]->value = args[k];
+}
+void PDDL_Base::ActionSymbol::set_arguments(const ptr_table::key_vec& args)
+{
+  if (args.length() != param.length()) {
+    std::cerr << "error: can't set arguments of (" << print_name;
+    for (index_type i = 0; i < param.length(); i++)
+      std::cerr << " " << param[i]->print_name;
+    std::cerr << ") with " << args << " -- wrong number!"
+       << std::endl;
+    exit(255);
+  }
+  for (index_type k = 0; k < param.length(); k++) {
+    param[k]->value = (PDDL_Base::Symbol*)args[k];
+  }
+}
+void PDDL_Base::ActionSymbol::clear_arguments()
+{
+  for (index_type k = 0; k < param.length(); k++)
+    param[k]->value = 0;
+  for (index_type k = 0; k < set_pre.length(); k++)
+    set_pre[k]->clear_arguments();
+  for (index_type k = 0; k < set_eff.length(); k++)
+    set_eff[k]->clear_arguments();
+}
+bool PDDL_Base::ActionSymbol::is_abstract()
+{
+  return (exps.length() > 0);
+}
+void PDDL_Base::ActionSymbol::instantiate(Instance& ins, Expression* cost_exp)
+{
+  assert(!is_abstract());
+  for (index_type k = 0; k < param.length(); k++) param[k]->value = 0;
+  build(ins, 0, cost_exp);
+}
+index_set* PDDL_Base::SetName::find()
+{
+  ptr_table* r = &(sym->set_table);
+  for (index_type k = 0; k < param.length(); k++) {
+    if (param[k]->sym_class == sym_variable) {
+      if (((VariableSymbol*)param[k])->value == 0) {
+ std::cerr << "error: unbound variable "
+    << param[k]->print_name << " in ";
+ print(std::cerr);
+ std::cerr << " - uncompiled object function?"
+    << std::endl;
+ exit(255);
+      }
+      r = r->insert_next(((VariableSymbol*)param[k])->value);
+    }
+    else {
+      r = r->insert_next(param[k]);
+    }
+  }
+  if (!r->val) {
+    PDDL_Name* s_name = new PDDL_Name(sym);
+    for (index_type k = 0; k < param.length(); k++) {
+      if (param[k]->sym_class == sym_variable) {
+ s_name->add(((VariableSymbol*)param[k])->value);
+      }
+      else {
+ s_name->add(param[k]);
+      }
+    }
+    index_set* s = new index_set;
+    r->val = s;
+    sym->sets.append(s);
+    sym->names.append(s_name);
+  }
+  return (index_set*)(r->val);
+}
+PDDL_Base::SetName* PDDL_Base::SetName::instantiate_partially()
+{
+  SetName* n = new SetName(sym);
+  fill_in_args(n);
+  return n;
+}
+bool PDDL_Base::Reference::match(symbol_vec& args)
+{
+  if (args.length() != param.length()) {
+    std::cerr << "error: wrong number of arguments (" << args.length()
+       << ", should be " << param.length() << ") in match"
+       << std::endl;
+    return false;
+  }
+  for (index_type k = 0; k < param.length(); k++) {
+    if (param[k]->sym_class == sym_variable) {
+      if (((VariableSymbol*)param[k])->value) {
+ if (args[k]->sym_class == sym_variable) {
+   if (((VariableSymbol*)args[k])->value !=
+       ((VariableSymbol*)param[k])->value)
+     return false;
+ }
+ else {
+   if (args[k] != ((VariableSymbol*)param[k])->value) return false;
+ }
+      }
+      else {
+ if (args[k]->sym_class == sym_variable) {
+   ((VariableSymbol*)param[k])->value =
+     ((VariableSymbol*)args[k])->value;
+ }
+ else {
+   ((VariableSymbol*)param[k])->value = args[k];
+ }
+      }
+    }
+    else if (param[k]->sym_class == sym_object) {
+      if (args[k]->sym_class == sym_variable) {
+ if (((VariableSymbol*)args[k])->value != param[k]) return false;
+      }
+      else {
+ if (args[k] != param[k]) return false;
+      }
+    }
+    else {
+      std::cerr << "program error: arg " << k + 1
+  << " has bad sym_class in match ";
+      print(std::cerr);
+      std::cerr << std::endl;
+      exit(255);
+    }
+  }
+  return true;
+}
+bool PDDL_Base::Reference::match(variable_vec& args)
+{
+  if (args.length() != param.length()) {
+    std::cerr << "error: wrong number of arguments (" << args.length()
+       << ", should be " << param.length() << ") in match"
+       << std::endl;
+    return false;
+  }
+  for (index_type k = 0; k < param.length(); k++) {
+    if (param[k]->sym_class == sym_variable) {
+      if (((VariableSymbol*)param[k])->value) {
+ if (args[k]->value != ((VariableSymbol*)param[k])->value) return false;
+      }
+      else {
+ ((VariableSymbol*)param[k])->value = args[k]->value;
+      }
+    }
+    else if (param[k]->sym_class == sym_object) {
+      if (args[k]->value != param[k]) return false;
+    }
+    else {
+      std::cerr << "program error: arg " << k + 1
+  << " has bad sym_class in match ";
+      print(std::cerr);
+      std::cerr << std::endl;
+      exit(255);
+    }
+  }
+  return true;
+}
+void* PDDL_Base::Reference::find_action()
+{
+  if (name->sym_class != sym_action) {
+    std::cerr << "error: ";
+    name->print(std::cerr);
+    std::cerr << " of ";
+    print(std::cerr);
+    std::cerr << " is not an action symbol" << std::endl;
+    exit(255);
+  }
+  ActionSymbol* act = (ActionSymbol*)name;
+  ptr_table* r = &(act->instances);
+  for (index_type k = 0; (k < param.length()) && r; k++) {
+    if (param[k]->sym_class == sym_variable)
+      r = r->find_next(((VariableSymbol*)param[k])->value);
+    else
+      r = r->find_next(param[k]);
+  }
+  if (r) {
+    return r->val;
+  }
+  else {
+    return 0;
+  }
+}
+void PDDL_Base::Reference::find(const name_vec& names, index_set& ind)
+{
+  ind.clear();
+  Name* n = 0;
+  if (has_args) {
+    PDDL_Name* pn = new PDDL_Name(name, neg);
+    for (index_type k = 0; k < param.length(); k++) {
+      if (param[k]->sym_class == sym_variable) {
+ VariableSymbol* v = (VariableSymbol*)param[k];
+ if (v->value == 0) {
+   if (write_warnings) {
+     std::cerr << "warning: ";
+     v->print(std::cerr);
+     std::cerr << " in ";
+     print(std::cerr);
+     std::cerr << " has no value" << std::endl;
+   }
+   delete pn;
+   return;
+ }
+ else {
+   pn->add(v->value);
+ }
+      }
+      else {
+ pn->add(param[k]);
+      }
+    }
+    n = pn;
+  }
+  else {
+    n = new StringName(name->print_name);
+  }
+  for (index_type k = 0; k < names.length(); k++) {
+    if (n->equals(names[k])) {
+      if (write_warnings && !ind.empty()) {
+ std::cerr << "warning: multiple matches for " << n
+    << " in " << names << std::endl;
+      }
+      ind.insert(k);
+    }
+  }
+  if (write_warnings && ind.empty()) {
+    std::cerr << "warning: no match for " << n
+       << " in " << names << std::endl;
+  }
+  delete n;
+}
+PDDL_Base::Reference* PDDL_Base::Reference::instantiate_partially()
+{
+  Reference* r = new Reference(name, neg, has_args);
+  if (has_args) fill_in_args(r);
+  return r;
+}
+PDDL_Base::IrrelevantItem* PDDL_Base::IrrelevantItem::instantiate_partially()
+{
+  IrrelevantItem* item = new IrrelevantItem();
+  item->param = param;
+  for (index_type k = 0; k < pos_con.length(); k++)
+    item->pos_con.append(pos_con[k]->instantiate_partially());
+  for (index_type k = 0; k < neg_con.length(); k++)
+    item->neg_con.append(neg_con[k]->instantiate_partially());
+  for (index_type k = 0; k < type_con.length(); k++)
+    if (type_con[k]->var->value == 0)
+      item->type_con.append(type_con[k]);
+  item->entity = entity->instantiate_partially();
+  return item;
+}
+bool PDDL_Base::IrrelevantItem::match(symbol_vec& args)
+{
+  for (index_type k = 0; k < param.length(); k++) param[k]->value = 0;
+  bool schema_match = entity->match(args);
+  if (schema_match) {
+    partial_value v = Context::partial_eval();
+    if (v == p_true) {
+      return true;
+    }
+    else if (v == p_false) {
+      return false;
+    }
+    else {
+      if (write_warnings) {
+ std::cerr << "warning: undecided context condition in :irrelevant ";
+ entity->print(std::cerr);
+ std::cerr << " treated as false" << std::endl;
+      }
+      return false;
+    }
+  }
+  else {
+    return false;
+  }
+}
+bool PDDL_Base::IrrelevantItem::match(variable_vec& args)
+{
+  for (index_type k = 0; k < param.length(); k++) param[k]->value = 0;
+  bool schema_match = entity->match(args);
+  if (schema_match) {
+    partial_value v = Context::partial_eval();
+    if (v == p_true) {
+      return true;
+    }
+    else if (v == p_false) {
+      return false;
+    }
+    else {
+      if (write_warnings) {
+ std::cerr << "warning: undecided context condition in :irrelevant ";
+ entity->print(std::cerr);
+ std::cerr << " treated as false" << std::endl;
+      }
+      return false;
+    }
+  }
+  else {
+    return false;
+  }
+}
+bool PDDL_Base::TypeConstraint::is_true()
+{
+  if (var->value) {
+    for (index_type k = 0; k < typ->elements.length(); k++) {
+      if (typ->elements[k] == var->value) return true;
+    }
+    return false;
+  }
+  else {
+    return true;
+  }
+}
+PDDL_Base::partial_value PDDL_Base::TypeConstraint::partial_eval()
+{
+  if (var->value) {
+    if (is_true()) {
+      return p_true;
+    }
+    else {
+      return p_false;
+    }
+  }
+  else {
+    return p_unknown;
+  }
+}
+bool PDDL_Base::Context::context_is_static() const
+{
+  for (index_type k = 0; k < pos_con.length(); k++)
+    if (!pos_con[k]->is_static()) return false;
+  for (index_type k = 0; k < neg_con.length(); k++)
+    if (!neg_con[k]->is_static()) return false;
+  return true;
+}
+bool PDDL_Base::Context::occurs_in_context(Symbol* s)
+{
+  for (index_type k = 0; k < pos_con.length(); k++)
+    if (pos_con[k]->occurs(s)) return true;
+  for (index_type k = 0; k < neg_con.length(); k++)
+    if (neg_con[k]->occurs(s)) return true;
+  return false;
+}
+bool PDDL_Base::Context::is_true()
+{
+  for (index_type k = 0; k < type_con.length(); k++) {
+    if (!type_con[k]->is_true()) return false;
+  }
+  for (index_type k = 0; k < pos_con.length(); k++) {
+    if (pos_con[k]->is_static()) {
+      partial_value v = pos_con[k]->partial_eval();
+      if (v == p_true) return true;
+      else if (v == p_false) return false;
+      else {
+ std::cerr << "error: context ";
+ AtomBase::print_bindings = true;
+ print(std::cerr);
+ AtomBase::print_bindings = false;
+ std::cerr << " undecided with complete assignment"
+    << std::endl;
+ exit(255);
+      }
+    }
+  }
+  for (index_type k = 0; k < neg_con.length(); k++) {
+    if (neg_con[k]->is_static()) {
+      partial_value v = neg_con[k]->partial_eval();
+      if (v == p_false) return true;
+      else if (v == p_true) return false;
+      else {
+ std::cerr << "error: context ";
+ AtomBase::print_bindings = true;
+ print(std::cerr);
+ AtomBase::print_bindings = false;
+ std::cerr << " undecided with complete assignment"
+    << std::endl;
+ exit(255);
+      }
+    }
+  }
+  return true;
+}
+void PDDL_Base::Context::clear_arguments()
+{
+  for (index_type k = 0; k < param.length(); k++)
+    param[k]->value = 0;
+}
+void PDDL_Base::Context::set_mode(mode_keyword m)
+{
+  for (index_type k = 0; k < pos_con.length(); k++)
+    if (pos_con[k]->at == md_none)
+      pos_con[k]->at = m;
+  for (index_type k = 0; k < neg_con.length(); k++)
+    if (neg_con[k]->at == md_none)
+      neg_con[k]->at = m;
+}
+PDDL_Base::partial_value PDDL_Base::Context::partial_eval()
+{
+  bool is_undecided = false;
+  for (index_type k = 0; k < type_con.length(); k++) {
+    partial_value v = type_con[k]->partial_eval();
+    if (v == p_false) return p_false;
+    if (v != p_true) is_undecided = true;
+  }
+  for (index_type k = 0; k < pos_con.length(); k++) {
+    if (pos_con[k]->is_static()) {
+      partial_value v = pos_con[k]->partial_eval();
+      if (v == p_false) return p_false;
+      if (v != p_true) is_undecided = true;
+    }
+  }
+  for (index_type k = 0; k < neg_con.length(); k++) {
+    if (neg_con[k]->is_static()) {
+      partial_value v = neg_con[k]->partial_eval();
+      if (v == p_true) return p_false;
+      if (v != p_false) is_undecided = true;
+    }
+  }
+  if (is_undecided)
+    return p_unknown;
+  return p_true;
+}
+bool PDDL_Base::SetOf::is_static() const {
+  for (index_type k = 0; k < pos_atoms.length(); k++)
+    if (!pos_atoms[k]->is_static()) return false;
+  for (index_type k = 0; k < neg_atoms.length(); k++)
+    if (!neg_atoms[k]->is_static()) return false;
+  return true;
+}
+void PDDL_Base::SetOf::set_mode(mode_keyword m)
+{
+  Context::set_mode(m);
+  for (index_type k = 0; k < pos_atoms.length(); k++)
+    if (pos_atoms[k]->at == md_none)
+      pos_atoms[k]->at = m;
+  for (index_type k = 0; k < neg_atoms.length(); k++)
+    if (neg_atoms[k]->at == md_none)
+      neg_atoms[k]->at = m;
+}
+PDDL_Base::partial_value PDDL_Base::SetOf::partial_eval
+(index_type p, bool as_disjunction)
+{
+  partial_value v_c = Context::partial_eval();
+  if ((v_c == p_false) && !as_disjunction) return p_true;
+  if ((v_c == p_false) && as_disjunction) return p_false;
+  bool all_sat = true;
+  bool some_sat = false;
+  for (index_type k = 0; k < pos_atoms.length(); k++) {
+    partial_value v_a = pos_atoms[k]->partial_eval();
+    if ((v_c == p_true) && (v_a == p_false) && !as_disjunction) {
+      if (PDDL_Base::write_info) {
+ AtomBase::print_bindings = true;
+ std::cerr << "info: set condition ";
+ print(std::cerr);
+ std::cerr << " evaluated to false"
+    << std::endl;
+ AtomBase::print_bindings = true;
+      }
+      return p_false;
+    }
+    if ((v_c == p_true) && (v_a == p_true) && as_disjunction) {
+      return p_true;
+    }
+    if (v_a != p_true) all_sat = false;
+    if (v_a == p_true) some_sat = true;
+  }
+  for (index_type k = 0; k < neg_atoms.length(); k++) {
+    partial_value v_a = neg_atoms[k]->partial_eval();
+    if ((v_c == p_true) && (v_a == p_true) && !as_disjunction) {
+      if (PDDL_Base::write_info) {
+ AtomBase::print_bindings = true;
+ std::cerr << "info: set condition ";
+ print(std::cerr);
+ std::cerr << " evaluated to false"
+    << std::endl;
+ AtomBase::print_bindings = true;
+      }
+      return p_false;
+    }
+    if ((v_c == p_true) && (v_a == p_false) && as_disjunction) {
+      return p_true;
+    }
+    if (v_a != p_false) all_sat = false;
+    if (v_a == p_false) some_sat = true;
+  }
+  if (!as_disjunction && all_sat) return p_true;
+  if (as_disjunction && !some_sat) return p_false;
+  if (p < param.length()) {
+    partial_value v = p_true;
+    for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+      param[p]->value = param[p]->sym_types.get_element(k);
+      partial_value v_i = partial_eval(p+1);
+      if (v_i == p_false) {
+ param[p]->value = 0;
+ return p_false;
+      }
+      else if (v_i == p_unknown) {
+ v = p_unknown;
+      }
+    }
+    param[p]->value = 0;
+    return v;
+  }
+  return p_unknown;
+}
+PDDL_Base::partial_value PDDL_Base::SetOf::partial_eval(bool as_disjunction)
+{
+  if (!context_is_static()) {
+    std::cerr << "error: expression ";
+    print(std::cerr);
+    std::cerr << " has non-static context" << std::endl;
+    exit(255);
+  }
+  if (!is_static()) {
+    std::cerr << "error: expression ";
+    print(std::cerr);
+    std::cerr << " has non-static atoms" << std::endl;
+    exit(255);
+  }
+  for (index_type k = 0; k < param.length(); k++) param[k]->value = 0;
+  return partial_eval(0, as_disjunction);
+}
+void PDDL_Base::SetOf::build_set
+(Instance& ins, index_set& s, index_type p)
+{
+  if (p < param.length()) {
+    for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+      param[p]->value = param[p]->sym_types.get_element(k);
+      if (Context::partial_eval() != p_false) {
+ build_set(ins, s, p+1);
+      }
+    }
+    param[p]->value = 0;
+  }
+  else if (Context::is_true()) {
+    for (index_type k = 0; k < pos_atoms.length(); k++)
+      if (!pos_atoms[k]->pred->is_equality()) {
+ Instance::Atom* p = pos_atoms[k]->find_prop(ins, false, true);
+ s.insert(p->index);
+      }
+    for (index_type k = 0; k < neg_atoms.length(); k++)
+      if (!pos_atoms[k]->pred->is_equality()) {
+ Instance::Atom* p = neg_atoms[k]->find_prop(ins, true, true);
+ s.insert(p->index);
+      }
+  }
+}
+void PDDL_Base::SetOf::instantiate_as_set(Instance& ins, index_set& s)
+{
+  if (!context_is_static()) {
+    std::cerr << "error: expression ";
+    print(std::cerr);
+    std::cerr << " has non-static context" << std::endl;
+    exit(255);
+  }
+  for (index_type k = 0; k < param.length(); k++) param[k]->value = 0;
+  build_set(ins, s, 0);
+}
+void PDDL_Base::SetOf::build_effect
+(Instance& ins, index_set& s_add, index_set& s_del, index_type p)
+{
+  if (p < param.length()) {
+    for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+      param[p]->value = param[p]->sym_types.get_element(k);
+      if (Context::partial_eval() != p_false) {
+ build_effect(ins, s_add, s_del, p+1);
+      }
+    }
+    param[p]->value = 0;
+  }
+  else if (Context::is_true()) {
+    for (index_type k = 0; k < pos_atoms.length(); k++) {
+      Instance::Atom* p = pos_atoms[k]->find_prop(ins, false, true);
+      s_add.insert(p->index);
+      if (pos_atoms[k]->pred->neg_pre) {
+ Instance::Atom* np = pos_atoms[k]->find_prop(ins, true, true);
+ s_del.insert(np->index);
+      }
+    }
+    for (index_type k = 0; k < neg_atoms.length(); k++) {
+      Instance::Atom* p = neg_atoms[k]->find_prop(ins, false, true);
+      s_del.insert(p->index);
+      if (neg_atoms[k]->pred->neg_pre) {
+ Instance::Atom* np = neg_atoms[k]->find_prop(ins, true, true);
+ s_add.insert(np->index);
+      }
+    }
+  }
+}
+void PDDL_Base::SetOf::instantiate_as_effect
+(Instance& ins, index_set& s_add, index_set& s_del)
+{
+  if (!context_is_static()) {
+    std::cerr << "error: expression ";
+    print(std::cerr);
+    std::cerr << " has non-static context" << std::endl;
+    exit(255);
+  }
+  for (index_type k = 0; k < param.length(); k++) param[k]->value = 0;
+  build_effect(ins, s_add, s_del, 0);
+}
+void PDDL_Base::SetOf::build_conditional
+(Instance& ins, rule_set& s_pos, rule_set& s_neg, index_type p)
+{
+  if (p < param.length()) {
+    for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+      param[p]->value = param[p]->sym_types.get_element(k);
+      if (Context::partial_eval() != p_false) {
+ build_conditional(ins, s_pos, s_neg, p + 1);
+      }
+    }
+    param[p]->value = 0;
+  }
+  else {
+    if (param.length() == 0) {
+      if (!is_true()) return;
+    }
+    index_set ant;
+    for (index_type k = 0; k < pos_con.length(); k++)
+      if (!pos_con[k]->is_static()) {
+ Instance::Atom* p = pos_con[k]->find_prop(ins, false, true);
+ Instance::Atom* neg_p = pos_con[k]->find_prop(ins, true, true);
+ ant.insert(p->index);
+      }
+    for (index_type k = 0; k < neg_con.length(); k++)
+      if (!neg_con[k]->is_static()) {
+ Instance::Atom* p = neg_con[k]->find_prop(ins, false, true);
+ Instance::Atom* neg_p = neg_con[k]->find_prop(ins, true, true);
+ ant.insert(neg_p->index);
+      }
+    for (index_type k = 0; k < pos_atoms.length(); k++) {
+      Instance::Atom* q = pos_atoms[k]->find_prop(ins, false, true);
+      if (pos_atoms[k]->pred->neg_pre) {
+ Instance::Atom* not_q = pos_atoms[k]->find_prop(ins, true, true);
+      }
+      rule& r = s_pos.append();
+      r.antecedent = ant;
+      r.consequent = q->index;
+    }
+    for (index_type k = 0; k < neg_atoms.length(); k++) {
+      Instance::Atom* q = neg_atoms[k]->find_prop(ins, false, true);
+      if (pos_atoms[k]->pred->neg_pre) {
+ Instance::Atom* not_q = neg_atoms[k]->find_prop(ins, true, true);
+      }
+      rule& r = s_neg.append();
+      r.antecedent = ant;
+      r.consequent = q->index;
+    }
+  }
+}
+void PDDL_Base::SetOf::instantiate_conditional
+(Instance& ins, rule_set& s_pos, rule_set& s_neg)
+{
+  for (index_type k = 0; k < param.length(); k++) param[k]->value = 0;
+  build_conditional(ins, s_pos, s_neg, 0);
+}
+PDDL_Base::SetOf* PDDL_Base::SetOf::instantiate_partially()
+{
+  SetOf* s = new SetOf();
+  s->param = param;
+  for (index_type k = 0; k < pos_con.length(); k++)
+    s->pos_con.append(pos_con[k]->instantiate_partially());
+  for (index_type k = 0; k < neg_con.length(); k++)
+    s->neg_con.append(neg_con[k]->instantiate_partially());
+  for (index_type k = 0; k < type_con.length(); k++)
+    if (type_con[k]->var->value == 0)
+      s->type_con.append(type_con[k]);
+  for (index_type k = 0; k < pos_atoms.length(); k++)
+    s->pos_atoms.append(pos_atoms[k]->instantiate_partially());
+  for (index_type k = 0; k < neg_atoms.length(); k++)
+    s->neg_atoms.append(neg_atoms[k]->instantiate_partially());
+  return s;
+}
+void PDDL_Base::SetOf::compile
+(atom_vec& pos_ins, atom_vec& neg_ins, index_type p)
+{
+  if (p < param.length()) {
+    for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+      param[p]->value = param[p]->sym_types.get_element(k);
+      if (Context::partial_eval() != p_false) {
+ compile(pos_ins, neg_ins, p + 1);
+      }
+    }
+    param[p]->value = 0;
+  }
+  else {
+    assert(context_is_static());
+    if (is_true()) {
+      for (index_type k = 0; k < pos_atoms.length(); k++)
+ pos_ins.append(pos_atoms[k]->instantiate_partially());
+      for (index_type k = 0; k < neg_atoms.length(); k++)
+ neg_ins.append(neg_atoms[k]->instantiate_partially());
+    }
+  }
+}
+void PDDL_Base::SetOf::compile_non_static
+(atom_set_vec& ins, index_type p)
+{
+  if (p < param.length()) {
+    for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+      param[p]->value = param[p]->sym_types.get_element(k);
+      if (Context::partial_eval() != p_false) {
+ compile_non_static(ins, p + 1);
+      }
+    }
+    param[p]->value = 0;
+  }
+  else if (is_true()) {
+    SetOf* d = new SetOf();
+    for (index_type k = 0; k < pos_con.length(); k++)
+      d->neg_atoms.append(pos_con[k]->instantiate_partially());
+    for (index_type k = 0; k < neg_con.length(); k++)
+      d->pos_atoms.append(neg_con[k]->instantiate_partially());
+    for (index_type k = 0; k < pos_atoms.length(); k++)
+      d->pos_atoms.append(pos_atoms[k]->instantiate_partially());
+    for (index_type k = 0; k < neg_atoms.length(); k++)
+      d->neg_atoms.append(neg_atoms[k]->instantiate_partially());
+    ins.append(d);
+  }
+}
+void PDDL_Base::SetConstraint::build(Instance& ins, index_type p)
+{
+  if (p < param.length()) {
+    for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+      param[p]->value = param[p]->sym_types.get_element(k);
+      if (Context::partial_eval() != p_false) build(ins, p+1);
+    }
+    param[p]->value = 0;
+  }
+  else {
+    index_set c_set;
+    for (index_type k = 0; k < atom_sets.length(); k++) {
+      atom_sets[k]->instantiate_as_set(ins, c_set);
+    }
+    for (index_type k = 0; k < pos_atoms.length(); k++) {
+      Instance::Atom* p = pos_atoms[k]->find_prop(ins, false, true);
+      c_set.insert(p->index);
+    }
+    for (index_type k = 0; k < neg_atoms.length(); k++) {
+      Instance::Atom* p = neg_atoms[k]->find_prop(ins, true, true);
+      c_set.insert(p->index);
+    }
+    if (c_set.empty()) {
+      if (write_warnings) {
+ std::cerr << "warning: ignoring" << std::endl;
+ AtomBase::print_bindings = true;
+ print(std::cerr);
+ AtomBase::print_bindings = false;
+ std::cerr << "because atom set is empty" << std::endl;
+      }
+      return;
+    }
+    Instance::Constraint& c =
+      ins.new_invariant(c_set, sc_count, (sc_type == sc_exactly));
+    if (!c.src) {
+      c.src = this;
+    }
+    if (name && !c.name) {
+      c.name = new PDDL_Name(name, param, false);
+    }
+  }
+}
+void PDDL_Base::SetConstraint::instantiate(Instance& ins)
+{
+  if (sc_type == sc_at_least) {
+    if (write_warnings)
+      std::cerr << "warning: skipping :at-least-n invariant" << std::endl;
+    return;
+  }
+  if (!included) return;
+  if (!context_is_static()) {
+    if (write_warnings)
+      std::cerr << "warning: skipping invariant with non-static context"
+  << std::endl;
+    return;
+  }
+  bool any_static = false;
+  for (index_type k = 0; k < pos_atoms.length(); k++)
+    if (pos_atoms[k]->is_static()) any_static = true;
+  for (index_type k = 0; k < neg_atoms.length(); k++)
+    if (neg_atoms[k]->is_static()) any_static = true;
+  for (index_type k = 0; k < atom_sets.length(); k++)
+    if (atom_sets[k]->is_static()) any_static = true;
+  if (any_static) {
+    if (write_warnings)
+      std::cerr << "warning: skipping invariant with static atoms"
+  << std::endl;
+    return;
+  }
+  for (index_type k = 0; k < param.length(); k++) param[k]->value = 0;
+  build(ins, 0);
+}
+void PDDL_Base::instantiate(Instance& ins)
+{
+  if (!ready_to_instantiate) post_process();
+  for (index_type k = 0; k < dom_constants.length(); k++) {
+    Atom* a = new Atom(dom_eq_pred);
+    a->param.append(dom_constants[k]);
+    a->param.append(dom_constants[k]);
+    a->insert(dom_eq_pred->init);
+  }
+  if (name_instance_by_problem_file) {
+    char* s = problem_file_basename();
+    if (s) {
+      ins.name = new StringName(s);
+    }
+    else {
+      ins.name = new StringName("NONAME");
+    }
+  }
+  else {
+    ins.name = new InstanceName
+      (domain_name ? tab.table_char_map().strdup(domain_name) :
+       tab.table_char_map().strdup("??"),
+       problem_name ? tab.table_char_map().strdup(problem_name) :
+       tab.table_char_map().strdup("??"));
+  }
+  if (instance_name_prefix != 0) {
+    ins.name = new ConcatenatedName(new StringName(instance_name_prefix),
+        ins.name, '-');
+  }
+  for (index_type k = 0; k < dom_sc_invariants.length(); k++) {
+    dom_sc_invariants[k]->included =
+      dom_sc_invariants[k]->item_is_included(excluded_dkel_tags,
+          required_dkel_tags);
+    if (!dom_sc_invariants[k]->included) {
+      if (PDDL_Base::write_info) {
+ std::cerr << "DKEL: excluding DKEL item" << std::endl;
+ dom_sc_invariants[k]->print(std::cerr);
+      }
+    }
+  }
+  for (index_type k = 0; k < dom_irrelevant.length(); k++) {
+    dom_irrelevant[k]->included =
+      dom_irrelevant[k]->item_is_included(excluded_dkel_tags,
+       required_dkel_tags);
+    if (!dom_irrelevant[k]->included) {
+      if (PDDL_Base::write_info) {
+ std::cerr << "DKEL: excluding DKEL item" << std::endl;
+ dom_irrelevant[k]->print(std::cerr);
+      }
+    }
+  }
+  if (create_all_atoms) {
+    for (index_type k = 0; k < dom_predicates.length(); k++)
+      dom_predicates[k]->instantiate(ins);
+  }
+  for (index_type k = 0; k < dom_actions.length(); k++)
+    if (!dom_actions[k]->is_abstract()) {
+      if (metric) {
+ Expression* c_exp = metric->copy();
+ if (c_exp) {
+   if (metric_type == metric_maximize) {
+     c_exp = new BinaryExpression(exp_mul, c_exp,
+      new ConstantExpression(-1));
+   }
+   if (dom_actions[k]->dmax) {
+     c_exp->substitute_for_time(dom_actions[k]->dmax);
+   }
+   else if (dom_actions[k]->dmin) {
+     c_exp->substitute_for_time(dom_actions[k]->dmin);
+   }
+   else {
+     c_exp->substitute_for_time(new ConstantExpression(1));
+   }
+ }
+ dom_actions[k]->instantiate(ins, c_exp);
+      }
+      else {
+ dom_actions[k]->instantiate(ins, 0);
+      }
+    }
+  for (index_type k = 0; k < ins.n_actions(); k++) {
+    ins.actions[k].use.inc_length_to(ins.n_resources(), 0);
+    ins.actions[k].cons.inc_length_to(ins.n_resources(), 0);
+  }
+  for (index_type k = 0; k < dom_goals.length(); k++) {
+    if (dom_goals[k]->is_propositional()) {
+      dom_goals[k]->instantiate(ins, POS_INF);
+    }
+    else if (write_warnings || !best_effort) {
+      std::cerr << "warning: goal ";
+      print(std::cerr);
+      std::cerr << " ignored in instantiation" << std::endl;
+      if (!best_effort) exit(1);
+    }
+  }
+  for (index_type k = 0; k < dom_sc_invariants.length(); k++)
+    dom_sc_invariants[k]->instantiate(ins);
+}
+void PDDL_Base::instantiate_atom_set
+(Instance& ins, atom_vec& a, index_set& s)
+{
+  for (index_type k = 0; k < a.length(); k++) {
+    Instance::Atom* p = a[k]->find_prop(ins, false, true);
+    s.insert(p->index);
+  }
+}
+void PDDL_Base::Goal::instantiate(Instance& ins, hsps::rational deadline)
+{
+  if (g_class == goal_pos_atom) {
+    Instance::Atom* p = ((AtomicGoal*)this)->atom->find_prop(ins, false, true);
+    p->goal = true;
+    p->goal_t = deadline;
+  }
+  else if (g_class == goal_neg_atom) {
+    Instance::Atom* p = ((AtomicGoal*)this)->atom->find_prop(ins, true, true);
+    p->goal = true;
+    p->goal_t = deadline;
+  }
+  else if (g_class == goal_conjunction) {
+    ConjunctiveGoal* g = (ConjunctiveGoal*)this;
+    for (index_type k = 0; k < g->goals.length(); k++)
+      g->goals[k]->instantiate(ins, deadline);
+  }
+  else if (g_class == goal_within) {
+    DeadlineGoal* g = (DeadlineGoal*)this;
+    g->goal->instantiate(ins, g->at);
+  }
+  else if ((g_class == goal_always) && compile_away_plan_constraints) {
+    index_set a;
+    ((SimpleSequenceGoal*)this)->constraint->instantiate(ins, a, 0, 0);
+    ins.compile_pc_always(a, 0);
+  }
+  else if ((g_class == goal_sometime) && compile_away_plan_constraints) {
+    index_set a;
+    ((SimpleSequenceGoal*)this)->constraint->instantiate(ins, a, 0, 0);
+    ins.compile_pc_sometime(a, 0);
+  }
+  else if ((g_class == goal_at_most_once) && compile_away_plan_constraints) {
+    index_set a;
+    ((SimpleSequenceGoal*)this)->constraint->instantiate(ins, a, 0, 0);
+    ins.compile_pc_at_most_once(a, 0);
+  }
+  else if ((g_class == goal_sometime_before) && compile_away_plan_constraints) {
+    index_set a;
+    ((TriggeredSequenceGoal*)this)->trigger->instantiate(ins, a, 0, 0);
+    index_set b;
+    ((TriggeredSequenceGoal*)this)->constraint->instantiate(ins, b, 0, 0);
+    ins.compile_pc_sometime_before(a, b, 0);
+  }
+  else if (write_warnings || !best_effort) {
+    std::cerr << "warning: goal ";
+    print(std::cerr);
+    std::cerr << " ignored in instantiation (1)" << std::endl;
+    if (!best_effort) exit(1);
+  }
+}
+void PDDL_Base::Goal::instantiate
+(Instance& ins, index_set& set, Symbol* p, index_type i)
+{
+  if (g_class == goal_pos_atom) {
+    Instance::Atom* p = ((AtomicGoal*)this)->atom->find_prop(ins, false, true);
+    set.insert(p->index);
+  }
+  else if (g_class == goal_neg_atom) {
+    Instance::Atom* p = ((AtomicGoal*)this)->atom->find_prop(ins, true, true);
+    set.insert(p->index);
+  }
+  else if (g_class == goal_conjunction) {
+    ConjunctiveGoal* g = (ConjunctiveGoal*)this;
+    for (index_type k = 0; k < g->goals.length(); k++)
+      g->goals[k]->instantiate(ins, set, p, k);
+  }
+  else if ((g_class == goal_always) && compile_away_plan_constraints) {
+    index_set a;
+    ((SimpleSequenceGoal*)this)->constraint->instantiate(ins, a, p, i);
+    Name* n = (p ? (i != no_such_index ?
+      (Name*)new EnumName(p->print_name, i) :
+      (Name*)new StringName(p->print_name)) :
+        (Name*)0);
+    set.insert(ins.compile_pc_always(a, n));
+  }
+  else if ((g_class == goal_sometime) && compile_away_plan_constraints) {
+    index_set a;
+    ((SimpleSequenceGoal*)this)->constraint->instantiate(ins, a, p, i);
+    Name* n = (p ? (i != no_such_index ?
+      (Name*)new EnumName(p->print_name, i) :
+      (Name*)new StringName(p->print_name)) :
+        (Name*)0);
+    set.insert(ins.compile_pc_sometime(a, n));
+  }
+  else if ((g_class == goal_at_most_once) && compile_away_plan_constraints) {
+    index_set a;
+    ((SimpleSequenceGoal*)this)->constraint->instantiate(ins, a, p, i);
+    Name* n = (p ? (i != no_such_index ?
+      (Name*)new EnumName(p->print_name, i) :
+      (Name*)new StringName(p->print_name)) :
+        (Name*)0);
+    set.insert(ins.compile_pc_at_most_once(a, n));
+  }
+  else if ((g_class == goal_sometime_before) && compile_away_plan_constraints) {
+    index_set a;
+    ((TriggeredSequenceGoal*)this)->trigger->instantiate(ins, a, p, i);
+    index_set b;
+    ((TriggeredSequenceGoal*)this)->constraint->instantiate(ins, b, p, i);
+    Name* n = (p ? (i != no_such_index ?
+      (Name*)new EnumName(p->print_name, i) :
+      (Name*)new StringName(p->print_name)) :
+        (Name*)0);
+    set.insert(ins.compile_pc_sometime_before(a, b, n));
+  }
+  else if (write_warnings || !best_effort) {
+    std::cerr << "warning: goal ";
+    print(std::cerr);
+    std::cerr << " ignored in instantiation (2)" << std::endl;
+    if (!best_effort) exit(1);
+  }
+}
+hsps::rational PDDL_Base::Preference::value(metric_class metric_type, Expression* m)
+{
+  assert(m);
+  hsps::rational b = m->eval_delta(0, 0, 1);
+  hsps::rational d = m->eval_delta(name, 0, 1);
+  return (metric_type == metric_minimize ? -1 : 1) * (d - b);
+}
+void PDDL_Base::Preference::instantiate
+(SoftInstance& ins, metric_class metric_type, Expression* m)
+{
+  SoftInstance::SoftGoal& g = ins.new_soft_goal();
+  g.name = new StringName(name->print_name, true);
+  g.src = this;
+  goal->instantiate(ins, g.atoms, name, no_such_index);
+  for (index_type k = 0; k < g.atoms.length(); k++)
+    ins.atoms[g.atoms[k]].goal = true;
+  g.weight = (m ? value(metric_type, m) : 1);
+}
+void PDDL_Base::instantiate_soft(SoftInstance& ins)
+{
+  for (index_type k = 0; k < ins.n_atoms(); k++)
+    if (ins.atoms[k].goal) ins.hard.insert(k);
+  for (index_type k = 0; k < dom_preferences.length(); k++) {
+    if (dom_preferences[k]->is_propositional()) {
+      dom_preferences[k]->instantiate(ins, metric_type, metric);
+    }
+    else if (write_warnings || !best_effort) {
+      std::cerr << "warning: non-propositional soft goal ";
+      dom_preferences[k]->print(std::cerr);
+      std::cerr << " ignored" << std::endl;
+      if (!best_effort) exit(1);
+    }
+  }
+  if (metric) {
+    ins.null_value =
+      (metric_type == metric_minimize ? -1 : 1) * metric->eval_delta(0, 0, 1);
+  }
+}
+bool PDDL_Base::InputPlan::export_to_instance
+(Instance& ins, const index_vec& map, Plan& p)
+{
+  if (steps.length() == 0) {
+    p.end();
+    return true;
+  }
+  InputPlanStep* sorted[steps.length() + 1];
+  for (index_type k = 0; k < steps.length(); k++) {
+    if (steps[k]->act->index.empty()) {
+      std::cerr << "error (export plan): action ";
+      steps[k]->act->print(std::cerr);
+      std::cerr << " does not exist in instance!" << std::endl;
+      exit(255);
+    }
+    index_type i = 0;
+    bool found = false;
+    while ((i < k) && !found) {
+      if (sorted[i]->start_time > steps[k]->start_time) {
+ for (index_type j = k - 1; j >= i; j--) sorted[j+1] = sorted[j];
+ sorted[i] = steps[k];
+ found = true;
+      }
+      else {
+ i += 1;
+      }
+    }
+    if (!found) {
+      sorted[k] = steps[k];
+    }
+  }
+  for (index_type k = 0; k < steps.length(); k++) {
+    if (sorted[k]->act->index.empty()) {
+      std::cerr << "warning (export plan): no action ";
+      sorted[k]->act->print(std::cerr);
+      std::cerr << " in instance" << std::endl;
+      return false;
+    }
+    if (sorted[k]->act->index.length() > 1) {
+      std::cerr << "warning (export plan): reference to action ";
+      sorted[k]->act->print(std::cerr);
+      std::cerr << " is ambiguous" << std::endl;
+      return false;
+    }
+    index_type i0 = sorted[k]->act->index[0];
+    if (i0 > map.length()) {
+      std::cerr << "error (export plan): action ";
+      sorted[k]->act->print(std::cerr);
+      std::cerr << " has invalid index " << sorted[k]->act->index
+  << std::endl;
+      exit(255);
+    }
+    index_type new_index = map[i0];
+    if (new_index == no_such_index) {
+      std::cerr << "warning (export plan): action ";
+      sorted[k]->act->print(std::cerr);
+      std::cerr << " has been removed" << std::endl;
+      return false;
+    }
+    p.insert(new_index);
+    if (k < steps.length() - 1) {
+      p.advance(sorted[k + 1]->start_time - sorted[k]->start_time);
+    }
+    else {
+      p.end();
+    }
+  }
+  return true;
+}
+bool PDDL_Base::export_plan
+(index_type i, Instance& ins, const index_vec& map, Plan& p)
+{
+  if (input_plans.length() <= i) {
+    std::cerr << "error: can't export plan " << i << " since there are only "
+       << input_plans.length() << " plans in input" << std::endl;
+    exit(255);
+  }
+  bool ok = input_plans[i]->export_to_instance(ins, map, p);
+  if (!ok) return false;
+  if (input_plans[i]->name)
+    p.set_name(new StringName(input_plans[i]->name->print_name, true));
+  p.set_optimal(input_plans[i]->is_opt);
+  return true;
+}
+bool PDDL_Base::export_plan
+(index_type i, Instance& ins, Plan& p)
+{
+  if (input_plans.length() <= i) {
+    std::cerr << "error: can't export plan " << i << " since there are only "
+       << input_plans.length() << " plans in input" << std::endl;
+    exit(255);
+  }
+  index_vec map(no_such_index, ins.n_actions());
+  for (index_type k = 0; k < ins.n_actions(); k++) map[k] = k;
+  bool ok = input_plans[i]->export_to_instance(ins, map, p);
+  if (!ok) return false;
+  if (input_plans[i]->name)
+    p.set_name(new StringName(input_plans[i]->name->print_name, true));
+  p.set_optimal(input_plans[i]->is_opt);
+  return true;
+}
+void PDDL_Base::export_heuristic
+(Instance& ins, const index_vec& atom_map, bool opt_maximize, Heuristic& h)
+{
+  for (index_type k = 0; k < h_table.length(); k++) {
+    index_set s;
+    for (index_type i = 0; i < h_table[k]->atoms.length(); i++) {
+      Instance::Atom* a =
+ h_table[k]->atoms[i]->find_prop(ins, h_table[k]->neg[i], false);
+      if (!a) {
+ std::cerr << "error (export heuristic): atom ";
+ h_table[k]->atoms[i]->print(std::cerr);
+ std::cerr << " does not exist in instance" << std::endl;
+ exit(255);
+      }
+      s.insert(a->index);
+    }
+    index_type l = s.length();
+    ins.remap_set(s, atom_map);
+    if (s.length() != l) {
+      std::cerr << "warning: set ";
+      ins.write_atom_set(std::cerr, s);
+      std::cerr << " shrunk in remap, ignoring it" << std::endl;
+    }
+    else {
+      if (opt_maximize) {
+ hsps::rational v = h.eval(s);
+ if (v < h_table[k]->cost) {
+   if (write_info) {
+     std::cerr << "info: storing ";
+     ins.write_atom_set(std::cerr, s);
+     std::cerr << " = " << v << std::endl;
+   }
+   h.store(s, h_table[k]->cost, h_table[k]->opt);
+ }
+      }
+      else {
+ h.store(s, h_table[k]->cost, h_table[k]->opt);
+      }
+    }
+  }
+}
+bool PDDL_Base::SimpleReferenceSet::build
+(const name_vec& names, index_set& set, index_type p)
+{
+  if (p < param.length()) {
+    for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+      param[p]->value = param[p]->sym_types.get_element(k);
+      if (Context::partial_eval() != p_false) {
+ bool ok = build(names, set, p + 1);
+ if (!ok && PDDL_Base::strict_set_export) return false;
+      }
+    }
+    param[p]->value = 0;
+    return true;
+  }
+  else if (is_true()) {
+    index_set m;
+    ref->find(names, m);
+    if (m.empty() && PDDL_Base::strict_set_export) {
+      return false;
+    }
+    if ((m.length() > 1) && !PDDL_Base::strict_set_export) {
+      return false;
+    }
+    if (write_info) {
+      std::cerr << "info: reference ";
+      print(std::cerr);
+      std::cerr << " with binding ";
+      print_assignment(std::cerr);
+      std::cerr << " matched to {";
+      for (index_type k = 0; k < m.length(); k++) {
+ if (k > 0) std::cerr << ", ";
+ std::cerr << m[k] << "." << names[m[k]];
+      }
+      std::cerr << "}" << std::endl;
+    }
+    set.insert(m);
+    return true;
+  }
+}
+void PDDL_Base::ReferenceSet::build
+(const name_vec& names, index_set_vec& sets, index_type p)
+{
+  if (p < param.length()) {
+    for (index_type k = 0; k < param[p]->sym_types.n_elements(); k++) {
+      param[p]->value = param[p]->sym_types.get_element(k);
+      if (Context::partial_eval() != p_false) {
+ build(names, sets, p + 1);
+      }
+    }
+    param[p]->value = 0;
+  }
+  else if (is_true()) {
+    index_set s;
+    bool all_ok = true;
+    for (index_type k = 0; (k < refs.length()) && all_ok; k++) {
+      bool ok = refs[k]->build(names, s, 0);
+      if (!ok && write_warnings) {
+ std::cerr << "warning: failed to build instance ";
+ print_assignment(std::cerr);
+ std::cerr << " of ";
+ print(std::cerr);
+ std::cerr << std::endl;
+      }
+      all_ok = (all_ok && ok);
+    }
+    if (all_ok) sets.append(s);
+  }
+}
+void PDDL_Base::export_sets(const name_vec& names, index_set_vec& sets)
+{
+  for (index_type k = 0; k < input_sets.length(); k++) {
+    input_sets[k]->build(names, sets, 0);
+  }
+}
+void PDDL_Base::export_action_partitions(name_vec& names, index_set_vec& sets)
+{
+  names.clear();
+  sets.clear();
+  for (index_type k = 0; k < partitions.length(); k++) {
+    SetSymbol* s = partitions[k];
+    assert(s->sets.length() == s->names.length());
+    for (index_type i = 0; i < s->sets.length(); i++) {
+      names.append(s->names[i]);
+      sets.append(*(s->sets[i]));
+    }
+  }
+}
+bool PDDL_Base::DKEL_Item::item_is_included
+(string_set& ex_tags, string_set& req_tags)
+{
+  if (exclude_all_dkel_items) return false;
+  for (index_type k = 0; k < item_tags.length(); k++) {
+    if (ex_tags.contains(item_tags[k])) {
+      return false;
+    }
+  }
+  for (index_type k = 0; k < req_tags.length(); k++) {
+    if (!item_tags.contains(req_tags[k])) {
+      return false;
+    }
+  }
+  return true;
+}
+void PDDL_Base::lift_DKEL_Items(const Instance& ins)
+{
+  for (index_type k = 0; k < ins.n_invariants(); k++)
+    if (ins.invariants[k].src == 0) {
+      SetConstraint* c = new SetConstraint();
+      for (index_type i = 0; i < ins.invariants[k].set.length(); i++) {
+ ptr_pair* p = (ptr_pair*)ins.atoms[ins.invariants[k].set[i]].src;
+ assert(p);
+ bool n;
+ Atom* a = make_atom_from_prop(*p, n);
+ if (!n) {
+   c->pos_atoms.append(a);
+ }
+ else {
+   c->neg_atoms.append(a);
+ }
+      }
+      if (ins.invariants[k].exact) {
+ c->sc_type = sc_exactly;
+      }
+      else {
+ c->sc_type = sc_at_most;
+      }
+      c->sc_count = ins.invariants[k].lim;
+      if (ins.invariants[k].verified) {
+ c->item_tags.append((char*)"verified");
+      }
+      c->defined_in_problem = true;
+      dom_sc_invariants.append(c);
+    }
+}
+PDDL_Base::PredicateSymbol*
+PDDL_Base::find_type_predicate(Symbol* type_sym)
+{
+  for (index_type k = 0; k < dom_predicates.length(); k++)
+    if (dom_predicates[k]->print_name == type_sym->print_name)
+      return dom_predicates[k];
+  std::cerr << "error: no type predicate found for type "
+     << type_sym->print_name << std::endl;
+  exit(255);
+}
+void PDDL_Base::Formula::untype(PDDL_Base* base)
+{
+  switch (fc) {
+  case fc_false:
+  case fc_true:
+  case fc_atom:
+  case fc_equality:
+    return;
+  case fc_negation:
+    ((NFormula*)this)->f->untype(base);
+    return;
+  case fc_conjunction:
+  case fc_disjunction:
+    for (index_type k = 0; k < ((CFormula*)this)->parts.length(); k++) {
+      ((CFormula*)this)->parts[k]->untype(base);
+    }
+    return;
+  case fc_implication:
+  case fc_equivalence:
+    ((BFormula*)this)->f1->untype(base);
+    ((BFormula*)this)->f2->untype(base);
+    return;
+  case fc_universal:
+    {
+      QFormula* qf = (QFormula*)this;
+      CFormula* df = new CFormula(fc_disjunction);
+      for (index_type k = 0; k < qf->vars.length(); k++) {
+ if (qf->vars[k]->sym_types.length() == 1) {
+   if (qf->vars[k]->sym_types[0] != base->dom_top_type) {
+     PredicateSymbol* type_pred =
+       base->find_type_predicate(qf->vars[k]->sym_types[0]);
+     AFormula* type_atom = new AFormula(type_pred);
+     type_atom->param.append(qf->vars[k]);
+     df->add(new NFormula(type_atom));
+   }
+   qf->vars[k]->sym_types.clear();
+ }
+ else if (qf->vars[k]->sym_types.length() > 1) {
+   CFormula* ddf = new CFormula(fc_disjunction);
+   for (index_type i = 0; i < qf->vars[k]->sym_types.length(); i++) {
+     if (qf->vars[k]->sym_types[i] != base->dom_top_type) {
+       PredicateSymbol* type_pred =
+  base->find_type_predicate(qf->vars[k]->sym_types[i]);
+       AFormula* type_atom = new AFormula(type_pred);
+       type_atom->param.append(qf->vars[k]);
+       ddf->add(type_atom);
+     }
+   }
+   df->add(new NFormula(ddf));
+   qf->vars[k]->sym_types.clear();
+ }
+      }
+      qf->f->untype(base);
+      df->add(qf->f);
+      qf->f = df;
+      return;
+    }
+  case fc_existential:
+    {
+      QFormula* qf = (QFormula*)this;
+      CFormula* cf = new CFormula(fc_conjunction);
+      for (index_type k = 0; k < qf->vars.length(); k++) {
+ if (qf->vars[k]->sym_types.length() == 1) {
+   if (qf->vars[k]->sym_types[0] != base->dom_top_type) {
+     PredicateSymbol* type_pred =
+       base->find_type_predicate(qf->vars[k]->sym_types[0]);
+     AFormula* type_atom = new AFormula(type_pred);
+     type_atom->param.append(qf->vars[k]);
+     cf->add(type_atom);
+   }
+   qf->vars[k]->sym_types.clear();
+ }
+ else if (qf->vars[k]->sym_types.length() > 1) {
+   CFormula* ddf = new CFormula(fc_disjunction);
+   for (index_type i = 0; i < qf->vars[k]->sym_types.length(); i++) {
+     if (qf->vars[k]->sym_types[i] != base->dom_top_type) {
+       PredicateSymbol* type_pred =
+  base->find_type_predicate(qf->vars[k]->sym_types[i]);
+       AFormula* type_atom = new AFormula(type_pred);
+       type_atom->param.append(qf->vars[k]);
+       ddf->add(type_atom);
+     }
+   }
+   cf->add(ddf);
+   qf->vars[k]->sym_types.clear();
+ }
+      }
+      qf->f->untype(base);
+      cf->add(qf->f);
+      qf->f = cf;
+      return;
+    }
+  }
+}
+void PDDL_Base::Context::untype(PDDL_Base* base)
+{
+  for (index_type k = 0; k < param.length(); k++) {
+    if (param[k]->sym_types.length() == 1) {
+      if (param[k]->sym_types[0] != base->dom_top_type) {
+ PredicateSymbol* type_pred =
+   base->find_type_predicate(param[k]->sym_types[0]);
+ Atom* type_atom = new Atom(type_pred);
+ type_atom->param.append(param[k]);
+ pos_con.append(type_atom);
+      }
+      param[k]->sym_types.clear();
+    }
+    else if (param[k]->sym_types.length() > 1) {
+      std::cerr << "error: can't untype ";
+      param[k]->print(std::cerr);
+      std::cerr << " in ";
+      print(std::cerr);
+      std::cerr << std::endl;
+      exit(255);
+    }
+  }
+}
+void PDDL_Base::SetConstraint::untype(PDDL_Base* base)
+{
+  PDDL_Base::Context::untype(base);
+  for (index_type k = 0; k < atom_sets.length(); k++)
+    atom_sets[k]->untype(base);
+}
+void PDDL_Base::InvariantFormula::untype(PDDL_Base* base)
+{
+  PDDL_Base::Context::untype(base);
+  f->untype(base);
+}
+void PDDL_Base::ActionSymbol::untype(PDDL_Base* base)
+{
+  for (index_type k = 0; k < param.length(); k++) {
+    if (param[k]->sym_types.length() == 1) {
+      if (param[k]->sym_types[0] != base->dom_top_type) {
+ PredicateSymbol* type_pred =
+   base->find_type_predicate(param[k]->sym_types[0]);
+ Atom* type_atom = new Atom(type_pred);
+ type_atom->param.append(param[k]);
+ pos_pre.append(type_atom);
+      }
+      param[k]->sym_types.clear();
+    }
+    else if (param[k]->sym_types.length() > 1) {
+      SetOf* d = new SetOf();
+      for (index_type i = 0; i < param[k]->sym_types.length(); i++)
+ if (param[k]->sym_types[i] != base->dom_top_type) {
+   PredicateSymbol* type_pred =
+     base->find_type_predicate(param[k]->sym_types[i]);
+   Atom* type_atom = new Atom(type_pred);
+   type_atom->param.append(param[k]);
+   d->pos_atoms.append(type_atom);
+ }
+      dis_pre.append(d);
+      param[k]->sym_types.clear();
+    }
+  }
+  for (index_type k = 0; k < set_pre.length(); k++) set_pre[k]->untype(base);
+  for (index_type k = 0; k < set_eff.length(); k++) set_eff[k]->untype(base);
+  for (index_type k = 0; k < cond_eff.length(); k++) cond_eff[k]->untype(base);
+}
+void PDDL_Base::untype()
+{
+  StringTable::Cell* var_x = tab.inserta("?X");
+  for (index_type k = 0; k < dom_types.length(); k++) {
+    PredicateSymbol* type_pred =
+      new PredicateSymbol(dom_types[k]->print_name);
+    type_pred->param.append(new VariableSymbol(var_x->text));
+    type_pred->pos_pre = true;
+    dom_predicates.append(type_pred);
+    for (index_type i = 0; i < dom_types[k]->elements.length(); i++) {
+      Atom* a = new Atom(type_pred);
+      a->param.append(dom_types[k]->elements[i]);
+      a->insert(type_pred->init);
+      dom_init.append(a);
+    }
+  }
+  for (index_type k = 0; k < dom_predicates.length(); k++) {
+    PredicateSymbol* pred = dom_predicates[k];
+    for (index_type i = 0; i < pred->param.length(); i++)
+      pred->param[i]->sym_types.clear();
+  }
+  for (index_type k = 0; k < dom_functions.length(); k++) {
+    FunctionSymbol* fun = dom_functions[k];
+    for (index_type i = 0; i < fun->param.length(); i++)
+      fun->param[i]->sym_types.clear();
+  }
+  for (index_type k = 0; k < dom_constants.length(); k++) {
+    dom_constants[k]->sym_types.clear();
+  }
+  for (index_type k = 0; k < dom_actions.length(); k++)
+    dom_actions[k]->untype(this);
+  for (index_type k = 0; k < dom_sc_invariants.length(); k++)
+    dom_sc_invariants[k]->untype(this);
+  for (index_type k = 0; k < dom_f_invariants.length(); k++)
+    dom_f_invariants[k]->untype(this);
+  for (index_type k = 0; k < dom_irrelevant.length(); k++)
+    dom_irrelevant[k]->untype(this);
+  dom_types.clear();
+}
+bool PDDL_Base::Goal::is_state()
+{
+  switch (g_class) {
+  case goal_pos_atom:
+  case goal_neg_atom:
+  case goal_relation:
+    return true;
+  case goal_conjunction:
+  case goal_disjunction:
+    {
+      ConjunctiveGoal* cg = (ConjunctiveGoal*)this;
+      for (index_type k = 0; k < cg->goals.length(); k++)
+ if (!cg->goals[k]->is_state()) return false;
+      return true;
+    }
+  case goal_forall:
+  case goal_exists:
+    {
+      QuantifiedGoal* qg = (QuantifiedGoal*)this;
+      return qg->goal->is_state();
+    }
+  case goal_task:
+  case goal_always:
+  case goal_sometime:
+  case goal_at_most_once:
+  case goal_within:
+  case goal_always_within:
+  case goal_sometime_before:
+  case goal_sometime_after:
+    return false;
+  default:
+    std::cerr << "error: invalid goal class (" << g_class << ")" << std::endl;
+    exit(255);
+  }
+}
+bool PDDL_Base::Goal::is_propositional()
+{
+  switch (g_class) {
+  case goal_pos_atom:
+  case goal_neg_atom:
+    return true;
+  case goal_conjunction:
+  case goal_disjunction:
+    {
+      ConjunctiveGoal* cg = (ConjunctiveGoal*)this;
+      for (index_type k = 0; k < cg->goals.length(); k++)
+ if (!cg->goals[k]->is_propositional()) return false;
+      return true;
+    }
+  case goal_forall:
+  case goal_exists:
+    {
+      QuantifiedGoal* qg = (QuantifiedGoal*)this;
+      return qg->goal->is_state();
+    }
+  case goal_relation:
+  case goal_task:
+    return false;
+  case goal_always:
+  case goal_sometime:
+  case goal_at_most_once:
+    return ((SimpleSequenceGoal*)this)->constraint->is_propositional();
+  case goal_within:
+  case goal_always_within:
+    return false;
+  case goal_sometime_before:
+  case goal_sometime_after:
+    return (((TriggeredSequenceGoal*)this)->trigger->is_propositional() &&
+     ((TriggeredSequenceGoal*)this)->constraint->is_propositional());
+  default:
+    std::cerr << "error: invalid goal class (" << g_class << ")" << std::endl;
+    exit(255);
+  }
+}
+bool PDDL_Base::Goal::is_singular()
+{
+  switch (g_class) {
+  case goal_pos_atom:
+  case goal_neg_atom:
+  case goal_relation:
+    return true;
+  case goal_conjunction:
+  case goal_disjunction:
+  case goal_forall:
+  case goal_exists:
+  case goal_task:
+  case goal_always:
+  case goal_sometime:
+  case goal_at_most_once:
+  case goal_within:
+  case goal_always_within:
+  case goal_sometime_before:
+  case goal_sometime_after:
+    return false;
+  default:
+    std::cerr << "error: invalid goal class (" << g_class << ")" << std::endl;
+    exit(255);
+  }
+}
+void PDDL_Base::Goal::print(std::ostream& s)
+{
+  switch (g_class) {
+  case goal_pos_atom:
+  case goal_neg_atom:
+    ((AtomicGoal*)this)->print(s);
+    break;
+  case goal_relation:
+    ((NumericGoal*)this)->print(s);
+    break;
+  case goal_conjunction:
+    ((ConjunctiveGoal*)this)->print(s);
+    break;
+  case goal_disjunction:
+    ((DisjunctiveGoal*)this)->print(s);
+    break;
+  case goal_forall:
+  case goal_exists:
+    ((QuantifiedGoal*)this)->print(s);
+    break;
+  case goal_task:
+    ((TaskGoal*)this)->print(s);
+    break;
+  case goal_always:
+  case goal_sometime:
+  case goal_at_most_once:
+    ((SimpleSequenceGoal*)this)->print(s);
+    break;
+  case goal_within:
+    ((DeadlineGoal*)this)->print(s);
+    break;
+  case goal_always_within:
+    ((TriggeredDeadlineGoal*)this)->print(s);
+    break;
+  case goal_sometime_before:
+  case goal_sometime_after:
+    ((TriggeredSequenceGoal*)this)->print(s);
+    break;
+  default:
+    std::cerr << "error: invalid goal class (" << g_class << ")" << std::endl;
+    exit(255);
+  }
+}
+void PDDL_Base::AtomicGoal::print(std::ostream& s)
+{
+  atom->print(s, (g_class == goal_neg_atom));
+}
+void PDDL_Base::NumericGoal::print(std::ostream& s)
+{
+  rel->print(s, false);
+}
+void PDDL_Base::TaskGoal::print(std::ostream& s)
+{
+  task->print(s);
+}
+void PDDL_Base::ConjunctiveGoal::print(std::ostream& s)
+{
+  if (goals.length() > 1) s << "(and";
+  for (index_type k = 0; k < goals.length(); k++) {
+    s << " ";
+    goals[k]->print(s);
+  }
+  if (goals.length() > 1) s << ")";
+}
+void PDDL_Base::DisjunctiveGoal::print(std::ostream& s)
+{
+  if (goals.length() > 1) s << "(or";
+  for (index_type k = 0; k < goals.length(); k++) {
+    s << " ";
+    goals[k]->print(s);
+  }
+  if (goals.length() > 1) s << ")";
+}
+void PDDL_Base::QuantifiedGoal::print(std::ostream& s)
+{
+  if (g_class == goal_forall) {
+    s << "(forall (";
+  }
+  else if (g_class == goal_exists) {
+    s << "(exists (";
+  }
+  else {
+    std::cerr << "error: invalid goal class " << g_class
+       << " for QuantifiedGoal" << std::endl;
+    exit(255);
+  }
+  bool first = true;
+  for (index_type k = 0; k < param.length(); k++) {
+    if (!first) s << " ";
+    s << param[k]->print_name;
+    param[k]->sym_types.write_type(s);
+    first = false;
+  }
+  s << ")";
+  if (pos_con.length() + neg_con.length() > 0) {
+    if (g_class == goal_forall) {
+      s << "(imply";
+      if (pos_con.length() + neg_con.length() > 1) s << " (and";
+      for (index_type k = 0; k < pos_con.length(); k++) {
+ s << " ";
+ pos_con[k]->print(s);
+      }
+      for (index_type k = 0; k < neg_con.length(); k++) {
+ s << " (not ";
+ neg_con[k]->print(s);
+ s << ")";
+      }
+      if (pos_con.length() + neg_con.length() > 1) s << ")";
+      s << " ";
+      goal->print(s);
+      s << "))";
+    }
+    else {
+      s << "(and";
+      for (index_type k = 0; k < pos_con.length(); k++) {
+ s << " ";
+ pos_con[k]->print(s);
+      }
+      for (index_type k = 0; k < neg_con.length(); k++) {
+ s << " (not ";
+ neg_con[k]->print(s);
+ s << ")";
+      }
+      s << " ";
+      goal->print(s);
+      s << "))";
+    }
+  }
+  else {
+    s << " ";
+    goal->print(s);
+    s << ")";
+  }
+}
+void PDDL_Base::SimpleSequenceGoal::print(std::ostream& s)
+{
+  switch (g_class) {
+  case goal_always:
+    s << "(always ";
+    break;
+  case goal_sometime:
+    s << "(sometime ";
+    break;
+  case goal_at_most_once:
+    s << "(at-most-once ";
+    break;
+  default:
+    std::cerr << "error: invalid goal class " << g_class
+       << " for SimpleSequenceGoal" << std::endl;
+    exit(255);
+  }
+  constraint->print(s);
+  s << ")";
+}
+void PDDL_Base::TriggeredSequenceGoal::print(std::ostream& s)
+{
+  switch (g_class) {
+  case goal_sometime_before:
+    s << "(sometime-before ";
+    break;
+  case goal_sometime_after:
+    s << "(sometime-after ";
+    break;
+  default:
+    std::cerr << "error: invalid goal class " << g_class << " for TriggeredSequenceGoal" << std::endl;
+    exit(255);
+  }
+  trigger->print(s);
+  s << " ";
+  constraint->print(s);
+  s << ")";
+}
+void PDDL_Base::DeadlineGoal::print(std::ostream& s)
+{
+  s << "(within " << std::resetiosflags(std::ios::scientific) << ((at).decimal()) << " ";
+  goal->print(s);
+  s << ")";
+}
+void PDDL_Base::TriggeredDeadlineGoal::print(std::ostream& s)
+{
+  s << "(always-within " << std::resetiosflags(std::ios::scientific) << ((delay).decimal()) << " ";
+  trigger->print(s);
+  s << " ";
+  goal->print(s);
+  s << ")";
+}
+void PDDL_Base::Symbol::print(std::ostream& s) const
+{
+  s << print_name;
+}
+void PDDL_Base::VariableSymbol::print(std::ostream& s)
+{
+  s << print_name;
+  sym_types.write_type(s);
+  if (binding) {
+    s << " :binding ";
+    binding->print(s);
+  }
+}
+void PDDL_Base::TypeSymbol::print(std::ostream& s) const
+{
+  s << "(:type " << print_name;
+  sym_types.write_type(s);
+  s << "):";
+  if (is_base_type) s << " basetype";
+  s << " {";
+  for (index_type k = 0; k < elements.length(); k++) {
+    elements[k]->print(s);
+    if (k < elements.length() - 1) s << ", ";
+  }
+  s << "}" << std::endl;
+}
+void PDDL_Base::PredicateSymbol::print(std::ostream& s)
+{
+  s << "(:predicate " << print_name;
+  for (index_type k = 0; k < param.length(); k++) {
+    s << " ";
+    param[k]->print(s);
+  }
+  s << "):";
+  if (is_static()) s << " static";
+  if (pos_pre) s << " pos prec.";
+  if (neg_pre) s << " neg prec.";
+  if (added) s << " added";
+  if (deleted) s << " deleted";
+  if (locked) s << " locked";
+  index_type c = init.count_values();
+  element_vec* its = init.values();
+  s << " init (" << c << ") = {";
+  for (index_type k = 0; k < its->length(); k++) {
+    if (k > 0) s << ' ';
+    ((PDDL_Base::Atom*)((*its)[k]))->print(s);
+  }
+  delete its;
+  s << "}" << std::endl;
+}
+void PDDL_Base::PredicateSymbol::write_prototype(std::ostream& s)
+{
+  s << "(" << print_name;
+  for (index_type k = 0; k < param.length(); k++) {
+    s << " ";
+    param[k]->print(s);
+  }
+  s << ")";
+}
+void PDDL_Base::ObjectFunctionSymbol::print(std::ostream& s)
+{
+  s << "(:function " << print_name;
+  for (index_type k = 0; k < param.length(); k++) {
+    s << " ";
+    param[k]->print(s);
+  }
+  s << ")";
+  sym_types.write_type(s);
+  s << ": ";
+  if (is_static()) s << " static";
+  index_type c = init.count_values();
+  element_vec* its = init.values();
+  s << " init (" << c << ") = {";
+  for (index_type k = 0; k < its->length(); k++) {
+    if (k > 0) s << ' ';
+    ((PDDL_Base::FInitAtom*)((*its)[k]))->print(s);
+  }
+  delete its;
+  s << "}" << std::endl;
+}
+void PDDL_Base::FunctionSymbol::print(std::ostream& s)
+{
+  s << "(:function " << print_name;
+  for (index_type k = 0; k < param.length(); k++) {
+    s << " ";
+    param[k]->print(s);
+  }
+  s << "):";
+  if (is_static()) s << " static";
+  if (increased) s << " increased";
+  if (decreased) s << " decreased";
+  if (assigned) s << " assigned";
+  if (borrowed) s << " borrowed";
+  if (linear) s << " linear";
+  if (integral) s << " integral";
+  index_type c = init.count_values();
+  element_vec* its = init.values();
+  s << " init (" << c << ") = {";
+  for (index_type k = 0; k < its->length(); k++) {
+    if (k > 0) s << ' ';
+    ((PDDL_Base::FInitAtom*)((*its)[k]))->print(s);
+  }
+  delete its;
+  s << "}" << std::endl;
+}
+void PDDL_Base::Expression::print_sum(std::ostream& s, bool grnd)
+{
+  if (exp_class == exp_add) {
+    BinaryExpression* bexp = (BinaryExpression*)this;
+    bexp->first->print_sum(s, grnd);
+    s << ' ';
+    bexp->second->print_sum(s, grnd);
+  }
+  else {
+    print(s, grnd);
+  }
+}
+void PDDL_Base::Expression::print_product(std::ostream& s, bool grnd)
+{
+  if (exp_class == exp_mul) {
+    BinaryExpression* bexp = (BinaryExpression*)this;
+    bexp->first->print_product(s, grnd);
+    s << ' ';
+    bexp->second->print_product(s, grnd);
+  }
+  else {
+    print(s, grnd);
+  }
+}
+void PDDL_Base::Expression::print(std::ostream& s, bool grnd)
+{
+  switch (exp_class) {
+  case exp_fun:
+    {
+      if (Instance::write_PDDL2) {
+ FunctionExpression* fexp = (FunctionExpression*)this;
+ s << '(' << fexp->fun->print_name;
+ if (fexp->args) fexp->args->print(s, grnd);
+ s << ')';
+      }
+      else {
+ s << "0";
+      }
+    }
+    return;
+  case exp_list:
+    {
+      ListExpression* lexp = (ListExpression*)this;
+      if ((lexp->sym->sym_class == sym_variable) &&
+   (((VariableSymbol*)lexp->sym)->value != 0) &&
+   grnd) {
+ s << ' ' << ((VariableSymbol*)lexp->sym)->value->print_name;
+      }
+      else {
+ s << ' ' << lexp->sym->print_name;
+      }
+      if (lexp->rest) lexp->rest->print(s, grnd);
+    }
+    return;
+  case exp_time:
+    {
+      TimeExpression* texp = (TimeExpression*)this;
+      if (texp->time_exp == 0) {
+ s << "(total-time)";
+      }
+      else {
+ texp->time_exp->print(s, grnd);
+      }
+    }
+    return;
+  case exp_const:
+    {
+      ConstantExpression* cexp = (ConstantExpression*)this;
+      s << std::resetiosflags(std::ios::scientific) << ((cexp->val).decimal());
+    }
+    return;
+  case exp_add:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      s << "(+ ";
+      if (print_nary) {
+ bexp->first->print_sum(s, grnd);
+      }
+      else {
+ bexp->first->print(s, grnd);
+      }
+      s << ' ';
+      if (print_nary) {
+ bexp->second->print_sum(s, grnd);
+      }
+      else {
+ bexp->second->print(s, grnd);
+      }
+      s << ')';
+    }
+    return;
+  case exp_sub:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      s << "(- ";
+      bexp->first->print(s, grnd);
+      s << ' ';
+      bexp->second->print(s, grnd);
+      s << ')';
+    }
+    return;
+  case exp_mul:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      s << "(* ";
+      if (print_nary) {
+ bexp->first->print_product(s, grnd);
+      }
+      else {
+ bexp->first->print(s, grnd);
+      }
+      s << ' ';
+      if (print_nary) {
+ bexp->second->print_product(s, grnd);
+      }
+      else {
+ bexp->second->print(s, grnd);
+      }
+      s << ')';
+    }
+    return;
+  case exp_div:
+    {
+      BinaryExpression* bexp = (BinaryExpression*)this;
+      s << "(/ ";
+      bexp->first->print(s, grnd);
+      s << ' ';
+      bexp->second->print(s, grnd);
+      s << ')';
+    }
+    return;
+  case exp_preference:
+    {
+      if (Instance::write_PDDL3) {
+ PreferenceExpression* pexp = (PreferenceExpression*)this;
+ s << "(is-violated ";
+ pexp->name->print(s);
+ s << ")";
+      }
+      else {
+ s << "0";
+      }
+    }
+    return;
+  }
+}
+void PDDL_Base::Relation::print(std::ostream& s, bool grnd)
+{
+  switch (at) {
+  case md_start:
+    s << "(at start ";
+    break;
+  case md_end:
+    s << "(at end ";
+    break;
+  case md_all:
+    s << "(over all ";
+    break;
+  case md_init:
+    s << "(:init ";
+    break;
+  case md_pos_goal:
+    s << "(:goal ";
+    break;
+  case md_neg_goal:
+    s << "(:goal (not ";
+    break;
+  }
+  s << "(";
+  switch (rel) {
+  case rel_equal:
+    s << "= ";
+    break;
+  case rel_greater:
+    s << "> ";
+    break;
+  case rel_greater_equal:
+    s << ">= ";
+    break;
+  case rel_less:
+    s << "< ";
+    break;
+  case rel_less_equal:
+    s << "<= ";
+    break;
+  }
+  first->print(s, grnd);
+  s << " ";
+  second->print(s, grnd);
+  s << ")";
+  switch (at) {
+  case md_start:
+  case md_end:
+  case md_all:
+  case md_init:
+  case md_pos_goal:
+    s << ")";
+    break;
+  case md_neg_goal:
+    s << "))";
+    break;
+  }
+}
+void PDDL_Base::ActionSymbol::print(std::ostream& s)
+{
+  s << "(:action " << print_name << std::endl;
+  s << "  :parameters (";
+  for (index_type k = 0; k < param.length(); k++) {
+    if (k > 0) s << ' ';
+    param[k]->print(s);
+  }
+  s << ")" << std::endl;
+  if (part) {
+    s << "  :set ";
+    part->print(s);
+    s << std::endl;
+  }
+  if (assoc) {
+    s << "  :assoc \"" << assoc << "\"" << std::endl;
+  }
+  s << "  :pos_prec (";
+  for (index_type k = 0; k < pos_pre.length(); k++) {
+    pos_pre[k]->print(s);
+    if (k + 1 < pos_pre.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :neg_prec (";
+  for (index_type k = 0; k < neg_pre.length(); k++) {
+    neg_pre[k]->print(s);
+    if (k + 1 < neg_pre.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :set_prec (";
+  for (index_type k = 0; k < set_pre.length(); k++) {
+    set_pre[k]->print(s);
+    if (k + 1 < set_pre.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :dis_prec (";
+  for (index_type k = 0; k < dis_pre.length(); k++) {
+    dis_pre[k]->print_as_disjunction(s);
+    if (k + 1 < dis_pre.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :num_prec (";
+  for (index_type k = 0; k < num_pre.length(); k++) {
+    num_pre[k]->print(s, false);
+    if (k + 1 < num_pre.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :add (";
+  for (index_type k = 0; k < adds.length(); k++) {
+    adds[k]->print(s);
+    if (k + 1 < adds.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :del (";
+  for (index_type k = 0; k < dels.length(); k++) {
+    dels[k]->print(s);
+    if (k + 1 < dels.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :lock (";
+  for (index_type k = 0; k < locks.length(); k++) {
+    locks[k]->print(s);
+    if (k + 1 < locks.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :enable (";
+  for (index_type k = 0; k < enables.length(); k++) {
+    enables[k]->print(s);
+    if (k + 1 < enables.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :cons - " << cons.length() << " - (";
+  for (index_type k = 0; k < cons.length(); k++) {
+    cons[k]->print(s);
+    if (k + 1 < cons.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :require (";
+  for (index_type k = 0; k < reqs.length(); k++) {
+    reqs[k]->print(s);
+    if (k + 1 < reqs.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :increase (";
+  for (index_type k = 0; k < incs.length(); k++) {
+    if (k > 0) s << " ";
+    incs[k]->print(s);
+  }
+  for (index_type k = 0; k < qc_incs.length(); k++) {
+    if ((k > 0) || (incs.length() > 0)) s << " ";
+    qc_incs[k]->print(s);
+  }
+  s << ")" << std::endl;
+  s << "  :decrease (";
+  for (index_type k = 0; k < decs.length(); k++) {
+    if (k > 0) s << " ";
+    decs[k]->print(s);
+  }
+  for (index_type k = 0; k < qc_decs.length(); k++) {
+    if ((k > 0) || (decs.length() > 0)) s << " ";
+    qc_decs[k]->print(s);
+  }
+  s << ")" << std::endl;
+  s << "  :assign (";
+  for (index_type k = 0; k < fass.length(); k++) {
+    if (k > 0) s << " ";
+    fass[k]->print(s);
+  }
+  for (index_type k = 0; k < qc_fass.length(); k++) {
+    if ((k > 0) || (fass.length() > 0)) s << " ";
+    qc_fass[k]->print(s);
+  }
+  s << ")" << std::endl;
+  s << "  :set_effects (";
+  for (index_type k = 0; k < set_eff.length(); k++) {
+    set_eff[k]->print(s);
+    if (k + 1 < set_eff.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  s << "  :cond_effects (";
+  for (index_type k = 0; k < cond_eff.length(); k++) {
+    cond_eff[k]->print(s);
+    if (k + 1 < cond_eff.length()) s << " ";
+  }
+  s << ")" << std::endl;
+  if (dmin) {
+    s << "  :dmin ";
+    dmin->print(s, false);
+    s << std::endl;
+  }
+  if (dmax) {
+    s << "  :dmax ";
+    dmax->print(s, false);
+    s << std::endl;
+  }
+  for (index_type k = 0; k < exps.length(); k++) {
+    s << "  (:expansion " << std::endl;
+    exps[k]->print(s);
+    s << "  )" << std::endl;
+  }
+  if (irr_ins.length() > 0) {
+    s << "%% irrelevant instances" << std::endl;
+    for (index_type k = 0; k < irr_ins.length(); k++) {
+      irr_ins[k]->print(s);
+    }
+    s << "%%" << std::endl;
+  }
+  s << "  :refs";
+  for (index_type k = 0; k < refs.length(); k++) {
+    s << " ";
+    refs[k]->print(s);
+  }
+  s << ")" << std::endl;
+}
+void PDDL_Base::ActionSymbol::write_prototype(std::ostream& s)
+{
+  s << "(" << print_name;
+  for (index_type k = 0; k < param.length(); k++) {
+    if (k > 0) s << ' ';
+    param[k]->print(s);
+  }
+  s << ")";
+}
+void PDDL_Base::SetName::print(std::ostream& s)
+{
+  s << "(" << sym->print_name;
+  PDDL_Base::AtomBase::print(s);
+  s << ")";
+}
+void PDDL_Base::AtomBase::print(std::ostream& s) const
+{
+  for (index_type k = 0; k < param.length(); k++) {
+    s << ' ';
+    if (param[k]->sym_class == sym_variable) {
+      VariableSymbol* v = (VariableSymbol*)param[k];
+      if (v->binding != 0) {
+ v->binding->print(s);
+      }
+      else {
+ s << v->print_name;
+      }
+    }
+    else {
+      s << param[k]->print_name;
+    }
+    if (print_bindings) {
+      if (param[k]->sym_class == sym_variable) {
+ VariableSymbol* v = (VariableSymbol*)param[k];
+ if (v->value)
+   v->value->print(s << " = ");
+ else
+   s << " = ??";
+      }
+    }
+  }
+}
+void PDDL_Base::SetName::print_instance(std::ostream& s)
+{
+  s << "(" << sym->print_name;
+  PDDL_Base::AtomBase::print_instance(s);
+  s << ")";
+}
+void PDDL_Base::AtomBase::print_instance(std::ostream& s)
+{
+  for (index_type k = 0; k < param.length(); k++) {
+    s << ' ';
+    if (param[k]->sym_class == sym_variable) {
+      VariableSymbol* v = (VariableSymbol*)param[k];
+      if (v->value)
+ v->value->print(s);
+      else
+ s << "?";
+    }
+    else {
+      param[k]->print(s);
+    }
+  }
+}
+void PDDL_Base::Atom::print(std::ostream& s, bool neg) const
+{
+  if (Instance::write_PDDL2) {
+    switch (at) {
+    case md_start:
+      s << "(at start ";
+      break;
+    case md_end:
+      s << "(at end ";
+      break;
+    case md_all:
+      s << "(over all ";
+      break;
+    }
+  }
+  if (neg) s << "(not ";
+  if (Instance::write_DKEL) {
+    switch (at) {
+    case md_init:
+      s << "(:init ";
+      break;
+    case md_pos_goal:
+      s << "(:goal ";
+      break;
+    case md_neg_goal:
+      s << "(:goal (not ";
+      break;
+    }
+  }
+  s << "(" << pred->print_name;
+  PDDL_Base::AtomBase::print(s);
+  s << ")";
+  if (Instance::write_DKEL) {
+    switch (at) {
+    case md_init:
+    case md_pos_goal:
+      s << ")";
+      break;
+    case md_neg_goal:
+      s << "))";
+    }
+  }
+  if (neg) s << ")";
+  if (Instance::write_PDDL2) {
+    switch (at) {
+    case md_start:
+    case md_end:
+    case md_all:
+      s << ")";
+    }
+  }
+}
+void PDDL_Base::FTerm::print(std::ostream& s) const
+{
+  s << "(" << fun->print_name;
+  PDDL_Base::AtomBase::print(s);
+  s << ")";
+}
+void PDDL_Base::FInitAtom::print(std::ostream& s)
+{
+  s << "(= (" << fun->print_name;
+  PDDL_Base::AtomBase::print(s);
+  s << ") " << val << ")";
+}
+void PDDL_Base::OInitAtom::print(std::ostream& s)
+{
+  s << "(= (" << fun->print_name;
+  PDDL_Base::AtomBase::print(s);
+  s << ") " << val->print_name << ")";
+}
+void PDDL_Base::FChangeAtom::print(std::ostream& s)
+{
+  switch (at) {
+  case md_start:
+    s << "(at start ";
+    break;
+  case md_end:
+    s << "(at end ";
+    break;
+  case md_all:
+    s << "(over all ";
+    break;
+  }
+  s << "((" << fun->print_name;
+  PDDL_Base::AtomBase::print(s);
+  s << ") . ";
+  val->print(s, false);
+  s << ")";
+  if (at != md_none) s << ")";
+}
+void PDDL_Base::Reference::print(std::ostream& s)
+{
+  s << '(' << name->print_name;
+  PDDL_Base::AtomBase::print(s);
+  s << ')';
+}
+void PDDL_Base::SimpleReferenceSet::print(std::ostream& s)
+{
+  if (param.length() > 0) s << "(setof";
+  PDDL_Base::Context::print(s);
+  ref->print(s);
+  if (param.length() > 0) s << ")";
+}
+void PDDL_Base::ReferenceSet::print(std::ostream& s)
+{
+  s << "(:set";
+  if (name) {
+    s << " :name" << name->print_name;
+  }
+  PDDL_Base::Context::print(s);
+  for (index_type k = 0; k < refs.length(); k++) {
+    s << " ";
+    refs[k]->print(s);
+  }
+  s << ")";
+}
+void PDDL_Base::SequentialTaskNet::print(std::ostream& s)
+{
+  s << "(:expansion" << std::endl;
+  PDDL_Base::Context::print(s);
+  s << "  :tasks (";
+  for (index_type k = 0; k < tasks.length(); k++) {
+    tasks[k]->print(s);
+    if (k + 1 < tasks.length()) s << std::endl;
+  }
+  s << "))" << std::endl;
+}
+void PDDL_Base::TypeConstraint::print(std::ostream& s)
+{
+  s << "( " << typ->print_name << " ";
+  if (var->binding != 0) {
+    var->binding->print(s);
+  }
+  else {
+    s << var->print_name;
+  }
+  s << ")";
+}
+void PDDL_Base::Context::print(std::ostream& s)
+{
+  if (param.length() > 0) {
+    s << "  :vars (";
+    for (index_type k = 0; k < param.length(); k++) {
+      if (k > 0) s << ' ';
+      param[k]->print(s);
+    }
+    s << ")" << std::endl;
+  }
+  if (pos_con.length() > 0) {
+    s << "  :pos_context (";
+    for (index_type k = 0; k < pos_con.length(); k++) {
+      pos_con[k]->print(s);
+      if (k + 1 < pos_con.length()) s << " ";
+    }
+    s << ")" << std::endl;
+  }
+  if (neg_con.length() > 0) {
+    s << "  :neg_context (";
+    for (index_type k = 0; k < neg_con.length(); k++) {
+      neg_con[k]->print(s);
+      if (k + 1 < neg_con.length()) s << " ";
+    }
+    s << ")" << std::endl;
+  }
+  if (type_con.length() > 0) {
+    s << "  :type_con (";
+    for (index_type k = 0; k < type_con.length(); k++) {
+      type_con[k]->print(s);
+      if (k + 1 < type_con.length()) s << " ";
+    }
+    s << ")" << std::endl;
+  }
+}
+void PDDL_Base::Context::print_assignment(std::ostream& s)
+{
+  for (index_type k = 0; k < param.length(); k++) {
+    if (k > 0) s << ", ";
+    param[k]->print(s);
+    s << " = ";
+    if (param[k]->value) {
+      param[k]->value->print(s);
+    }
+    else {
+      s << "?";
+    }
+  }
+}
+void PDDL_Base::DKEL_Item::print_begin(std::ostream& s)
+{
+  s << '(' << item_name << std::endl;
+  if (name) {
+    s << "  :name " << name->print_name << std::endl;
+  }
+  for (index_type k = 0; k < item_tags.length(); k++) {
+    s << "  :tag " << item_tags[k] << std::endl;
+  }
+  Context::print(s);
+}
+void PDDL_Base::DKEL_Item::write_dkel(std::ostream& s)
+{
+  s << " (" << item_name << std::endl;
+  if (name) {
+    s << "  :name " << name->print_name << std::endl;
+  }
+  for (index_type k = 0; k < item_tags.length(); k++) {
+    s << "  :tag " << item_tags[k] << std::endl;
+  }
+  if (param.length() > 0) {
+    s << "  :vars (";
+    for (index_type k = 0; k < param.length(); k++) {
+      if (k > 0) s << ' ';
+      param[k]->print(s);
+    }
+    s << ")" << std::endl;
+  }
+  if ((pos_con.length() + neg_con.length()) > 0) {
+    s << "  :context (and";
+    for (index_type k = 0; k < pos_con.length(); k++) {
+      s << " ";
+      pos_con[k]->print(s, false);
+    }
+    for (index_type k = 0; k < neg_con.length(); k++) {
+      s << " ";
+      neg_con[k]->print(s, true);
+    }
+    s << ")" << std::endl;
+  }
+}
+void PDDL_Base::DKEL_Item::print_end(std::ostream& s)
+{
+  s << ")" << std::endl;
+}
+void PDDL_Base::DKEL_Item::print(std::ostream& s)
+{
+  print_begin(s);
+  print_end(s);
+}
+void PDDL_Base::SetOf::print(std::ostream& s)
+{
+  s << "(setof :vars (";
+  for (index_type k = 0; k < param.length(); k++) {
+    if (k > 0) s << ' ';
+    param[k]->print(s);
+  }
+  s << ")";
+  if (pos_con.length() + neg_con.length() > 0) {
+    s << ":context";
+    if (pos_con.length() + neg_con.length() > 1) s << " (and";
+    for (index_type k = 0; k < pos_con.length(); k++) {
+      s << " ";
+      pos_con[k]->print(s);
+    }
+    for (index_type k = 0; k < neg_con.length(); k++) {
+      s << " (not ";
+      neg_con[k]->print(s);
+      s << ")";
+    }
+    if (pos_con.length() + neg_con.length() > 1) s << ")";
+  }
+  if (pos_atoms.length() + neg_atoms.length() > 1) s << " (and";
+  for (index_type k = 0; k < pos_atoms.length(); k++) {
+    s << " ";
+    pos_atoms[k]->print(s);
+  }
+  for (index_type k = 0; k < neg_atoms.length(); k++) {
+    s << " ";
+    neg_atoms[k]->print(s);
+  }
+  if (pos_atoms.length() + neg_atoms.length() > 1) s << ")";
+  s << ")";
+}
+void PDDL_Base::SetOf::print_as_disjunction(std::ostream& s)
+{
+  if (param.length() > 0) {
+    s << "(exists (";
+    for (index_type k = 0; k < param.length(); k++) {
+      if (k > 0) s << ' ';
+      param[k]->print(s);
+    }
+    s << ") ";
+  }
+  if (pos_con.length() + neg_con.length() > 0) {
+    s << "(and ";
+    for (index_type k = 0; k < pos_con.length(); k++) {
+      s << " ";
+      pos_con[k]->print(s);
+    }
+    for (index_type k = 0; k < neg_con.length(); k++) {
+      s << " (not ";
+      neg_con[k]->print(s);
+      s << ")";
+    }
+    s << " ";
+  }
+  if (pos_atoms.length() + neg_atoms.length() > 1) s << "(or ";
+  for (index_type k = 0; k < pos_atoms.length(); k++) {
+    if (k > 0) s << " ";
+    pos_atoms[k]->print(s);
+  }
+  for (index_type k = 0; k < neg_atoms.length(); k++) {
+    if ((k > 0) || (pos_atoms.length() > 0)) s << " ";
+    neg_atoms[k]->print(s);
+  }
+  if (pos_atoms.length() + neg_atoms.length() > 1) s << ")";
+  if (pos_con.length() + neg_con.length() > 0) s << ")";
+  if (param.length() > 0) s << ")";
+}
+void PDDL_Base::QCNumericEffect::print(std::ostream& s)
+{
+  s << "(setof :vars (";
+  for (index_type k = 0; k < param.length(); k++) {
+    if (k > 0) s << ' ';
+    param[k]->print(s);
+  }
+  s << ") ";
+  if (pos_con.length() + neg_con.length() > 0) {
+    s << ":context";
+    if (pos_con.length() + neg_con.length() > 1) s << " (and";
+    for (index_type k = 0; k < pos_con.length(); k++) {
+      s << " ";
+      pos_con[k]->print(s);
+    }
+    for (index_type k = 0; k < neg_con.length(); k++) {
+      s << " (not ";
+      neg_con[k]->print(s);
+      s << ")";
+    }
+    if (pos_con.length() + neg_con.length() > 1) s << ")";
+    s << " ";
+  }
+  atom->print(s);
+  s << ")";
+}
+void PDDL_Base::SetConstraint::print(std::ostream& s)
+{
+  PDDL_Base::DKEL_Item::print_begin(s);
+  s << "  :set-constraint (";
+  switch (sc_type) {
+  case sc_at_most:
+    s << "at-most-n";
+    break;
+  case sc_at_least:
+    s << "at-least-n";
+    break;
+  case sc_exactly:
+    s << "exactly-n";
+    break;
+  }
+  s << " " << sc_count;
+  for (index_type k = 0; k < pos_atoms.length(); k++) {
+    s << " ";
+    pos_atoms[k]->print(s);
+  }
+  for (index_type k = 0; k < neg_atoms.length(); k++) {
+    s << " (not ";
+    neg_atoms[k]->print(s);
+    s << ")";
+  }
+  for (index_type k = 0; k < atom_sets.length(); k++) {
+    s << " ";
+    atom_sets[k]->print(s);
+  }
+  s << ")" << std::endl;
+  PDDL_Base::DKEL_Item::print_end(s);
+}
+void PDDL_Base::SetConstraint::write_dkel(std::ostream& s)
+{
+  PDDL_Base::DKEL_Item::write_dkel(s);
+  s << "  :set-constraint (";
+  switch (sc_type) {
+  case sc_at_most:
+    s << "at-most-n";
+    break;
+  case sc_at_least:
+    s << "at-least-n";
+    break;
+  case sc_exactly:
+    s << "exactly-n";
+    break;
+  }
+  s << " " << sc_count;
+  for (index_type k = 0; k < pos_atoms.length(); k++) {
+    s << " ";
+    pos_atoms[k]->print(s);
+  }
+  for (index_type k = 0; k < neg_atoms.length(); k++) {
+    s << " (not ";
+    neg_atoms[k]->print(s);
+    s << ")";
+  }
+  for (index_type k = 0; k < atom_sets.length(); k++) {
+    s << " ";
+    atom_sets[k]->print(s);
+  }
+  s << "))" << std::endl;
+}
+void PDDL_Base::InvariantFormula::write_dkel(std::ostream& s)
+{
+  PDDL_Base::DKEL_Item::write_dkel(s);
+  s << "  :formula ";
+  f->print(s);
+  s << ")" << std::endl;
+}
+void PDDL_Base::IrrelevantItem::print(std::ostream& s)
+{
+  PDDL_Base::DKEL_Item::print_begin(s);
+  if (entity->name->sym_class == sym_predicate)
+    s << "  :fact ";
+  else
+    s << "  :action ";
+  entity->print(s);
+  PDDL_Base::DKEL_Item::print_end(s);
+}
+void PDDL_Base::IrrelevantItem::write_dkel(std::ostream& s)
+{
+  PDDL_Base::DKEL_Item::write_dkel(s);
+  if (entity->name->sym_class == sym_predicate)
+    s << "  :fact ";
+  else
+    s << "  :action ";
+  entity->print(s);
+  s << ")" << std::endl;
+}
+void PDDL_Base::Preference::print(std::ostream& s)
+{
+  s << "(preference ";
+  if (name) {
+    name->print(s);
+    s << " ";
+  }
+  goal->print(s);
+  s << ")";
+}
+void PDDL_Base::InputPlan::print(std::ostream& s)
+{
+  s << "(:plan";
+  if (name) {
+    s << std::endl << "  :name ";
+    name->print(s);
+  }
+  if (is_opt) {
+    s << std::endl << "  :opt";
+  }
+  for (index_type k = 0; k < steps.length(); k++) {
+    s << std::endl << "  " << std::resetiosflags(std::ios::scientific) << ((steps[k]->start_time).decimal()) << " : ";
+    steps[k]->act->print(s);
+    s << " ; " << steps[k]->act->index;
+  }
+  s << std::endl << ")" << std::endl;
+}
+void PDDL_Base::print(std::ostream& s)
+{
+  s << "domain: " << (domain_name ? domain_name : "<not defined>") << std::endl;
+  s << "problem: " << (problem_name ? problem_name : "<not defined>") << std::endl;
+  s << "<" << dom_predicates.length() << "," << dom_functions.length() << "," << dom_actions.length()
+    << ">" << std::endl;
+  dom_top_type->print(s);
+  for (index_type k = 0; k < dom_types.length(); k++) dom_types[k]->print(s);
+  for (index_type k = 0; k < dom_predicates.length(); k++) dom_predicates[k]->print(s);
+  for (index_type k = 0; k < dom_object_functions.length(); k++) dom_object_functions[k]->print(s);
+  for (index_type k = 0; k < dom_functions.length(); k++) dom_functions[k]->print(s);
+  for (index_type k = 0; k < dom_actions.length(); k++) dom_actions[k]->print(s);
+  for (index_type k = 0; k < dom_sc_invariants.length(); k++)
+    dom_sc_invariants[k]->print(s);
+  for (index_type k = 0; k < dom_f_invariants.length(); k++)
+    dom_f_invariants[k]->print(s);
+  s << "goals:";
+  for (index_type k = 0; k < dom_goals.length(); k++) {
+    s << " ";
+    dom_goals[k]->print(s);
+  }
+  s << std::endl << "preferences:";
+  for (index_type k = 0; k < dom_preferences.length(); k++) {
+    s << " ";
+    dom_preferences[k]->print(s);
+  }
+  s << std::endl;
+}
+void PDDL_Base::write_declarations(std::ostream& s)
+{
+  if (dom_types.length() > 0) {
+    s << " (:types";
+    for (index_type k = 0; k < dom_types.length(); k++) {
+      s << " " << dom_types[k]->print_name;
+      dom_types[k]->sym_types.write_type(s);
+    }
+    s << ")" << std::endl;
+  }
+  if (dom_predicates.length() > 0) {
+    s << " (:predicates";
+    for (index_type k = 0; k < dom_predicates.length(); k++) {
+      s << " (" << dom_predicates[k]->print_name;
+      for (index_type i = 0; i < dom_predicates[k]->param.length(); i++) {
+ s << " " << dom_predicates[k]->param[i]->print_name;
+ if (dom_types.length() > 0) {
+   dom_predicates[k]->param[i]->sym_types.write_type(s);
+ }
+      }
+      s << ")";
+    }
+    s << ")" << std::endl;
+  }
+  if (Instance::write_PDDL2 && (dom_functions.length() > 0)) {
+    s << " (:functions";
+    for (index_type k = 0; k < dom_functions.length(); k++) {
+      s << " (" << dom_functions[k]->print_name;
+      for (index_type i = 0; i < dom_functions[k]->param.length(); i++) {
+ s << " " << dom_functions[k]->param[i]->print_name;
+ if (dom_types.length() > 0) {
+   dom_functions[k]->param[i]->sym_types.write_type(s);
+ }
+      }
+      s << ")";
+    }
+    s << ")" << std::endl;
+  }
+}
+void PDDL_Base::write_set_precondition(std::ostream& s, SetOf* set)
+{
+  mode_keyword m = md_none;
+  if (set->pos_atoms.length() > 0)
+    m = set->pos_atoms[0]->at;
+  else if (set->neg_atoms.length() > 0)
+    m = set->neg_atoms[0]->at;
+  if (Instance::write_PDDL2) {
+    switch (m) {
+    case md_start:
+      s << "(at start ";
+      break;
+    case md_end:
+      s << "(at end ";
+      break;
+    case md_all:
+      s << "(over all ";
+      break;
+    }
+  }
+  s << "(forall (";
+  for (index_type j = 0; j < set->param.length(); j++) {
+    s << " " << set->param[j]->print_name;
+    if (dom_types.length() > 0) {
+      set->param[j]->sym_types.write_type(s);
+    }
+  }
+  s << ")";
+  if (set->pos_con.length() + set->neg_con.length() + set->type_con.length() > 0) {
+    s << " (imply (and";
+    for (index_type j = 0; j < set->pos_con.length(); j++) {
+      s << " ";
+      set->pos_con[j]->print(s, false);
+    }
+    for (index_type j = 0; j < set->neg_con.length(); j++) {
+      s << " ";
+      set->neg_con[j]->print(s, true);
+    }
+    for (index_type j = 0; j < set->type_con.length(); j++) {
+      s << " ";
+      set->type_con[j]->print(s);
+    }
+    s << ")";
+  }
+  if (set->pos_atoms.length() + set->neg_atoms.length() > 1) s << " (and";
+  for (index_type k = 0; k < set->pos_atoms.length(); k++) {
+    s << " (" << set->pos_atoms[k]->pred->print_name;
+    ((PDDL_Base::AtomBase*)set->pos_atoms[k])->print(s);
+    s << ")";
+  }
+  for (index_type k = 0; k < set->neg_atoms.length(); k++) {
+    s << " (not (" << set->neg_atoms[k]->pred->print_name;
+    ((PDDL_Base::AtomBase*)set->neg_atoms[k])->print(s);
+    s << "))";
+  }
+  if (set->pos_atoms.length() + set->neg_atoms.length() > 1) s << ")";
+  if (set->pos_con.length() + set->neg_con.length() + set->type_con.length() > 0) s << ")";
+  s << ")";
+  if (Instance::write_PDDL2) {
+    switch (m) {
+    case md_start:
+    case md_end:
+    case md_all:
+      s << ")";
+    }
+  }
+}
+void PDDL_Base::write_disjunctive_set_precondition(std::ostream& s, SetOf* set)
+{
+  mode_keyword m = md_none;
+  if (set->pos_atoms.length() > 0)
+    m = set->pos_atoms[0]->at;
+  else if (set->neg_atoms.length() > 0)
+    m = set->neg_atoms[0]->at;
+  if (Instance::write_PDDL2) {
+    switch (m) {
+    case md_start:
+      s << "(at start ";
+      break;
+    case md_end:
+      s << "(at end ";
+      break;
+    case md_all:
+      s << "(over all ";
+      break;
+    }
+  }
+  s << "(exists (";
+  for (index_type j = 0; j < set->param.length(); j++) {
+    s << " " << set->param[j]->print_name;
+    if (dom_types.length() > 0) {
+      set->param[j]->sym_types.write_type(s);
+    }
+  }
+  s << ")";
+  if (set->pos_con.length() + set->neg_con.length() + set->type_con.length() > 0) {
+    s << " (and";
+    for (index_type j = 0; j < set->pos_con.length(); j++) {
+      s << " ";
+      set->pos_con[j]->print(s, false);
+    }
+    for (index_type j = 0; j < set->neg_con.length(); j++) {
+      s << " ";
+      set->neg_con[j]->print(s, true);
+    }
+    for (index_type j = 0; j < set->type_con.length(); j++) {
+      s << " ";
+      set->type_con[j]->print(s);
+    }
+  }
+  if (set->pos_atoms.length() + set->neg_atoms.length() > 1) s << " (or";
+  for (index_type k = 0; k < set->pos_atoms.length(); k++) {
+    s << " (" << set->pos_atoms[k]->pred->print_name;
+    ((PDDL_Base::AtomBase*)set->pos_atoms[k])->print(s);
+    s << ")";
+  }
+  for (index_type k = 0; k < set->neg_atoms.length(); k++) {
+    s << " (not (" << set->neg_atoms[k]->pred->print_name;
+    ((PDDL_Base::AtomBase*)set->neg_atoms[k])->print(s);
+    s << "))";
+  }
+  if (set->pos_atoms.length() + set->neg_atoms.length() > 1) s << ")";
+  if (set->pos_con.length() + set->neg_con.length() + set->type_con.length() > 0) s << ")";
+  s << ")";
+  if (Instance::write_PDDL2) {
+    switch (m) {
+    case md_start:
+    case md_end:
+    case md_all:
+      s << ")";
+    }
+  }
+}
+void PDDL_Base::write_set_effect(std::ostream& s, SetOf* set)
+{
+  mode_keyword m = md_none;
+  if (set->pos_atoms.length() > 0)
+    m = set->pos_atoms[0]->at;
+  else if (set->neg_atoms.length() > 0)
+    m = set->neg_atoms[0]->at;
+  if (Instance::write_PDDL2) {
+    switch (m) {
+    case md_start:
+      s << "(at start ";
+      break;
+    case md_end:
+      s << "(at end ";
+      break;
+    case md_all:
+      s << "(over all ";
+      break;
+    }
+  }
+  if (set->param.length() > 0) {
+    s << "(forall (";
+    for (index_type j = 0; j < set->param.length(); j++) {
+      s << " " << set->param[j]->print_name;
+      if (dom_types.length() > 0) {
+ set->param[j]->sym_types.write_type(s);
+      }
+    }
+    s << ") ";
+  }
+  if (set->pos_con.length() + set->neg_con.length() + set->type_con.length() > 0) {
+    s << "(when (and";
+    for (index_type j = 0; j < set->pos_con.length(); j++) {
+      s << " ";
+      set->pos_con[j]->print(s, false);
+    }
+    for (index_type j = 0; j < set->neg_con.length(); j++) {
+      s << " ";
+      set->neg_con[j]->print(s, true);
+    }
+    for (index_type j = 0; j < set->type_con.length(); j++) {
+      s << " ";
+      set->type_con[j]->print(s);
+    }
+    s << ") ";
+  }
+  if (set->pos_atoms.length() + set->neg_atoms.length() > 1) s << "(and";
+  for (index_type k = 0; k < set->pos_atoms.length(); k++) {
+    s << " (" << set->pos_atoms[k]->pred->print_name;
+    ((PDDL_Base::AtomBase*)set->pos_atoms[k])->print(s);
+    s << ")";
+  }
+  for (index_type k = 0; k < set->neg_atoms.length(); k++) {
+    s << " (not (" << set->neg_atoms[k]->pred->print_name;
+    ((PDDL_Base::AtomBase*)set->neg_atoms[k])->print(s);
+    s << "))";
+  }
+  if (set->pos_atoms.length() + set->neg_atoms.length() > 1) s << ")";
+  if (set->pos_con.length() + set->neg_con.length() + set->type_con.length() > 0) s << ")";
+  if (set->param.length() > 0) s << ")";
+  if (Instance::write_PDDL2) {
+    switch (m) {
+    case md_start:
+    case md_end:
+    case md_all:
+      s << ")";
+    }
+  }
+}
+void PDDL_Base::write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn)
+{
+  if (Instance::write_PDDL2) {
+    switch (qcn->atom->at) {
+    case md_start:
+      s << "(at start ";
+      break;
+    case md_end:
+      s << "(at end ";
+      break;
+    }
+  }
+  if (qcn->param.length() > 0) {
+    s << "(forall (";
+    for (index_type j = 0; j < qcn->param.length(); j++) {
+      if (j > 0) s << " ";
+      s << qcn->param[j]->print_name;
+      if (dom_types.length() > 0) {
+ qcn->param[j]->sym_types.write_type(s);
+      }
+    }
+    s << ") ";
+  }
+  if (qcn->pos_con.length() + qcn->neg_con.length() + qcn->type_con.length() > 0) {
+    s << "(when (and";
+    for (index_type j = 0; j < qcn->pos_con.length(); j++) {
+      s << " ";
+      qcn->pos_con[j]->print(s, false);
+    }
+    for (index_type j = 0; j < qcn->neg_con.length(); j++) {
+      s << " ";
+      qcn->neg_con[j]->print(s, true);
+    }
+    for (index_type j = 0; j < qcn->type_con.length(); j++) {
+      s << " ";
+      qcn->type_con[j]->print(s);
+    }
+    s << ") ";
+  }
+  s << "(" << effect_type << " ";
+  s << "(" << qcn->atom->fun->print_name;
+  ((PDDL_Base::AtomBase*)qcn->atom)->print(s);
+  s << ") ";
+  qcn->atom->val->print(s, false);
+  s << ")";
+  if (qcn->pos_con.length() + qcn->neg_con.length() + qcn->type_con.length() > 0) s << ")";
+  if (qcn->param.length() > 0) s << ")";
+  if (Instance::write_PDDL2) {
+    switch (qcn->atom->at) {
+    case md_start:
+    case md_end:
+    case md_all:
+      s << ")";
+    }
+  }
+}
+void PDDL_Base::write_action(std::ostream& s, ActionSymbol* act)
+{
+  bool is_durative = (Instance::write_PDDL2 && (act->dmin || act->dmax));
+  index_type n_pre = (act->pos_pre.length() + act->neg_pre.length() +
+        act->set_pre.length() + act->dis_pre.length() +
+        (Instance::write_PDDL2 ? act->num_pre.length() : 0));
+  index_type n_eff = (act->adds.length() + act->dels.length() +
+        act->set_eff.length() + act->cond_eff.length() +
+        (Instance::write_PDDL2 ? act->locks.length() : 0) +
+        (Instance::write_PDDL2 ? act->enables.length() : 0) +
+        (Instance::write_PDDL2 ? act->reqs.length() : 0) +
+        (Instance::write_PDDL2 ? act->incs.length() : 0) +
+        (Instance::write_PDDL2 ? act->decs.length() : 0) +
+        (Instance::write_PDDL2 ? act->fass.length() : 0) +
+        (Instance::write_PDDL2 ? act->qc_fass.length() : 0));
+  if (is_durative)
+    s << " (:durative-action " << act->print_name << std::endl;
+  else
+    s << " (:action " << act->print_name << std::endl;
+  if ((act->param.length() > 0) ||
+      Instance::always_write_parameters) {
+    s << "  :parameters (";
+    for (index_type i = 0; i < act->param.length(); i++) {
+      s << " " << act->param[i]->print_name;
+      if (dom_types.length() > 0) {
+ act->param[i]->sym_types.write_type(s);
+      }
+    }
+    s << ")" << std::endl;
+  }
+  if ((act->part != 0) && Instance::write_extra) {
+    s << "  :set ";
+    act->part->print(s);
+    s << std::endl;
+  }
+  if (act->assoc && Instance::write_extra) {
+    s << "  :assoc \"" << act->assoc << "\"" << std::endl;
+  }
+  if (Instance::write_PDDL2 && (act->dmin || act->dmax)) {
+    if (act->dmin == act->dmax) {
+      s << "  :duration (= ?duration ";
+      act->dmax->print(s, false);
+      s << ")" << std::endl;
+    }
+    else if (act->dmax) {
+      if (act->dmin) {
+ s << "  :duration (and (>= ?duration ";
+ act->dmin->print(s, false);
+ s << ") (<= ?duration ";
+ act->dmax->print(s, false);
+ s << "))" << std::endl;
+      }
+      else {
+ s << "  :duration (<= ?duration ";
+ act->dmax->print(s, false);
+ s << ")" << std::endl;
+      }
+    }
+    else if (act->dmin) {
+      s << "  :duration (>= ?duration ";
+      act->dmin->print(s, false);
+      s << ")" << std::endl;
+    }
+  }
+  if (n_pre > 0) {
+    if (is_durative)
+      s << "  :condition";
+    else
+      s << "  :precondition";
+    if ((n_pre > 1) || Instance::always_write_conjunction) s << " (and";
+    for (index_type i = 0; i < act->pos_pre.length(); i++) {
+      s << " ";
+      act->pos_pre[i]->print(s, false);
+    }
+    for (index_type i = 0; i < act->neg_pre.length(); i++) {
+      s << " ";
+      act->neg_pre[i]->print(s, true);
+    }
+    for (index_type i = 0; i < act->set_pre.length(); i++) {
+      s << " ";
+      write_set_precondition(s, act->set_pre[i]);
+    }
+    for (index_type i = 0; i < act->dis_pre.length(); i++) {
+      s << " ";
+      write_disjunctive_set_precondition(s, act->dis_pre[i]);
+    }
+    for (index_type i = 0; i < act->num_pre.length(); i++) {
+      s << " ";
+      act->num_pre[i]->print(s, false);
+    }
+    if ((n_pre > 1) || Instance::always_write_conjunction) s << ")";
+    s << std::endl;
+  }
+  else if (Instance::always_write_precondition) {
+    if (is_durative)
+      s << "  :condition (";
+    else
+      s << "  :precondition (";
+    if (Instance::always_write_conjunction)
+      s << "and)";
+    else
+      s << ")";
+  }
+  if (n_eff > 0) {
+    s << "  :effect ";
+    if ((n_eff > 1) || Instance::always_write_conjunction) s << "(and";
+    for (index_type i = 0; i < act->adds.length(); i++) {
+      s << " ";
+      act->adds[i]->print(s, false);
+    }
+    for (index_type i = 0; i < act->dels.length(); i++) {
+      s << " ";
+      act->dels[i]->print(s, true);
+    }
+    for (index_type i = 0; i < act->set_eff.length(); i++) {
+      s << " ";
+      write_set_effect(s, act->set_eff[i]);
+    }
+    for (index_type i = 0; i < act->cond_eff.length(); i++) {
+      s << " ";
+      write_set_effect(s, act->cond_eff[i]);
+    }
+    if (Instance::write_PDDL2) {
+      for (index_type i = 0; i < act->locks.length(); i++) {
+ s << " (at start (not (" << act->locks[i]->pred->print_name;
+ ((PDDL_Base::AtomBase*)act->locks[i])->print(s);
+ s << ")))";
+ s << " (at end (" << act->locks[i]->pred->print_name;
+ ((PDDL_Base::AtomBase*)act->locks[i])->print(s);
+ s << "))";
+      }
+      for (index_type i = 0; i < act->enables.length(); i++) {
+ s << " (at start (" << act->enables[i]->pred->print_name;
+ ((PDDL_Base::AtomBase*)act->enables[i])->print(s);
+ s << "))";
+ s << " (at end (not (" << act->enables[i]->pred->print_name;
+ ((PDDL_Base::AtomBase*)act->enables[i])->print(s);
+ s << ")))";
+      }
+      for (index_type i = 0; i < act->incs.length(); i++) {
+ s << " ";
+ switch (act->incs[i]->at) {
+ case md_start:
+   s << "(at start ";
+   break;
+ case md_end:
+   s << "(at end ";
+   break;
+ case md_all:
+   s << "(over all ";
+   break;
+ }
+ s << "(increase (" << act->incs[i]->fun->print_name;
+ ((PDDL_Base::AtomBase*)act->incs[i])->print(s);
+ s << ") ";
+ act->incs[i]->val->print(s, false);
+ s << ")";
+ if ((act->incs[i]->at == md_start) ||
+     (act->incs[i]->at == md_end) ||
+     (act->incs[i]->at == md_all))
+   s << ")";
+      }
+      for (index_type i = 0; i < act->decs.length(); i++) {
+ s << " ";
+ switch (act->decs[i]->at) {
+ case md_start:
+   s << "(at start ";
+   break;
+ case md_end:
+   s << "(at end ";
+   break;
+ case md_all:
+   s << "(over all ";
+   break;
+ }
+ s << "(decrease (" << act->decs[i]->fun->print_name;
+ ((PDDL_Base::AtomBase*)act->decs[i])->print(s);
+ s << ") ";
+ act->decs[i]->val->print(s, false);
+ s << ")";
+ if ((act->decs[i]->at == md_start) ||
+     (act->decs[i]->at == md_end) ||
+     (act->decs[i]->at == md_all))
+   s << ")";
+      }
+      for (index_type i = 0; i < act->fass.length(); i++) {
+ s << " ";
+ switch (act->fass[i]->at) {
+ case md_start:
+   s << "(at start ";
+   break;
+ case md_end:
+   s << "(at end ";
+   break;
+ case md_all:
+   s << "(over all ";
+   break;
+ }
+ s << "(assign (" << act->fass[i]->fun->print_name;
+ ((PDDL_Base::AtomBase*)act->fass[i])->print(s);
+ s << ") ";
+ act->fass[i]->val->print(s, false);
+ s << ")";
+ if ((act->fass[i]->at == md_start) ||
+     (act->fass[i]->at == md_end) ||
+     (act->fass[i]->at == md_all))
+   s << ")";
+      }
+      for (index_type i = 0; i < act->qc_fass.length(); i++) {
+ s << " ";
+ write_QCN_effect(s, "assign", act->qc_fass[i]);
+      }
+      for (index_type i = 0; i < act->reqs.length(); i++) {
+ s << " (at start (decrease (" << act->reqs[i]->fun->print_name;
+ ((PDDL_Base::AtomBase*)act->reqs[i])->print(s);
+ s << ") ";
+ act->reqs[i]->val->print(s, false);
+ s << ")) (at end (increase (" << act->reqs[i]->fun->print_name;
+ ((PDDL_Base::AtomBase*)act->reqs[i])->print(s);
+ s << ") ";
+ act->reqs[i]->val->print(s, false);
+ s << "))";
+      }
+    }
+    if ((n_eff > 1) || Instance::always_write_conjunction) s << ")";
+    s << std::endl;
+  }
+  else if (Instance::always_write_effect) {
+    if (Instance::always_write_conjunction)
+      s << "  :effect (and)" << std::endl;
+    else
+      s << "  :effect ()" << std::endl;
+  }
+  s << " )" << std::endl;
+}
+void PDDL_Base::write_objects(std::ostream& s, bool defined_in_problem)
+{
+  index_type n_obj = 0;
+  for (index_type k = 0; k < dom_constants.length(); k++)
+    if (dom_constants[k]->defined_in_problem == defined_in_problem) n_obj += 1;
+  if (n_obj > 0) {
+    if (defined_in_problem) {
+      s << " (:objects";
+    }
+    else {
+      s << " (:constants";
+    }
+    for (index_type k = 0; k < dom_constants.length(); k++)
+      if (dom_constants[k]->defined_in_problem == defined_in_problem) {
+ s << " " << dom_constants[k]->print_name;
+ if (dom_types.length() > 0) {
+   dom_constants[k]->sym_types.write_type(s);
+ }
+      }
+    s << ")" << std::endl;
+  }
+}
+void PDDL_Base::write_init(std::ostream& s)
+{
+  index_type n_init = dom_init.length();
+  if (Instance::write_PDDL2) n_init += dom_fun_init.length();
+  if (write_PDDL31) n_init += dom_obj_init.length();
+  if (n_init > 0) {
+    s << " (:init";
+    for (index_type k = 0; k < dom_init.length(); k++) {
+      s << " (" << dom_init[k]->pred->print_name;
+      ((AtomBase*)dom_init[k])->print(s);
+      s << ")";
+    }
+    if (write_PDDL31) {
+      for (index_type k = 0; k < dom_obj_init.length(); k++) {
+ s << " (= (" << dom_obj_init[k]->fun->print_name;
+ ((AtomBase*)dom_obj_init[k])->print(s);
+ s << ") " << dom_obj_init[k]->val->print_name << ")";
+      }
+    }
+    if (Instance::write_PDDL2) {
+      for (index_type k = 0; k < dom_fun_init.length(); k++) {
+ s << " (= (" << dom_fun_init[k]->fun->print_name;
+ ((AtomBase*)dom_fun_init[k])->print(s);
+ s << ") " << std::resetiosflags(std::ios::scientific) << ((dom_fun_init[k]->val).decimal()) << ")";
+      }
+    }
+    s << ")" << std::endl;
+  }
+}
+void PDDL_Base::write_goal(std::ostream& s)
+{
+  index_type n_in_goal = 0;
+  for (index_type k = 0; k < dom_goals.length(); k++)
+    if (dom_goals[k]->is_state())
+      if (dom_goals[k]->is_propositional() || Instance::write_PDDL2)
+ n_in_goal += 1;
+  if (Instance::write_PDDL3)
+    for (index_type k = 0; k < dom_preferences.length(); k++)
+      if (dom_preferences[k]->is_state())
+ if (dom_preferences[k]->is_propositional() || Instance::write_PDDL2)
+   n_in_goal += 1;
+  if (n_in_goal > 0) {
+    s << " (:goal";
+    if (n_in_goal > 1) s << " (and";
+    for (index_type k = 0; k < dom_goals.length(); k++) {
+      if (dom_goals[k]->is_state()) {
+ if (dom_goals[k]->is_propositional() || Instance::write_PDDL2) {
+   s << " ";
+   dom_goals[k]->print(s);
+ }
+      }
+    }
+    if (Instance::write_PDDL3) {
+      for (index_type k = 0; k < dom_preferences.length(); k++) {
+ if (dom_preferences[k]->is_state()) {
+   if (dom_preferences[k]->is_propositional() ||
+       Instance::write_PDDL2) {
+     s << " ";
+     dom_preferences[k]->print(s);
+   }
+ }
+      }
+    }
+    if (n_in_goal > 1) s << ")";
+    s << ")" << std::endl;
+  }
+  if (Instance::write_PDDL3) {
+    index_type n_in_cons = 0;
+    for (index_type k = 0; k < dom_goals.length(); k++)
+      if (!dom_goals[k]->is_state())
+ if (dom_goals[k]->is_propositional() || Instance::write_PDDL2)
+   n_in_cons += 1;
+    for (index_type k = 0; k < dom_preferences.length(); k++)
+      if (!dom_preferences[k]->is_state())
+ if (dom_preferences[k]->is_propositional() || Instance::write_PDDL2)
+   n_in_cons += 1;
+    if (n_in_cons > 0) {
+      s << " (:constraints";
+      if (n_in_cons > 1) s << " (and";
+      for (index_type k = 0; k < dom_goals.length(); k++) {
+ if (!dom_goals[k]->is_state()) {
+   if (dom_goals[k]->is_propositional() || Instance::write_PDDL2) {
+     s << " ";
+     dom_goals[k]->print(s);
+   }
+ }
+      }
+      for (index_type k = 0; k < dom_preferences.length(); k++) {
+ if (!dom_preferences[k]->is_state()) {
+   if (dom_preferences[k]->is_propositional() ||
+       Instance::write_PDDL2) {
+     s << " ";
+     dom_preferences[k]->print(s);
+   }
+ }
+      }
+      if (n_in_cons > 1) s << ")";
+      s << ")" << std::endl;
+    }
+  }
+}
+void PDDL_Base::write_metric(std::ostream& s)
+{
+  if (Instance::write_metric &&
+      (Instance::write_PDDL2 || Instance::write_PDDL3)) {
+    switch (metric_type) {
+    case metric_makespan:
+      s << " (:metric minimize (total-time))" << std::endl;
+      break;
+    case metric_minimize:
+      s << " (:metric minimize ";
+      metric->print(s, false);
+      s << ")" << std::endl;
+      break;
+    case metric_maximize:
+      s << " (:metric maximize ";
+      metric->print(s, false);
+      s << ")" << std::endl;
+      break;
+    }
+  }
+}
+void PDDL_Base::write_dkel_items(std::ostream& s, bool defined_in_problem)
+{
+  if (Instance::write_DKEL) {
+    for (index_type k = 0; k < dom_irrelevant.length(); k++) {
+      if ((dom_irrelevant[k]->
+    item_is_included(excluded_dkel_tags, required_dkel_tags)) &&
+   (dom_irrelevant[k]->defined_in_problem == defined_in_problem))
+ dom_irrelevant[k]->write_dkel(s);
+    }
+    for (index_type k = 0; k < dom_sc_invariants.length(); k++) {
+      if ((dom_sc_invariants[k]->
+    item_is_included(excluded_dkel_tags, required_dkel_tags)) &&
+   (dom_sc_invariants[k]->defined_in_problem == defined_in_problem))
+ dom_sc_invariants[k]->write_dkel(s);
+    }
+    for (index_type k = 0; k < dom_f_invariants.length(); k++) {
+      if ((dom_f_invariants[k]->
+    item_is_included(excluded_dkel_tags, required_dkel_tags)) &&
+   (dom_f_invariants[k]->defined_in_problem == defined_in_problem))
+ dom_f_invariants[k]->write_dkel(s);
+    }
+  }
+}
+void PDDL_Base::write_domain_begin(std::ostream& s)
+{
+  s << "(define (domain " << domain_name << ")" << std::endl;
+}
+void PDDL_Base::write_problem_begin(std::ostream& s)
+{
+  s << "(define (problem " << problem_name << ")" << std::endl;
+  if (domain_name) {
+    s << " (:domain " << domain_name << ")" << std::endl;
+  }
+}
+void PDDL_Base::write_end(std::ostream& s)
+{
+  s << ")" << std::endl;
+}
+void PDDL_Base::write_dkel_domain(std::ostream& s, bool leave_open)
+{
+  write_domain_begin(s);
+  write_declarations(s);
+  write_objects(s, false);
+  for (index_type k = 0; k < dom_actions.length(); k++) {
+    write_action(s, dom_actions[k]);
+  }
+  write_dkel_items(s, false);
+  if (!leave_open) write_end(s);
+}
+void PDDL_Base::write_dkel_problem(std::ostream& s, bool leave_open)
+{
+  write_problem_begin(s);
+  write_objects(s, true);
+  write_init(s);
+  write_goal(s);
+  write_metric(s);
+  write_dkel_items(s, true);
+  if (!leave_open) write_end(s);
+}
+void PDDL_Base::write_plans(std::ostream& s)
+{
+  for (index_type k = 0; k < input_plans.length(); k++) {
+    input_plans[k]->print(s);
+  }
+}
+void PDDL_Base::write_heuristic_table(std::ostream& s)
+{
+  s << "(:heuristic";
+  for (index_type k = 0; k < h_table.length(); k++) {
+    s << std::endl << "(";
+    for (index_type i = 0; i < h_table[k]->atoms.length(); i++)
+      h_table[k]->atoms[i]->print(s);
+    s << ") ";
+    if (h_table[k]->opt) s << ":opt ";
+    if ((h_table[k]->cost).infinite()) s << ":inf";
+    else s << h_table[k]->cost;
+  }
+  s << ")" << std::endl;
+}
+void PDDL_Base::write_sets(std::ostream& s)
+{
+  for (index_type k = 0; k < input_sets.length(); k++) {
+    input_sets[k]->print(s);
+    s << std::endl;
+  }
+}
+PDDL_Base::Atom* PDDL_Base::make_atom_from_prop(ptr_pair& src, bool& neg)
+{
+  index_type i = dom_predicates.first((PredicateSymbol*)src.first);
+  if (i == no_such_index) {
+    std::cerr << "error in make_atom_from_prop: "
+       << src.first << " is not a predicate symbol in the domain"
+       << std::endl;
+    exit(255);
+  }
+  ptr_table* ins = (ptr_table*)src.second;
+  ptr_table::key_vec* args = ins->key_sequence();
+  ptr_table* root = ins->root();
+  if (root == &(dom_predicates[i]->pos_prop)) {
+    neg = false;
+  }
+  else if (root == &(dom_predicates[i]->neg_prop)) {
+    neg = true;
+  }
+  else {
+    std::cerr << "error: root " << root << " of atom instance "
+       << ins << " does not equal pos. or neg. set of predicate "
+       << dom_predicates[i]->print_name
+       << std::endl;
+    exit(255);
+  }
+  Atom* a = new Atom(dom_predicates[i]);
+  for (index_type k = 0; k < dom_predicates[i]->param.length(); k++)
+    a->param.append((PDDL_Base::Symbol*)((*args)[k + 1]));
+  delete args;
+  return a;
+}
+void InstanceName::write(std::ostream& s, unsigned int c) const
+{
+  if (context_is_domain(c)) write_string_escaped(s, domain_name, c);
+  else if (context_is_problem(c)) write_string_escaped(s, problem_name, c);
+  else {
+    write_string_escaped(s, domain_name, c);
+    write_string_escaped(s, "::", c);
+    write_string_escaped(s, problem_name, c);
+  }
+}
+const Name* InstanceName::cast_to(const char* cname) const
+{
+  if (strcmp(cname, "InstanceName") == 0) return this;
+  return 0;
+}
+char PDDL_Name::catc = '_';
+bool PDDL_Name::obscure_symbol_names = false;
+PDDL_Name::PDDL_Name
+(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n)
+  : neg(n), sym(s), arg(0, a.length()), vis(s->visible), avis(true, a.length())
+{
+  for (index_type k = 0; k < a.length(); k++) {
+    arg[k] = a[k]->value;
+    avis[k] = a[k]->visible;
+  }
+}
+void PDDL_Name::add(PDDL_Base::Symbol* s)
+{
+  arg.append(s);
+  avis.append(s->visible);
+}
+void PDDL_Name::add(PDDL_Base::Symbol* s, bool v)
+{
+  arg.append(s);
+  avis.append(v);
+}
+void PDDL_Name::write(std::ostream& s, unsigned int c) const
+{
+  if (context_is_instance(c)) {
+    if (neg) {
+      s << "not";
+      write_char_escaped(s, catc, c);
+    }
+    if (obscure_symbol_names) {
+      s << "S" << ((void*)sym->print_name);
+    }
+    else {
+      write_string_escaped(s, sym->print_name, c);
+    }
+    for (index_type k = 0; k < arg.length(); k++) {
+      write_char_escaped(s, catc, c);
+      if (obscure_symbol_names) {
+ s << "S" << ((void*)arg[k]->print_name);
+      }
+      else {
+ write_string_escaped(s, arg[k]->print_name, c);
+      }
+    }
+  }
+  else {
+    if (context_is_plan(c) && conform_to_IPC(c) && !vis) return;
+    if (neg) write_string_escaped(s, "(not ", c);
+    write_char_escaped(s, '(', c);
+    if (obscure_symbol_names) {
+      s << "S" << ((void*)sym->print_name);
+    }
+    else {
+      write_string_escaped(s, sym->print_name, c);
+    }
+    for (index_type k = 0; k < arg.length(); k++) {
+      bool do_print = true;
+      if (context_is_plan(c) && conform_to_IPC(c)) {
+ assert(avis.length() > k);
+ if (!avis[k]) do_print = false;
+      }
+      if (do_print) {
+ s << ' ';
+ if (obscure_symbol_names) {
+   s << "S" << ((void*)arg[k]->print_name);
+ }
+ else {
+   write_string_escaped(s, arg[k]->print_name, c);
+ }
+      }
+    }
+    write_char_escaped(s, ')', c);
+    if (neg) write_char_escaped(s, ')', c);
+  }
+}
+const Name* PDDL_Name::cast_to(const char* cname) const
+{
+  if (strcmp(cname, "PDDL_Name") == 0) return this;
+  return 0;
+}
+Numbered_PDDL_Name::Numbered_PDDL_Name(PDDL_Name* n, index_type c)
+  : PDDL_Name(n->symbol(), n->args(), n->is_neg()), copy(c)
+{
+}
+void Numbered_PDDL_Name::write(std::ostream& s, unsigned int c) const
+{
+  if (context_is_instance(c)) {
+    if (neg) write_string_escaped(s, "not_", c);
+    write_string_escaped(s, sym->print_name, c);
+    for (index_type k = 0; k < arg.length(); k++) {
+      write_char_escaped(s, '_', c);
+      write_string_escaped(s, arg[k]->print_name, c);
+    }
+    write_char_escaped(s, '_', c);
+    s << copy;
+  }
+  else {
+    if (neg) write_string_escaped(s, "(not ", c);
+    write_char_escaped(s, '(', c);
+    write_string_escaped(s, sym->print_name, c);
+    for (index_type k = 0; k < arg.length(); k++) {
+      write_char_escaped(s, ' ', c);
+      write_string_escaped(s, arg[k]->print_name, c);
+    }
+    write_char_escaped(s, ' ', c);
+    if (!context_is_plan(c)) {
+      write_char_escaped(s, '#', c);
+      s << copy;
+    }
+    if (neg) write_char_escaped(s, ')', c);
+  }
+}
+}

--- a/pr/seq-opt-hspsf/bfs.ccx
+++ b/pr/seq-opt-hspsf/bfs.ccx
@@ -1,0 +1,3226 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+class Node;
+typedef Node* nodep;
+typedef lvector<nodep> node_vec;
+struct Link {
+  Node* node;
+  hsps::rational delta;
+  Link() : node(0), delta(0) { };
+  Link(Node* s, hsps::rational d) : node(s), delta(d) { };
+  Link& operator=(const Link& l);
+  bool operator==(const Link& l);
+  bool operator<(const Link& l);
+  bool operator>(const Link& l);
+  bool operator<=(const Link& l);
+  bool operator>=(const Link& l);
+};
+typedef svector<Link> link_vec;
+class Node {
+ public:
+  index_type id;
+  State* state;
+  link_vec succ;
+  bool closed;
+  hsps::rational acc;
+  hsps::rational est;
+  hsps::rational val;
+  hsps::rational opt;
+  index_type pos;
+  count_type exp;
+  Node* bp_pre;
+  hsps::rational bp_delta;
+  link_vec* all_pre;
+  Node() :
+    id(0), state(0), closed(false), acc(0), est(0), val(0), opt(POS_INF),
+    pos(no_such_index), exp(0), bp_pre(0), bp_delta(0), all_pre(0) { };
+  ~Node();
+  hsps::rational min_delta_to(Node* n);
+  bool solved() { return (opt).finite(); };
+  bool back_path_contains(Node* n);
+  void add_predecessor(Node* n, hsps::rational d);
+  void backup_costs(node_vec& p);
+  void write(std::ostream& s, const Name* p = 0);
+  void write_short(std::ostream& s, const Name* p = 0);
+  void write_graph_node(std::ostream& s);
+  void write_graph_edges(std::ostream& s);
+};
+class NodeQueue : public node_vec {
+  const node_vec::order& before;
+ public:
+  NodeQueue(const node_vec::order& b);
+  ~NodeQueue();
+  void check_queue();
+  Node* peek();
+  void enqueue(Node*);
+  Node* dequeue();
+  void shift_up(index_type i);
+  void shift_down(index_type i);
+};
+class NodeSet {
+ protected:
+  static index_type next_id;
+  node_vec roots;
+ public:
+  static bool write_state_in_graph_node;
+  virtual ~NodeSet();
+  virtual Node* insert_node(State& s) = 0;
+  virtual Node* find_node(State& s) = 0;
+  virtual void clear() = 0;
+  virtual void collect_nodes(node_vec& ns) = 0;
+  Node* insert_root_node(State& s);
+  void make_root(Node* n);
+  node_vec& root_nodes();
+  void compute_reverse_links(node_vec& v);
+  void compute_reverse_links();
+  void mark_solved_apsp();
+  void mark_solved();
+  void backup_costs();
+  void set_back_path_solution_cost(Node* n, hsps::rational c_sol);
+  void cache_pg(hsps::rational c_sol);
+  void back_path_to_sequence(Node* n, node_vec& ns);
+  State* build_path(node_vec& ns);
+  State* build_path(Node* tn);
+  void write_short(std::ostream& s, const Name* p = 0);
+  void write_graph(std::ostream& s);
+};
+class NodeSetSearchState : public State {
+  Node* node;
+  hsps::rational delta;
+  State* path;
+ public:
+  NodeSetSearchState(Node* n);
+  NodeSetSearchState(NodeSetSearchState* p, Link& l, State* s);
+  NodeSetSearchState(const NodeSetSearchState& s);
+  virtual ~NodeSetSearchState();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write(std::ostream& s);
+  virtual void write_plan(std::ostream& s);
+};
+class TreeNodeSet : public Node, public NodeSet {
+  TreeNodeSet* left;
+  TreeNodeSet* right;
+ public:
+  TreeNodeSet();
+  virtual ~TreeNodeSet();
+  virtual Node* insert_node(State& s);
+  virtual Node* find_node(State& s);
+  virtual void clear();
+  virtual void collect_nodes(node_vec& ns);
+};
+class HashNodeSet : public NodeSet {
+  index_type size;
+  TreeNodeSet** tab;
+ public:
+  HashNodeSet(index_type s);
+  virtual ~HashNodeSet();
+  virtual Node* insert_node(State& s);
+  virtual Node* find_node(State& s);
+  virtual void clear();
+  virtual void collect_nodes(node_vec& ns);
+};
+inline Link& Link::operator=(const Link& l)
+{
+  node = l.node;
+  delta = l.delta;
+  return *this;
+}
+inline bool Link::operator==(const Link& l)
+{
+  return ((node == l.node) && (delta == l.delta));
+}
+inline bool Link::operator<(const Link& l)
+{
+  return ((node < l.node) || ((node == l.node) && (delta < l.delta)));
+}
+inline bool Link::operator>(const Link& l)
+{
+  return ((node > l.node) || ((node == l.node) && (delta > l.delta)));
+}
+inline bool Link::operator<=(const Link& l)
+{
+  return ((node <= l.node) || ((node == l.node) && (delta <= l.delta)));
+}
+inline bool Link::operator>=(const Link& l)
+{
+  return ((node >= l.node) || ((node == l.node) && (delta >= l.delta)));
+}
+}
+namespace hsps {
+class NodeOrderForBFS : public node_vec::order {
+ public:
+  NodeOrderForBFS() { };
+  virtual bool operator()(const nodep& v0, const nodep& v1) const;
+};
+class BFS : public SingleSearchAlgorithm {
+  static NodeOrderForBFS b_op;
+ protected:
+  static const count_type TRACE_LEVEL_2_NOTIFY = 10000;
+  HashNodeSet graph;
+  NodeQueue queue;
+  Node* current_node;
+  hsps::rational best_node_cost;
+  count_type acc_succ;
+  count_type new_succ;
+  void update_cost(Node* n, Node* p, hsps::rational d);
+ public:
+  NodeSet& state_space() { return graph; };
+  BFS(Statistics& s, SearchResult& r);
+  BFS(Statistics& s, SearchResult& r, index_type nt_size);
+  virtual ~BFS();
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+  virtual hsps::rational resume();
+  virtual hsps::rational main();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual hsps::rational cost() const;
+  virtual bool done() const;
+};
+class BFS_PX : public BFS {
+  hsps::rational threshold;
+ public:
+  BFS_PX(Statistics& s, SearchResult& r, hsps::rational thresh)
+    : BFS(s, r), threshold(thresh) { };
+  BFS_PX(Statistics& s, SearchResult& r, index_type nt_size, hsps::rational thresh)
+    : BFS(s, r, nt_size), threshold(thresh) { };
+  virtual ~BFS_PX() { };
+  virtual hsps::rational main();
+};
+}
+namespace hsps {
+bool NodeOrderForBFS::operator()(const nodep& v0, const nodep& v1) const
+{
+  if (v0->val < v1->val) return true;
+  if ((v0->val == v1->val) && (v0->est < v1->est)) return true;
+  return false;
+}
+NodeOrderForBFS BFS::b_op;
+void BFS::update_cost(Node* n, Node* p, hsps::rational d) {
+  hsps::rational c_new = p->acc + d;
+  if (c_new < n->acc) {
+    n->acc = c_new;
+    n->val = c_new + n->est;
+    n->bp_pre = p;
+    n->bp_delta = d;
+    if (n->pos != no_such_index) {
+      queue.shift_up(n->pos);
+    }
+    for (index_type k = 0; k < n->succ.length(); k++)
+      update_cost(n->succ[k].node, n, n->succ[k].delta);
+  }
+}
+hsps::rational BFS::new_state(State& s, hsps::rational bound) {
+  hsps::rational s_est = s.est_cost();
+  if ((s_est).infinite()) return POS_INF;
+  acc_succ += 1;
+  Node* n = graph.insert_node(s);
+  if (n->state) {
+    assert(current_node);
+    current_node->succ.insert(Link(n, s.delta_cost()));
+    if (n->acc > (current_node->acc + s.delta_cost())) {
+      if (trace_level > 3) {
+ std::cerr << "update #" << n->id << " " << s
+    << ": " << n->acc << "/" << n->est << "/" << n->val
+    << " -> "
+    << current_node->acc + s.delta_cost() << "/"
+    << n->est << "/"
+    << current_node->acc + s.delta_cost() + n->est
+    << ", #" << current_node->id << std::endl;
+ Node* p = n->bp_pre;
+ while (p) {
+   std::cerr << " #" << p->id
+      << ": " << p->acc << "/" << p->est << "/" << p->val
+      << " <- ";
+   p = p->bp_pre;
+ }
+ std::cerr << "0" << std::endl;
+ p = current_node;
+ while (p) {
+   std::cerr << " #" << p->id
+      << ": " << p->acc << "/" << p->est << "/" << p->val
+      << " <- ";
+   p = p->bp_pre;
+ }
+ std::cerr << "0" << std::endl;
+      }
+      delete n->state;
+      n->state = s.copy();
+      update_cost(n, current_node, s.delta_cost());
+    }
+  }
+  else {
+    new_succ += 1;
+    stats.create_node(s);
+    n->state = s.copy();
+    if (current_node) {
+      current_node->succ.insert(Link(n, s.delta_cost()));
+      n->bp_pre = current_node;
+      n->bp_delta = s.delta_cost();
+      n->acc = current_node->acc + s.delta_cost();
+    }
+    else {
+      graph.make_root(n);
+      n->bp_pre = 0;
+      n->bp_delta = s.delta_cost();
+      if (n->bp_delta > 0) {
+ std::cerr << "warning: root node with non-zero delta cost"
+    << std::endl;
+      }
+      n->acc = s.delta_cost();
+    }
+    n->est = s_est;
+    n->val = n->acc + n->est;
+    n->exp = 0;
+    queue.enqueue(n);
+    if (trace_level > 3) {
+      std::cerr << "new #" << n->id << " " << s
+  << ": " << n->acc << "/" << n->est << "/" << n->val;
+      if (trace_level > 4) {
+ std::cerr << " >> ";
+ s.write_path(std::cerr);
+      }
+      std::cerr << std::endl;
+    }
+  }
+  return POS_INF;
+}
+BFS::BFS(Statistics& s, SearchResult& r)
+  : SingleSearchAlgorithm(s, r),
+    graph(31337),
+    queue(b_op),
+    current_node(0),
+    best_node_cost(0)
+{
+}
+BFS::BFS(Statistics& s, SearchResult& r, index_type nt_size)
+  : SingleSearchAlgorithm(s, r),
+    graph(nt_size),
+    queue(b_op),
+    current_node(0),
+    best_node_cost(0)
+{
+}
+BFS::~BFS() {
+}
+hsps::rational BFS::main() {
+  while ((!solved() || result.more()) && !queue.empty()) {
+    if (break_signal_raised()) return best_node_cost;
+    current_node = queue.peek();
+    if (current_node->val > best_node_cost) {
+      if (!solved()) stats.current_lower_bound(best_node_cost);
+      result.no_more_solutions(best_node_cost);
+      if (solved() && !result.more()) return best_node_cost;
+      best_node_cost = current_node->val;
+      if (trace_level > 0) {
+ std::cerr << "f = " << current_node->val
+    << ", q = " << queue.length()
+    << ", " << stats << std::endl;
+      }
+    }
+    if (best_node_cost > cost_limit) {
+      return best_node_cost;
+    }
+    current_node = queue.dequeue();
+    assert(!current_node->state->is_max());
+    if (current_node->state->is_final()) {
+      if (trace_level > 0) {
+ std::cerr << "solution (cost = " << current_node->acc
+    << " (" << current_node->state->acc_cost()
+    << "), depth = " << current_node->state->depth() << ")"
+    << std::endl;
+      }
+      set_solved(true);
+      graph.set_back_path_solution_cost(current_node, current_node->acc);
+      if (current_node->state->is_encapsulated()) {
+ result.solution(*(current_node->state),
+   current_node->state->acc_cost());
+      }
+      else {
+ State* f_state = graph.build_path(current_node);
+ result.solution(*f_state, f_state->acc_cost());
+ f_state->delete_path();
+      }
+    }
+    else {
+      assert(current_node->exp == 0);
+      stats.expand_node(*(current_node->state));
+      if (trace_level > 2) {
+ std::cerr << "expanding #" << current_node->id
+    << " " << *(current_node->state)
+    << ": " << current_node->acc
+    << "/" << current_node->est
+    << "/" << current_node->val;
+ if (current_node->bp_pre) {
+   std::cerr << ", pre = #" << current_node->bp_pre->id;
+ }
+ std::cerr << std::endl;
+      }
+      else if (trace_level > 1) {
+ if ((stats.nodes() % TRACE_LEVEL_2_NOTIFY) == 0)
+   std::cerr << stats << std::endl;
+      }
+      acc_succ = 0;
+      new_succ = 0;
+      index_type l = queue.length();
+      current_node->state->expand(*this, POS_INF);
+      current_node->exp += 1;
+      if (!done()) current_node->closed = true;
+      assert(new_succ == (queue.length() - l));
+      if (trace_level > 3) {
+ std::cerr << "done expanding #" << current_node->id
+    << " (" << acc_succ << " acc. / " << new_succ
+    << " new succs.), closed = " << current_node->closed
+    << std::endl;
+      }
+    }
+    current_node = 0;
+  }
+  if (queue.empty()) {
+    result.no_more_solutions(POS_INF);
+    if (!solved()) best_node_cost = POS_INF;
+  }
+  return best_node_cost;
+}
+hsps::rational BFS::start(State& s, hsps::rational b)
+{
+  return start(s);
+}
+hsps::rational BFS::start(State& s)
+{
+  reset();
+  graph.clear();
+  queue.set_length(0);
+  best_node_cost = 0;
+  start_count();
+  current_node = 0;
+  new_state(s, POS_INF);
+  hsps::rational val = main();
+  stop_count();
+  return val;
+}
+hsps::rational BFS::resume() {
+  start_count();
+  hsps::rational val = main();
+  stop_count();
+  return val;
+}
+hsps::rational BFS::cost() const {
+  return best_node_cost;
+}
+bool BFS::done() const {
+  return ((solved() && !result.more()) || break_signal_raised());
+}
+hsps::rational BFS_PX::main() {
+  while ((!solved() || result.more()) && !queue.empty()) {
+    if (break_signal_raised()) return best_node_cost;
+    current_node = queue.peek();
+    if (current_node->val > best_node_cost) {
+      if (!solved()) stats.current_lower_bound(current_node->val);
+      result.no_more_solutions(best_node_cost);
+      if (solved() && !result.more()) return best_node_cost;
+      best_node_cost = current_node->val;
+      if (trace_level > 0) {
+ std::cerr << "f = " << current_node->val
+    << ", q = " << queue.length()
+    << ", " << stats << std::endl;
+      }
+    }
+    if (best_node_cost > cost_limit) {
+      return best_node_cost;
+    }
+    current_node = queue.dequeue();
+    assert(!current_node->state->is_max());
+    if (current_node->state->is_final()) {
+      set_solved(true);
+      if (current_node->state->is_encapsulated()) {
+ result.solution(*(current_node->state),
+   current_node->state->acc_cost());
+      }
+      else {
+ State* f_state = graph.build_path(current_node);
+ result.solution(*f_state, f_state->acc_cost());
+ f_state->delete_path();
+      }
+    }
+    else {
+      stats.expand_node(*(current_node->state));
+      if (trace_level > 2) {
+ if (current_node->exp == 0)
+   std::cerr << "expanding ";
+ else
+   std::cerr << "re-expanding ";
+ std::cerr << *(current_node->state) << ": "
+    << current_node->acc << "/"
+    << current_node->est << "/"
+    << current_node->val
+    << " with bound " << current_node->val + threshold
+    << std::endl;
+ acc_succ = 0;
+ new_succ = 0;
+      }
+      else if (trace_level > 1) {
+ if ((stats.nodes() % TRACE_LEVEL_2_NOTIFY) == 0)
+   std::cerr << stats << std::endl;
+      }
+      hsps::rational new_val =
+ current_node->state->expand(*this, current_node->val + threshold);
+      if (trace_level > 2) {
+ std::cerr << "new value is " << new_val << ", " << acc_succ
+    << " successors accepted, " << new_succ << " are new"
+    << std::endl;
+      }
+      if ((new_val).finite()) {
+ current_node->val = new_val;
+ queue.enqueue(current_node);
+      }
+      current_node->exp += 1;
+    }
+    current_node = 0;
+  }
+  if (queue.empty()) {
+    result.no_more_solutions(POS_INF);
+    if (!solved()) best_node_cost = POS_INF;
+  }
+  return best_node_cost;
+}
+}

--- a/pr/seq-opt-hspsf/build
+++ b/pr/seq-opt-hspsf/build
@@ -1,0 +1,36 @@
+set -x
+g++ -O6 -m32 -c -x c++ hsp_f.ccx
+g++ -O6 -m32 -c -x c++ rational.ccx
+g++ -O6 -m32 -c -x c++ index_type.ccx
+g++ -O6 -m32 -c -x c++ name.ccx
+g++ -O6 -m32 -c -x c++ ptr_table.ccx
+g++ -O6 -m32 -c -x c++ char_map.ccx
+g++ -O6 -m32 -c -x c++ string_table.ccx
+g++ -O6 -m32 -c -x c++ numeric_type.ccx
+g++ -O6 -m32 -c -x c++ graph.ccx
+g++ -O6 -m32 -c -x c++ enumerators.ccx
+g++ -O6 -m32 -c -x c++ rng.ccx
+g++ -O6 -m32 -c -x c++ problem.ccx
+g++ -O6 -m32 -c -x c++ soft.ccx
+g++ -O6 -m32 -c -x c++ search.ccx
+g++ -O6 -m32 -c -x c++ heuristic.ccx
+g++ -O6 -m32 -c -x c++ stats.ccx
+g++ -O6 -m32 -c -x c++ exec.ccx
+g++ -O6 -m32 -c -x c++ plans.ccx
+g++ -O6 -m32 -c -x c++ preprocess.ccx
+g++ -O6 -m32 -c -x c++ cost_table.ccx
+g++ -O6 -m32 -c -x c++ additive.ccx
+g++ -O6 -m32 -c -x c++ atomset.ccx
+g++ -O6 -m32 -c -x c++ resource.ccx
+g++ -O6 -m32 -c -x c++ seq_reg.ccx
+g++ -O6 -m32 -c -x c++ forward.ccx
+g++ -O6 -m32 -c -x c++ search_base.ccx
+g++ -O6 -m32 -c -x c++ hashtable.ccx
+g++ -O6 -m32 -c -x c++ ida.ccx
+g++ -O6 -m32 -c -x c++ nodeset.ccx
+g++ -O6 -m32 -c -x c++ bfs.ccx
+g++ -O6 -m32 -c -x c++ base.ccx
+g++ -O6 -m32 -c -x c++ parser.ccx
+g++ -O6 -m32 -c -x c++ grammar.ccx
+g++ -O6 -m32 -c -x c++ scanner.ccx
+g++ -O6 -m32 -o hsp_f  hsp_f.o  rational.o  index_type.o  name.o  ptr_table.o  char_map.o  string_table.o  numeric_type.o  graph.o  enumerators.o  rng.o  problem.o  soft.o  search.o  heuristic.o  stats.o  exec.o  plans.o  preprocess.o  cost_table.o  additive.o  atomset.o  resource.o  seq_reg.o  forward.o  search_base.o  hashtable.o  ida.o  nodeset.o  bfs.o  base.o  parser.o  grammar.o  scanner.o 

--- a/pr/seq-opt-hspsf/char_map.ccx
+++ b/pr/seq-opt-hspsf/char_map.ccx
@@ -1,0 +1,1623 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+const char lowercase[char_map::_CHAR_COUNT] =
+    {(char)0x00,(char)0x01,(char)0x02,(char)0x03,(char)0x04,
+     (char)0x05,(char)0x06,(char)0x07,(char)0x08,(char)0x09,
+     (char)0x0A,(char)0x0B,(char)0x0C,(char)0x0D,(char)0x0E,
+     (char)0x0F,(char)0x10,(char)0x11,(char)0x12,(char)0x13,
+     (char)0x14,(char)0x15,(char)0x16,(char)0x17,(char)0x18,
+     (char)0x19,(char)0x1A,(char)0x1B,(char)0x1C,(char)0x1D,
+     (char)0x1E,(char)0x1F,(char)0x20,(char)0x21,(char)0x22,
+     (char)0x23,(char)0x24,(char)0x25,(char)0x26,(char)0x27,
+     (char)0x28,(char)0x29,(char)0x2A,(char)0x2B,(char)0x2C,
+     (char)0x2D,(char)0x2E,(char)0x2F,(char)0x30,(char)0x31,
+     (char)0x32,(char)0x33,(char)0x34,(char)0x35,(char)0x36,
+     (char)0x37,(char)0x38,(char)0x39,(char)0x3A,(char)0x3B,
+     (char)0x3C,(char)0x3D,(char)0x3E,(char)0x3F,(char)0x40,
+     (char)0x61,(char)0x62,(char)0x63,(char)0x64,(char)0x65,
+     (char)0x66,(char)0x67,(char)0x68,(char)0x69,(char)0x6A,
+     (char)0x6B,(char)0x6C,(char)0x6D,(char)0x6E,(char)0x6F,
+     (char)0x70,(char)0x71,(char)0x72,(char)0x73,(char)0x74,
+     (char)0x75,(char)0x76,(char)0x77,(char)0x78,(char)0x79,
+     (char)0x7A,(char)0x5B,(char)0x5C,(char)0x5D,(char)0x5E,
+     (char)0x5F,(char)0x60,(char)0x61,(char)0x62,(char)0x63,
+     (char)0x64,(char)0x65,(char)0x66,(char)0x67,(char)0x68,
+     (char)0x69,(char)0x6A,(char)0x6B,(char)0x6C,(char)0x6D,
+     (char)0x6E,(char)0x6F,(char)0x70,(char)0x71,(char)0x72,
+     (char)0x73,(char)0x74,(char)0x75,(char)0x76,(char)0x77,
+     (char)0x78,(char)0x79,(char)0x7A,(char)0x7B,(char)0x7C,
+     (char)0x7D,(char)0x7E,(char)0x7F,(char)0x80,(char)0x81,
+     (char)0x82,(char)0x83,(char)0x84,(char)0x85,(char)0x86,
+     (char)0x87,(char)0x88,(char)0x89,(char)0x8A,(char)0x8B,
+     (char)0x8C,(char)0x8D,(char)0x8E,(char)0x8F,(char)0x90,
+     (char)0x91,(char)0x92,(char)0x93,(char)0x94,(char)0x95,
+     (char)0x96,(char)0x97,(char)0x98,(char)0x99,(char)0x9A,
+     (char)0x9B,(char)0x9C,(char)0x9D,(char)0x9E,(char)0x9F,
+     (char)0xA0,(char)0xA1,(char)0xA2,(char)0xA3,(char)0xA4,
+     (char)0xA5,(char)0xA6,(char)0xA7,(char)0xA8,(char)0xA9,
+     (char)0xAA,(char)0xAB,(char)0xAC,(char)0xAD,(char)0xAE,
+     (char)0xAF,(char)0xB0,(char)0xB1,(char)0xB2,(char)0xB3,
+     (char)0xB4,(char)0xB5,(char)0xB6,(char)0xB7,(char)0xB8,
+     (char)0xB9,(char)0xBA,(char)0xBB,(char)0xBC,(char)0xBD,
+     (char)0xBE,(char)0xBF,(char)0xC0,(char)0xC1,(char)0xC2,
+     (char)0xC3,(char)0xC4,(char)0xC5,(char)0xC6,(char)0xC7,
+     (char)0xC8,(char)0xC9,(char)0xCA,(char)0xCB,(char)0xCC,
+     (char)0xCD,(char)0xCE,(char)0xCF,(char)0xD0,(char)0xD1,
+     (char)0xD2,(char)0xD3,(char)0xD4,(char)0xD5,(char)0xD6,
+     (char)0xD7,(char)0xD8,(char)0xD9,(char)0xDA,(char)0xDB,
+     (char)0xDC,(char)0xDD,(char)0xDE,(char)0xDF,(char)0xE0,
+     (char)0xE1,(char)0xE2,(char)0xE3,(char)0xE4,(char)0xE5,
+     (char)0xE6,(char)0xE7,(char)0xE8,(char)0xE9,(char)0xEA,
+     (char)0xEB,(char)0xEC,(char)0xED,(char)0xEE,(char)0xEF,
+     (char)0xF0,(char)0xF1,(char)0xF2,(char)0xF3,(char)0xF4,
+     (char)0xF5,(char)0xF6,(char)0xF7,(char)0xF8,(char)0xF9,
+     (char)0xFA,(char)0xFB,(char)0xFC,(char)0xFD,(char)0xFE,
+     (char)0xFF};
+const char rot13[char_map::_CHAR_COUNT] =
+    {(char)0x00,(char)0x01,(char)0x02,(char)0x03,(char)0x04,
+     (char)0x05,(char)0x06,(char)0x07,(char)0x08,(char)0x09,
+     (char)0x0A,(char)0x0B,(char)0x0C,(char)0x0D,(char)0x0E,
+     (char)0x0F,(char)0x10,(char)0x11,(char)0x12,(char)0x13,
+     (char)0x14,(char)0x15,(char)0x16,(char)0x17,(char)0x18,
+     (char)0x19,(char)0x1A,(char)0x1B,(char)0x1C,(char)0x1D,
+     (char)0x1E,(char)0x1F,(char)0x20,(char)0x21,(char)0x22,
+     (char)0x23,(char)0x24,(char)0x25,(char)0x26,(char)0x27,
+     (char)0x28,(char)0x29,(char)0x2A,(char)0x2B,(char)0x2C,
+     (char)0x2D,(char)0x2E,(char)0x2F,(char)0x30,(char)0x31,
+     (char)0x32,(char)0x33,(char)0x34,(char)0x35,(char)0x36,
+     (char)0x37,(char)0x38,(char)0x39,(char)0x3A,(char)0x3B,
+     (char)0x3C,(char)0x3D,(char)0x3E,(char)0x3F,(char)0x40,
+     (char)0x6E,(char)0x6F,(char)0x70,(char)0x71,(char)0x72,
+     (char)0x73,(char)0x74,(char)0x75,(char)0x76,(char)0x77,
+     (char)0x78,(char)0x79,(char)0x7A,(char)0x61,(char)0x62,
+     (char)0x63,(char)0x64,(char)0x65,(char)0x66,(char)0x67,
+     (char)0x68,(char)0x69,(char)0x6A,(char)0x6B,(char)0x6C,
+     (char)0x6D,(char)0x5B,(char)0x5C,(char)0x5D,(char)0x5E,
+     (char)0x5F,(char)0x60,(char)0x6E,(char)0x6F,(char)0x70,
+     (char)0x71,(char)0x72,(char)0x73,(char)0x74,(char)0x75,
+     (char)0x76,(char)0x77,(char)0x78,(char)0x79,(char)0x7A,
+     (char)0x61,(char)0x62,(char)0x63,(char)0x64,(char)0x65,
+     (char)0x66,(char)0x67,(char)0x68,(char)0x69,(char)0x6A,
+     (char)0x6B,(char)0x6C,(char)0x6D,(char)0x7B,(char)0x7C,
+     (char)0x7D,(char)0x7E,(char)0x7F,(char)0x80,(char)0x81,
+     (char)0x82,(char)0x83,(char)0x84,(char)0x85,(char)0x86,
+     (char)0x87,(char)0x88,(char)0x89,(char)0x8A,(char)0x8B,
+     (char)0x8C,(char)0x8D,(char)0x8E,(char)0x8F,(char)0x90,
+     (char)0x91,(char)0x92,(char)0x93,(char)0x94,(char)0x95,
+     (char)0x96,(char)0x97,(char)0x98,(char)0x99,(char)0x9A,
+     (char)0x9B,(char)0x9C,(char)0x9D,(char)0x9E,(char)0x9F,
+     (char)0xA0,(char)0xA1,(char)0xA2,(char)0xA3,(char)0xA4,
+     (char)0xA5,(char)0xA6,(char)0xA7,(char)0xA8,(char)0xA9,
+     (char)0xAA,(char)0xAB,(char)0xAC,(char)0xAD,(char)0xAE,
+     (char)0xAF,(char)0xB0,(char)0xB1,(char)0xB2,(char)0xB3,
+     (char)0xB4,(char)0xB5,(char)0xB6,(char)0xB7,(char)0xB8,
+     (char)0xB9,(char)0xBA,(char)0xBB,(char)0xBC,(char)0xBD,
+     (char)0xBE,(char)0xBF,(char)0xC0,(char)0xC1,(char)0xC2,
+     (char)0xC3,(char)0xC4,(char)0xC5,(char)0xC6,(char)0xC7,
+     (char)0xC8,(char)0xC9,(char)0xCA,(char)0xCB,(char)0xCC,
+     (char)0xCD,(char)0xCE,(char)0xCF,(char)0xD0,(char)0xD1,
+     (char)0xD2,(char)0xD3,(char)0xD4,(char)0xD5,(char)0xD6,
+     (char)0xD7,(char)0xD8,(char)0xD9,(char)0xDA,(char)0xDB,
+     (char)0xDC,(char)0xDD,(char)0xDE,(char)0xDF,(char)0xE0,
+     (char)0xE1,(char)0xE2,(char)0xE3,(char)0xE4,(char)0xE5,
+     (char)0xE6,(char)0xE7,(char)0xE8,(char)0xE9,(char)0xEA,
+     (char)0xEB,(char)0xEC,(char)0xED,(char)0xEE,(char)0xEF,
+     (char)0xF0,(char)0xF1,(char)0xF2,(char)0xF3,(char)0xF4,
+     (char)0xF5,(char)0xF6,(char)0xF7,(char)0xF8,(char)0xF9,
+     (char)0xFA,(char)0xFB,(char)0xFC,(char)0xFD,(char)0xFE,
+     (char)0xFF};
+char_map lowercase_map(lowercase);
+char_map rot13_map(rot13);
+char_map::char_map() {
+  for (int k = 0; k < _CHAR_COUNT; k++) _map[k] = k;
+}
+char_map::char_map(const char in[_CHAR_COUNT]) {
+  for (int k = 0; k < _CHAR_COUNT; k++) _map[k] = in[k];
+}
+void char_map::identify(char _c0, char _c1) {
+  _map[(unsigned char)_c1] = _c0;
+  for (unsigned int k = 0; k < _CHAR_COUNT; k++)
+    if (_map[k] == _c1) _map[k] = _c0;
+}
+void char_map::apply(char* s) const {
+  for (; *s; s++) *s = _map[*s];
+}
+void char_map::apply(char* s, index_type len) const {
+  for (index_type k = 0; k < len; s++, k++) *s = _map[*s];
+}
+int char_map::strcmp(const char *s0, const char *s1) const {
+  while (true) {
+    if (_map[*s0] < _map[*s1]) return -1;
+    else if (_map[*s0] > _map[*s1]) return 1;
+    else if (*s0 == (char)0) return 0;
+    else { s0++; s1++; }
+  }
+}
+int char_map::strcmp(const char *s0, const char *s1, index_type len) const {
+  while (true) {
+    if (len == 0) return 0;
+    else if (_map[*s0] < _map[*s1]) return -1;
+    else if (_map[*s0] > _map[*s1]) return 1;
+    else { s0++; s1++; len--; }
+  }
+}
+const char* char_map::strchr(const char* s, char c) const {
+  for (; *s && (_map[*s] != _map[c]); s++);
+  if (*s) return s;
+  else return 0;
+}
+const char* char_map::strchr(const char* s, index_type len, char c) const {
+  for (; len && (_map[*s] != _map[c]); s++, len--);
+  if (len) return s;
+  else return 0;
+}
+char* char_map::strcpy(const char *s0, char *s1) const {
+  char* r = s1;
+  while (*s0) {
+    *s1 = _map[(unsigned char)*s0];
+    s0++; s1++;
+  }
+  *s1 = 0;
+  return r;
+}
+char* char_map::strcpy(const char *s0, index_type len, char *s1) const {
+  char* r = s1;
+  while (len) {
+    *s1 = _map[(unsigned char)*s0];
+    s0++; s1++; len--;
+  }
+  *s1 = 0;
+  return r;
+}
+char* char_map::strdup(const char *s0) const {
+  char* r = new char[strlen(s0)+1];
+  return strcpy(s0, r);
+}
+char* char_map::strdup(const char *s0, index_type len) const {
+  char* r = new char[len+1];
+  return strcpy(s0, len, r);
+}
+index_type char_map::hash(const char *s) const {
+  index_type val = 0;
+  char* v = (char*)&val;
+  for (int k = 0; *s != '\0'; k++)
+    v[k % sizeof(index_type)] ^= _map[*(s++)];
+  return val;
+}
+index_type char_map::hash(const char *s, index_type len) const {
+  index_type val = 0;
+  char* v = (char*)&val;
+  for (int k = 0; k < len; k++)
+    v[k % sizeof(index_type)] ^= _map[*(s++)];
+  return val;
+}
+}

--- a/pr/seq-opt-hspsf/copyright.txt
+++ b/pr/seq-opt-hspsf/copyright.txt
@@ -1,0 +1,12 @@
+
+The source code in this archive is released without copyright (i.e., it
+is public domain). You may use it in any way for any purpose (including
+to make a profit - ha!). Note, however, that you can not copyright it
+(precisely because it has been made _public_ without copyright). You can
+still copyright works derived from it, though it seems most judicial
+systems apply some measure of common sense in interpreting what is a
+"derived work" (in short, you have to put some actual _work_ into making
+it).
+
+cheers,
+   /P@trik

--- a/pr/seq-opt-hspsf/cost_table.ccx
+++ b/pr/seq-opt-hspsf/cost_table.ccx
@@ -1,0 +1,6233 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+void sort2(index_type& i, index_type& j);
+void sort3(index_type& i, index_type& j, index_type& l);
+class PairIndexFunction : index_vec {
+ public:
+  PairIndexFunction(index_type n);
+  ~PairIndexFunction();
+  index_type operator()(index_type i, index_type j) const;
+  index_type max_in() const;
+  index_type max_out() const;
+};
+class CostNode {
+ public:
+  struct Value {
+    hsps::rational val;
+    bool opt;
+    CostNode* next;
+    bool mark;
+    count_type work;
+    Value() : val(0), opt(false), next(0), mark(false), work(0) { };
+    Value(hsps::rational v, bool o) : val(v), opt(o), next(0), mark(false), work(0) { };
+    Value& operator=(const Value& v)
+    { val = v.val; opt = v.opt; return *this; };
+    Value& operator=(hsps::rational v) { val = v; return *this; };
+    bool operator==(const Value& v) { return (val == v.val); };
+    bool operator<(const Value& v) { return (val < v.val); };
+    bool operator<=(const Value& v) { return (val <= v.val); };
+    bool operator>(const Value& v) { return (val > v.val); };
+    bool operator>=(const Value& v) { return (val >= v.val); };
+    bool operator==(const hsps::rational v) { return (val == v); };
+    bool operator<(const hsps::rational v) { return (val < v); };
+    bool operator<=(const hsps::rational v) { return (val <= v); };
+    bool operator>(const hsps::rational v) { return (val > v); };
+    bool operator>=(const hsps::rational v) { return (val >= v); };
+    void clear() {
+      val = 0;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+    void clear(hsps::rational v_default) {
+      val = v_default;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+  };
+ private:
+  index_type _size;
+  index_type _depth;
+  index_type _first;
+  hsps::rational _default;
+  hsps::rational _max;
+  Value* _store;
+  CostNode* _prev;
+  CostNode(CostNode* p, index_type f);
+  hsps::rational eval(const index_set& s, index_type i);
+  hsps::rational eval(const bool_vec& s, index_type i);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, index_type i, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, index_type i, hsps::rational bound);
+  void find_all(const index_set& s, index_type i, const index_set& c,
+   index_set_vec& a);
+  void set_max(hsps::rational v);
+  void write(std::ostream& s, index_set q) const;
+  void write_pddl(std::ostream& s, Instance& ins, index_set q) const;
+ public:
+  static bool eval_set_mark;
+  CostNode(index_type size);
+  CostNode(index_type size, hsps::rational v_default);
+  ~CostNode();
+  index_type size() const { return _size; };
+  index_type depth() const { return _depth; };
+  index_type first() const { return _first; };
+  index_type last() const { return _size - 1; };
+  Value& val(index_type p);
+  const Value& val(index_type p) const;
+  hsps::rational max() const { return _max; };
+  hsps::rational max_finite() const;
+  CostNode& next(index_type p);
+  Value* val_p(index_type p);
+  CostNode* next_p(index_type p);
+  Value* find(const index_set& s);
+  Value* find(const bool_vec& s);
+  void find_all(const index_set& s, index_set_vec& a);
+  Value& insert(const index_set& s);
+  Value& insert(const bool_vec& s);
+  void store(index_type p, hsps::rational v, bool opt);
+  void store(index_type p, hsps::rational v);
+  hsps::rational eval(const index_set& s);
+  hsps::rational eval(const bool_vec& s);
+  hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  void store(const index_set& s, hsps::rational v, bool opt);
+  void store(const bool_vec& s, hsps::rational v, bool opt);
+  void store(const index_set& s, hsps::rational v);
+  void store(const bool_vec& s, hsps::rational v);
+  hsps::rational eval_min(const index_set& s);
+  void compute_max();
+  void clear_marks();
+  void clear();
+  void write(std::ostream& s) const;
+  void write_pddl(std::ostream& s, Instance& ins) const;
+};
+class CostTable : public Heuristic, public CostNode {
+ public:
+  class Entry {
+  public:
+    index_set set;
+    CostNode::Value& val;
+    Entry* prev;
+    Entry* next;
+    Entry(index_set s, CostNode::Value& v)
+      : set(s), val(v), prev(0), next(0) { };
+    Entry& operator=(const Entry& e);
+    bool operator==(const Entry& e) { return set == e.set; };
+    bool operator<(const Entry& e) { return val < e.val; };
+    bool operator<=(const Entry& e) { return val <= e.val; };
+    bool operator>(const Entry& e) { return val > e.val; };
+    bool operator>=(const Entry& e) { return val >= e.val; };
+    Entry* first();
+    Entry* last();
+    Entry* move_down();
+    Entry* move_up();
+    void unlink();
+    void place_before(Entry* p);
+    void place_after(Entry* p);
+    void delete_list();
+    count_type list_length();
+  };
+ private:
+  Statistics& stats;
+  hsps::rational* pre_cost;
+  hsps::rational* per_cost;
+  bool update(index_type i, hsps::rational v, bool_vec& f);
+  bool update(index_type i, hsps::rational v);
+  bool update(index_type i, index_type j, hsps::rational v);
+  bool update(index_type i, index_type j, index_type l, hsps::rational v);
+  Entry* entries(CostNode* n, index_set s, Entry* l,
+   const index_set* filter, bool ign_zero, bool ign_opt,
+   bool ign_inf, bool req_mark, bool sort);
+  count_type count_entries(CostNode* n, index_set s, bool ign_zero,
+      bool ign_opt, bool ign_inf);
+  void fill(index_set& s, index_type d);
+  Entry* create_new_entries(const index_set& set,
+       const index_set& conflict_set,
+       const index_set& cd_ignore,
+       CostTable::Entry* list);
+  void compute_hm_graph_min
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+  void compute_hm_graph_max
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+ public:
+  static bool strong_conflict_detection;
+  static bool ultra_weak_conflict_detection;
+  static bool boost_new_entries;
+  static count_type n_entries_boosted;
+  static count_type n_entries_solved;
+  static count_type n_entries_discarded;
+  static count_type n_entries_created;
+  static count_type n_boost_searches;
+  static count_type n_boost_searches_with_cd;
+  CostTable(Instance& i, Statistics& s);
+  CostTable(Instance& i, Statistics& s, hsps::rational v_default);
+  ~CostTable();
+  virtual hsps::rational eval(index_type i);
+  virtual hsps::rational eval(index_type i, index_type j);
+  virtual hsps::rational eval(index_type i, index_type j, index_type k);
+  virtual hsps::rational eval(const index_set& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational eval(const bool_vec& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual void store(const index_set& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const index_set& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  virtual void store(const bool_vec& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  void store_list(Entry* l);
+  static Entry* insert_entry(Entry* e, Entry* l);
+  static Entry* prepend_entry(Entry* e, Entry* l);
+  static Entry* remove_entry(Entry* e, Entry* l);
+  static Entry* find_entry(index_set& s, Entry* l);
+  static Entry* copy_list(Entry* l);
+  count_type write_list(std::ostream& s, Entry* l);
+  bool interesting(const index_set& s);
+  Entry* atoms();
+  Entry* pairs();
+  Entry* entries();
+  Entry* entries(bool ign_zero, bool ign_opt, bool ign_inf, bool req_mark);
+  Entry* entries(const index_set& s);
+  Entry* unsorted_entries(bool ign_zero, bool ign_opt, bool ign_inf,
+     bool req_mark);
+  Entry* boostable_entries();
+  Entry* boostable_entries(const index_set& s);
+  Entry* boost_cd_entries();
+  Entry* marked_entries(bool ign_nb);
+  count_type count_entries(bool ign_zero, bool ign_opt, bool ign_inf);
+  hsps::rational action_pre_cost(index_type i);
+  hsps::rational action_per_cost(index_type i);
+  bool compatible(index_type a, index_type b, bool opt_resources) const;
+  void compute_H1(const ACF& cost);
+  void compute_H1(const ACF& cost, const bool_vec& init);
+  void compute_H1max(const ACF& cost, const bool_vec& init);
+  void compute_H2(const ACF& cost);
+  void compute_H2(const ACF& cost, const bool_vec& init);
+  void compute_H3(const ACF& cost);
+  void compute_H2C(const ACF& cost, bool opt_resources);
+  void verify_H2C(const ACF& cost, bool opt_resources, bool opt_verbose);
+  void compute_action_cost();
+  void fill(index_type to_depth);
+  void clear();
+  void closure(const ACF& cost);
+  void closure(const ACF& cost, const index_set& nd);
+  void compute_hm_graph(const ACF& cost, const index_set& s,
+   index_set_graph& g);
+};
+class LinearScanH2Eval : public CostTable {
+  index_type n_pairs;
+  index_pair* pairs;
+  hsps::rational* values;
+  bool complete;
+ public:
+  LinearScanH2Eval(Instance& i, Statistics& s);
+  ~LinearScanH2Eval();
+  void compile_finite();
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH1 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH1(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH1();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH2 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH2(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH2();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+inline void sort2(index_type& i, index_type& j)
+{
+  if (i > j) {
+    index_type t = i;
+    i = j;
+    j = t;
+  }
+}
+inline void sort3(index_type& i, index_type& j, index_type& l)
+{
+  sort2(i, l);
+  sort2(i, j);
+  sort2(j, l);
+}
+inline CostNode::Value& CostNode::val(index_type p)
+{
+  return _store[p];
+}
+inline const CostNode::Value& CostNode::val(index_type p) const
+{
+  return _store[p];
+}
+inline CostNode::Value* CostNode::val_p(index_type p)
+{
+  return &(_store[p]);
+}
+inline CostNode& CostNode::next(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return *(_store[p].next);
+}
+inline CostNode* CostNode::next_p(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return _store[p].next;
+}
+inline CostTable::Entry& CostTable::Entry::operator=(const Entry& e)
+{
+  set = e.set;
+  val = e.val;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode::Value& v)
+{
+  s << std::resetiosflags(std::ios::scientific) << ((v.val).decimal());
+  if (v.opt) s << '*';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode& t)
+{
+  t.write(s);
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostTable::Entry& e)
+{
+  if (e.set.length() > 0) {
+    s << "{" << e.set[0];
+    for (index_type k = 1; k < e.set.length(); k++) s << ',' << e.set[k];
+    s << "}:" << e.val;
+  }
+  else {
+    s << "{}:" << e.val;
+  }
+  return s;
+}
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+PairIndexFunction::PairIndexFunction(index_type n)
+  : index_vec(0, n)
+{
+  for (index_type k = 1; k < n; k++)
+    (*this)[k] = (*this)[k - 1] + (n - k) + 1;
+}
+PairIndexFunction::~PairIndexFunction()
+{
+}
+index_type PairIndexFunction::operator()(index_type i, index_type j) const
+{
+  sort2(i, j);
+  return ((*this)[i] + (j - i));
+}
+index_type PairIndexFunction::max_in() const
+{
+  return length() - 1;
+}
+index_type PairIndexFunction::max_out() const
+{
+  return (*this)(length() - 1, length() - 1);
+}
+bool CostNode::eval_set_mark = false;
+bool CostTable::strong_conflict_detection = true;
+bool CostTable::ultra_weak_conflict_detection = false;
+bool CostTable::boost_new_entries = true;
+count_type CostTable::n_entries_boosted = 0;
+count_type CostTable::n_entries_solved = 0;
+count_type CostTable::n_entries_discarded = 0;
+count_type CostTable::n_entries_created = 0;
+count_type CostTable::n_boost_searches = 0;
+count_type CostTable::n_boost_searches_with_cd = 0;
+CostNode::CostNode(index_type size)
+  : _size(size),
+    _depth(0),
+    _first(0),
+    _store(0),
+    _default(0),
+    _max(POS_INF),
+    _prev(0)
+{
+  _store = new Value[_size];
+  for (index_type k = 0; k < _size; k++) {
+    _store[k].val = _default;
+    _store[k].next = 0;
+  }
+}
+CostNode::CostNode(index_type size, hsps::rational v_default)
+  : _size(size),
+    _depth(0),
+    _first(0),
+    _store(0),
+    _default(v_default),
+    _max(POS_INF),
+    _prev(0)
+{
+  _store = new Value[_size];
+  for (index_type k = 0; k < _size; k++) {
+    _store[k].val = _default;
+    _store[k].next = 0;
+  }
+}
+CostNode::CostNode(CostNode* p, index_type f)
+  : _size(p->_size),
+    _depth(p->_depth + 1),
+    _first(f),
+    _store(0),
+    _default(p->_default),
+    _max(POS_INF),
+    _prev(p)
+{
+  _store = new Value[_size];
+  for (index_type k = 0; k < _size; k++) {
+    _store[k].val = _default;
+    _store[k].next = 0;
+  }
+}
+CostNode::~CostNode()
+{
+  for (index_type k = 0; k < _size; k++)
+    if (_store[k].next) delete _store[k].next;
+  delete [] _store;
+}
+void CostNode::clear()
+{
+  for (index_type k = 0; k < _size; k++) {
+    if (_store[k].next) delete _store[k].next;
+    _store[k].clear(_default);
+  }
+  _max = POS_INF;
+}
+CostNode::Value* CostNode::find(const index_set& s)
+{
+  Value* v = 0;
+  CostNode* n = this;
+  for (index_type k = 0; k < s.length(); k++) {
+    if (!n) return 0;
+    v = n->val_p(s[k]);
+    n = v->next;
+  }
+  return v;
+}
+CostNode::Value* CostNode::find(const bool_vec& s)
+{
+  Value* v = 0;
+  CostNode* n = this;
+  for (index_type k = 0; k < _size; k++) if (s[k]) {
+    if (!n) return 0;
+    v = n->val_p(k);
+    n = v->next;
+  }
+  return v;
+}
+void CostNode::find_all
+(const index_set& s, index_set_vec& a)
+{
+  find_all(s, 0, EMPTYSET, a);
+}
+void CostNode::find_all
+(const index_set& s, index_type i, const index_set& c, index_set_vec& a)
+{
+  for (index_type k = i; k < s.length(); k++) {
+    index_set nc(c);
+    nc.insert(s[k]);
+    a.append_if_new(nc);
+    if (val(s[k]).next) {
+      val(s[k]).next->find_all(s, k + 1, nc, a);
+    }
+  }
+}
+CostNode::Value& CostNode::insert(const index_set& s)
+{
+  assert(s.length() > 0);
+  CostNode* n = this;
+  for (index_type k = 0; k < s.length() - 1; k++) {
+    n = n->next_p(s[k]);
+  }
+  return n->val(s[s.length() - 1]);
+}
+CostNode::Value& CostNode::insert(const bool_vec& s)
+{
+  index_type last = no_such_index;
+  for (index_type k = _size; (k > 0) && (last == no_such_index); k--)
+    if (s[k - 1]) last = k - 1;
+  assert(last != no_such_index);
+  CostNode* n = this;
+  for (index_type k = 0; k < last; k++) if (s[k]) {
+    n = n->next_p(k);
+  }
+  return n->val(last);
+}
+void CostNode::store(index_type p, hsps::rational v, bool opt)
+{
+  val(p) = Value(v, opt);
+}
+void CostNode::store(index_type p, hsps::rational v)
+{
+  val(p) = v;
+}
+void CostNode::set_max(hsps::rational v)
+{
+  if (v > _max) {
+    _max = v;
+    if (_prev) _prev->set_max(v);
+  }
+}
+void CostNode::store(const index_set& s, hsps::rational v, bool opt)
+{
+  if (s.length() > 0) {
+    CostNode* n = this;
+    for (index_type i = 0; i < s.length() - 1; i++) n = n->next_p(s[i]);
+    n->store(s[s.length() - 1], v, opt);
+  }
+}
+void CostNode::store(const bool_vec& s, hsps::rational v, bool opt)
+{
+  CostNode* p = 0;
+  CostNode* n = this;
+  index_type l = no_such_index;
+  for (index_type k = 0; k < _size; k++) if (s[k]) {
+    p = n;
+    n = n->next_p(k);
+    l = k;
+  }
+  if (p) p->store(l, v, opt);
+}
+void CostNode::store(const index_set& s, hsps::rational v)
+{
+  if (s.length() > 0) {
+    CostNode* n = this;
+    for (index_type i = 0; i < s.length() - 1; i++) n = n->next_p(s[i]);
+    n->store(s[s.length() - 1], v);
+  }
+}
+void CostNode::store(const bool_vec& s, hsps::rational v)
+{
+  CostNode* p = 0;
+  CostNode* n = this;
+  index_type l = no_such_index;
+  for (index_type k = 0; k < _size; k++) if (s[k]) {
+    p = n;
+    n = n->next_p(k);
+    l = k;
+  }
+  if (p) p->store(l, v);
+}
+hsps::rational CostNode::eval(const index_set& s)
+{
+  return eval(s, 0);
+}
+hsps::rational CostNode::eval(const bool_vec& s)
+{
+  return eval(s, 0);
+}
+hsps::rational CostNode::eval_to_bound(const index_set& s, hsps::rational bound)
+{
+  return eval_to_bound(s, 0, bound);
+}
+hsps::rational CostNode::eval_to_bound(const bool_vec& s, hsps::rational bound)
+{
+  return eval_to_bound(s, 0, bound);
+}
+hsps::rational CostNode::eval(const index_set& s, index_type i)
+{
+  Heuristic::eval_count += 1;
+  hsps::rational v_new = 0;
+  for (index_type k = i; k < s.length(); k++) {
+    if ((val(s[k]).val).infinite()) return POS_INF;
+    v_new = hsps::rational::max(v_new,val(s[k]).val);
+    if (val(s[k]).next) {
+      v_new = hsps::rational::max(v_new,val(s[k]).next->eval(s, k + 1));
+    }
+    val(s[k]).mark = true;
+  }
+  return v_new;
+}
+hsps::rational CostNode::eval(const bool_vec& s, index_type i)
+{
+  Heuristic::eval_count += 1;
+  hsps::rational v_new = 0;
+  for (index_type k = i; k < _size; k++) if (s[k]) {
+    if ((val(k).val).infinite()) return POS_INF;
+    v_new = hsps::rational::max(v_new,val(k).val);
+    if (val(k).next) {
+      v_new = hsps::rational::max(v_new,val(k).next->eval(s, k + 1));
+    }
+    val(k).mark = true;
+  }
+  return v_new;
+}
+hsps::rational CostNode::eval_to_bound(const index_set& s, index_type i, hsps::rational bound)
+{
+  hsps::rational v = 0;
+  for (index_type k = i; k < s.length(); k++) {
+    v = hsps::rational::max(v,val(s[k]).val);
+    val(s[k]).mark = true;
+    if (v > bound) return v;
+    if (val(s[k]).next)
+      v = hsps::rational::max(v,val(s[k]).next->eval_to_bound(s, k + 1, bound));
+  }
+  return v;
+}
+hsps::rational CostNode::eval_to_bound(const bool_vec& s, index_type i, hsps::rational bound)
+{
+  hsps::rational v = 0;
+  for (index_type k = i; k < _size; k++) if (s[k]) {
+    v = hsps::rational::max(v,val(k).val);
+    val(k).mark = true;
+    if (v > bound) return v;
+    if (val(k).next)
+      v = hsps::rational::max(v,val(k).next->eval_to_bound(s, k + 1, bound));
+  }
+  return v;
+}
+hsps::rational CostNode::incremental_eval(const bool_vec& s, index_type i, index_type i_new)
+{
+  Heuristic::eval_count += 1;
+  hsps::rational v = val(i_new).val;
+  if (val(i_new).next) {
+    v = hsps::rational::max(v,val(i_new).next->eval(s, i_new + 1));
+  }
+  for (index_type k = i; k < i_new; k++) if (s[k]) {
+    if (val(k).next) {
+      v = hsps::rational::max(v,val(k).next->incremental_eval(s, k + 1, i_new));
+    }
+  }
+  return v;
+}
+hsps::rational CostNode::incremental_eval(const bool_vec& s, index_type i_new)
+{
+  return incremental_eval(s, 0, i_new);
+}
+hsps::rational CostNode::incremental_eval(const index_set& s, index_type i_new)
+{
+  index_set s_new(s);
+  s_new.insert(i_new);
+  return eval(s_new);
+}
+hsps::rational CostNode::eval_min(const index_set& s)
+{
+  hsps::rational v_min = POS_INF;
+  CostNode* n = this;
+  index_type l = no_such_index;
+  for (index_type k = 0; (k < s.length()) && (n != 0); k++) {
+    if (s[k] >= _first) {
+      if (l == no_such_index) l = s[k];
+      Value& v = n->val(s[k]);
+      if (k == (s.length() - 1)) v_min = v.val;
+      n = v.next;
+    }
+  }
+  if (l != no_such_index) {
+    for (index_type k = _first; k <= l; k++) {
+      CostNode* n1 = val(k).next;
+      if (n1) {
+ hsps::rational v1 = n1->eval_min(s);
+ v_min = hsps::rational::min(v_min,v1);
+      }
+    }
+  }
+  else {
+    for (index_type k = _first; k < _size; k++) {
+      v_min = hsps::rational::min(v_min,val(k).val);
+      CostNode* n1 = val(k).next;
+      if (n1) {
+ hsps::rational v1 = n1->eval_min(s);
+ v_min = hsps::rational::min(v_min,v1);
+      }
+    }
+  }
+  return v_min;
+}
+hsps::rational CostNode::max_finite() const
+{
+  hsps::rational v = 0;
+  for (index_type k = _first; k < _size; k++)
+    if ((_store[k].val).finite()) {
+      v = hsps::rational::max(v,_store[k].val);
+      if (_store[k].next) {
+ v = hsps::rational::max(v,_store[k].next->max_finite());
+      }
+    }
+  return v;
+}
+void CostNode::compute_max()
+{
+  hsps::rational v = 0;
+  for (index_type k = _first; k < _size; k++) {
+    v = hsps::rational::max(v,_store[k].val);
+    if (_store[k].next) {
+      _store[k].next->compute_max();
+      v = hsps::rational::max(v,_store[k].next->_max);
+    }
+  }
+  _max = v;
+}
+void CostNode::clear_marks()
+{
+  for (index_type k = _first; k < _size; k++) {
+    _store[k].mark = false;
+    if (_store[k].next) _store[k].next->clear_marks();
+  }
+}
+void CostNode::write(std::ostream& s, index_set q) const
+{
+  index_type l = q.length();
+  q.inc_length();
+  for (index_type k = _first; k < _size; k++) {
+    q[l] = k;
+    if (true || (_store[k].val != _default) || (_store[k].opt)) {
+      s << q << ": " << _store[k] << std::endl;
+    }
+    if (_store[k].next) _store[k].next->write(s, q);
+  }
+  q.dec_length();
+}
+void CostNode::write_pddl(std::ostream& s, Instance& ins, index_set q) const
+{
+  assert(ins.n_atoms() >= _size);
+  index_type l = q.length();
+  q.inc_length();
+  for (index_type k = _first; k < _size; k++) {
+    q[l] = k;
+    if ((_store[k].val != _default) || (_store[k].opt)) {
+      s << std::endl << '(';
+      for (index_type i = 0; i < q.length(); i++) {
+ if (i > 0) s << ' ';
+ ins.atoms[q[i]].name->write(s, Name::NC_PDDL);
+      }
+      s << ')';
+      if (_store[k].opt) s << " :opt";
+      if ((_store[k].val).infinite()) s << " :inf";
+      else s << ' ' << _store[k].val;
+    }
+    if (_store[k].next) _store[k].next->write_pddl(s, ins, q);
+  }
+  q.dec_length();
+}
+void CostNode::write(std::ostream& s) const
+{
+  index_set q;
+  write(s, q);
+}
+void CostNode::write_pddl(std::ostream& s, Instance& ins) const
+{
+  index_set q;
+  s << "(:heuristic";
+  write_pddl(s, ins, q);
+  s << ")" << std::endl;
+}
+CostTable::CostTable(Instance& i, Statistics& s)
+  : Heuristic(i),
+    CostNode(i.n_atoms()),
+    stats(s),
+    pre_cost(0),
+    per_cost(0)
+{
+}
+CostTable::CostTable(Instance& i, Statistics& s, hsps::rational v_default)
+  : Heuristic(i),
+    CostNode(i.n_atoms(), v_default),
+    stats(s),
+    pre_cost(0),
+    per_cost(0)
+{
+}
+CostTable::~CostTable()
+{
+  if (pre_cost) {
+    delete pre_cost;
+    pre_cost = 0;
+  }
+  if (per_cost) {
+    delete per_cost;
+    per_cost = 0;
+  }
+}
+CostTable::Entry* CostTable::Entry::first()
+{
+  Entry* e = this;
+  while (e->prev) e = e->prev;
+  return e;
+}
+CostTable::Entry* CostTable::Entry::last()
+{
+  Entry* e = this;
+  while (e->next) e = e->next;
+  return e;
+}
+CostTable::Entry* CostTable::Entry::move_down()
+{
+  if (next) if (val.val > next->val.val) {
+    Entry* p = next;
+    while ((val.val > p->val.val) && p->next) p = p->next;
+    if (p->val.val <= val.val) {
+      unlink();
+      place_after(p);
+    }
+    else {
+      unlink();
+      place_before(p);
+    }
+  }
+  return first();
+}
+CostTable::Entry* CostTable::Entry::move_up()
+{
+  if (prev) if (val.val < prev->val.val) {
+    Entry* p = prev;
+    while ((val.val < p->val.val) && p->prev) p = p->prev;
+    if (p->val.val <= val.val) {
+      unlink();
+      place_after(p);
+    }
+    else {
+      unlink();
+      place_before(p);
+    }
+  }
+  return first();
+}
+void CostTable::Entry::unlink()
+{
+  if (prev) prev->next = next;
+  if (next) next->prev = prev;
+  prev = 0;
+  next = 0;
+}
+void CostTable::Entry::place_before(Entry* p)
+{
+  prev = p->prev;
+  if (p->prev) p->prev->next = this;
+  next = p;
+  p->prev = this;
+}
+void CostTable::Entry::place_after(Entry* p)
+{
+  next = p->next;
+  if (p->next) p->next->prev = this;
+  p->next = this;
+  prev = p;
+}
+void CostTable::Entry::delete_list()
+{
+  Entry* l = this;
+  while (l) {
+    Entry* e = l;
+    l = l->next;
+    delete e;
+  }
+}
+count_type CostTable::Entry::list_length()
+{
+  count_type n = 0;
+  for (Entry* e = this; e; e = e->next) n += 1;
+  return n;
+}
+CostTable::Entry* CostTable::insert_entry
+(CostTable::Entry* e, CostTable::Entry* l)
+{
+  if (!l) {
+    return e;
+  }
+  if (e->val.val < l->val.val) {
+    e->next = l;
+    l->prev = e;
+    return e;
+  }
+  Entry* p = l;
+  while ((p->val.val <= e->val.val) && p->next) {
+    if (p->set == e->set) return l;
+    p = p->next;
+  }
+  if (p->val.val <= e->val.val) {
+    e->place_after(p);
+  }
+  else {
+    e->place_before(p);
+  }
+  return l;
+}
+CostTable::Entry* CostTable::prepend_entry
+(CostTable::Entry* e, CostTable::Entry* l)
+{
+  if (!l) {
+    return e;
+  }
+  e->next = l;
+  l->prev = e;
+  return e;
+}
+CostTable::Entry* CostTable::remove_entry
+(CostTable::Entry* e, CostTable::Entry* l)
+{
+  if (e == l) {
+    if (e->next) e->next->prev = 0;
+    Entry* r = e->next;
+    e->next = 0;
+    e->prev = 0;
+    return r;
+  }
+  else {
+    if (e->next) e->next->prev = e->prev;
+    if (e->prev) e->prev->next = e->next;
+    e->next = 0;
+    e->prev = 0;
+    return l;
+  }
+}
+CostTable::Entry* CostTable::copy_list(Entry* l)
+{
+  Entry* r = 0;
+  while (l) {
+    Entry* e = new Entry(l->set, l->val);
+    r = insert_entry(e, r);
+    l = l->next;
+  }
+  return r;
+}
+CostTable::Entry* CostTable::find_entry(index_set& s, Entry* l)
+{
+  for (Entry* e = l; e; e = e->next)
+    if (e->set == s) return e;
+  return 0;
+}
+count_type CostTable::write_list(std::ostream& s, Entry* l)
+{
+  count_type n = 0;
+  for (Entry* e = l; e; e = e->next) {
+    instance.write_atom_set(s, e->set);
+    s << ": " << e->val << " (" << eval(e->set) << ")" << std::endl;
+    n += 1;
+  }
+  return n;
+}
+void CostTable::store_list(Entry* l)
+{
+  for (Entry* e = l; e; e = e->next)
+    store(e->set, e->val.val, e->val.opt);
+}
+CostTable::Entry* CostTable::atoms()
+{
+  Entry* l = 0;
+  index_set s;
+  s.set_length(1);
+  for (index_type i = 0; i < instance.n_atoms(); i++) {
+    s[0] = i;
+    Entry* e = new Entry(s, val(i));
+    l = insert_entry(e, l);
+  }
+  return l;
+}
+CostTable::Entry* CostTable::pairs()
+{
+  Entry* l = atoms();
+  index_set s;
+  s.set_length(2);
+  for (index_type i = 0; i < instance.n_atoms(); i++) {
+    for (index_type j = i + 1; j < instance.n_atoms(); j++) {
+      CostNode::Value v = next(i).val(j);
+      if (!v.opt && (v.val).finite()) {
+ s[0] = i;
+ s[1] = j;
+ Entry* e = new Entry(s, v);
+ l = insert_entry(e, l);
+      }
+    }
+  }
+  return l;
+}
+bool CostTable::interesting(const index_set& s)
+{
+  hsps::rational v = eval(s);
+  for (index_type k = 0; k < s.length(); k++) {
+    index_set sub_s(s);
+    sub_s.remove(k);
+    if (eval(sub_s) >= v) return false;
+  }
+  return true;
+}
+CostTable::Entry* CostTable::entries
+(CostNode* n, index_set s, Entry* l, const index_set* filter,
+ bool ign_zero, bool ign_opt, bool ign_inf, bool req_mark, bool sort)
+{
+  index_type i = s.length();
+  s.inc_length();
+  for (index_type k = n->first(); k < instance.n_atoms(); k++) {
+    s[i] = k;
+    bool accept = true;
+    if (accept && req_mark) {
+      if (!n->val(k).mark) accept = false;
+    }
+    if (accept && (filter != 0)) {
+      if (!filter->contains(k)) accept = false;
+    }
+    if (accept && ign_zero) {
+      if (n->val(k).val == 0) accept = false;
+    }
+    if (accept && ign_opt) {
+      if (n->val(k).opt) accept = false;
+    }
+    if (accept && ign_inf) {
+      if ((n->val(k).val).infinite()) accept = false;
+    }
+    if (accept) {
+      if (sort) {
+ l = insert_entry(new Entry(s, n->val(k)), l);
+      }
+      else {
+ l = prepend_entry(new Entry(s, n->val(k)), l);
+      }
+    }
+    if (n->val(k).next)
+      l = entries(n->val(k).next, s, l, filter, ign_zero, ign_opt, ign_inf,
+    req_mark, sort);
+  }
+  s.dec_length();
+  return l;
+}
+count_type CostTable::count_entries
+(CostNode* n, index_set s, bool ign_zero, bool ign_opt, bool ign_inf)
+{
+  count_type l = 0;
+  index_type i = s.length();
+  s.inc_length();
+  for (index_type k = n->first(); k < instance.n_atoms(); k++) {
+    s[i] = k;
+    if (((n->val(k).val > 0) || !ign_zero) &&
+ (!n->val(k).opt || !ign_opt) &&
+ ((n->val(k).val).finite() || !ign_inf))
+    {
+      l += 1;
+    }
+    if (n->val(k).next)
+      l += count_entries(n->val(k).next, s, ign_zero, ign_opt, ign_inf);
+  }
+  s.dec_length();
+  return l;
+}
+CostTable::Entry* CostTable::entries()
+{
+  index_set s;
+  return entries(this, s, 0, 0, false, false, false, false, true);
+}
+CostTable::Entry* CostTable::entries
+(bool ign_zero, bool ign_opt, bool ign_inf, bool req_mark)
+{
+  index_set s;
+  return entries(this, s, 0, 0, ign_zero, ign_opt, ign_inf, req_mark, true);
+}
+CostTable::Entry* CostTable::unsorted_entries
+(bool ign_zero, bool ign_opt, bool ign_inf, bool req_mark)
+{
+  index_set s;
+  return entries(this, s, 0, 0, ign_zero, ign_opt, ign_inf, req_mark, false);
+}
+CostTable::Entry* CostTable::boostable_entries()
+{
+  index_set s;
+  return entries(this, s, 0, 0, true, true, true, false, true);
+}
+CostTable::Entry* CostTable::boostable_entries(const index_set& f)
+{
+  index_set s;
+  return entries(this, s, 0, &f, true, true, true, false, true);
+}
+CostTable::Entry* CostTable::boost_cd_entries()
+{
+  index_set s;
+  return entries(this, s, 0, 0, true, false, true, false, true);
+}
+CostTable::Entry* CostTable::marked_entries(bool ign_nb)
+{
+  index_set s;
+  return entries(this, s, 0, 0, ign_nb, ign_nb, ign_nb, true, true);
+}
+CostTable::Entry* CostTable::entries(const index_set& f)
+{
+  index_set s;
+  return entries(this, s, 0, &f, false, false, false, false, true);
+}
+count_type CostTable::count_entries(bool ign_zero, bool ign_opt, bool ign_inf)
+{
+  index_set s;
+  return count_entries(this, s, ign_zero, ign_opt, ign_inf);
+}
+void CostTable::fill(index_set& s, index_type d)
+{
+  index_type l = s.length();
+  s.inc_length();
+  for (index_type k = (l > 0 ? s[l-1] + 1 : 0); k < instance.n_atoms(); k++) {
+    s[l] = k;
+    store(s, eval(s));
+    if (d > s.length()) fill(s, d);
+  }
+  s.dec_length();
+}
+void CostTable::fill(index_type to_depth)
+{
+  index_set s;
+  fill(s, to_depth);
+}
+void CostTable::clear()
+{
+  CostNode::clear();
+  if (pre_cost) {
+    delete pre_cost;
+    pre_cost = 0;
+  }
+  if (per_cost) {
+    delete per_cost;
+    per_cost = 0;
+  }
+}
+hsps::rational CostTable::eval(index_type i)
+{
+  return val(i).val;
+}
+hsps::rational CostTable::eval(index_type i, index_type j)
+{
+  if (i == j) {
+    return val(i).val;
+  }
+  else {
+    sort2(i, j);
+    hsps::rational v = hsps::rational::max(val(i).val,val(j).val);
+    if (val(i).next) {
+      v = hsps::rational::max(v,next(i).val(j).val);
+    }
+    return v;
+  }
+}
+hsps::rational CostTable::eval(index_type i, index_type j, index_type k)
+{
+  if (i == j) {
+    return eval(i, k);
+  }
+  else if (i == k) {
+    return eval(i, j);
+  }
+  else if (j == k) {
+    return eval(i, j);
+  }
+  else {
+    sort3(i, j, k);
+    hsps::rational v = hsps::rational::max(hsps::rational::max(val(i).val,val(j).val),val(k).val);
+    if (val(i).next) {
+      v = hsps::rational::max(v,hsps::rational::max(next(i).val(j).val,next(i).val(k).val));
+      if (next(i).val(j).next) {
+ v = hsps::rational::max(v,next(i).next(j).val(k).val);
+      }
+    }
+    if (val(j).next) {
+      v = hsps::rational::max(v,next(j).val(k).val);
+    }
+    return v;
+  }
+}
+hsps::rational CostTable::action_pre_cost(index_type i)
+{
+  if (pre_cost) return pre_cost[i];
+  else return eval(instance.actions[i].pre);
+}
+hsps::rational CostTable::action_per_cost(index_type i)
+{
+  if (per_cost) return per_cost[i];
+  else {
+    index_set per_set(instance.actions[i].pre);
+    per_set.subtract(instance.actions[i].del);
+    return eval(per_set);
+  }
+}
+bool CostTable::update(index_type i, hsps::rational v, bool_vec& f)
+{
+  if (val(i) > v) {
+    val(i) = CostNode::Value(v, false);
+    for (index_type k = 0; k < instance.atoms[i].req_by.length(); k++)
+      if (instance.actions[instance.atoms[i].req_by[k]].sel)
+ f[instance.atoms[i].req_by[k]] = true;
+    return true;
+  }
+  return false;
+}
+bool CostTable::update(index_type i, hsps::rational v)
+{
+  if (val(i) > v) {
+    val(i) = CostNode::Value(v, false);
+    return true;
+  }
+  return false;
+}
+bool CostTable::update
+(index_type i, index_type j, hsps::rational v)
+{
+  if (i == j) {
+    CostNode::Value& v_store = val(i);
+    if (v_store > v) {
+      v_store = CostNode::Value(v, false);
+      return true;
+    }
+    return false;
+  }
+  else {
+    sort2(i, j);
+    CostNode::Value& v_store = next(i).val(j);
+    if (v_store > v) {
+      v_store = CostNode::Value(v, false);
+      return true;
+    }
+    return false;
+  }
+}
+bool CostTable::update
+(index_type i, index_type j, index_type l, hsps::rational v)
+{
+  if (i == j) {
+    return update(i, l, v);
+  }
+  else if (i == l) {
+    return update(i, j, v);
+  }
+  else if (j == l) {
+    return update(i, j, v);
+  }
+  else {
+    sort3(i, j, l);
+    CostNode::Value& v_store = next(i).next(j).val(l);
+    if (v_store > v) {
+      v_store = CostNode::Value(v, false);
+      return true;
+    }
+    return false;
+  }
+}
+void CostTable::closure(const ACF& cost)
+{
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type k = 0; k < instance.n_actions(); k++) {
+      if (stats.break_signal_raised()) return;
+      if (instance.actions[k].sel) {
+ hsps::rational c_pre = eval(instance.actions[k].pre);
+ if ((c_pre).finite()) {
+   for (index_type i = 0; i < instance.actions[k].add.length(); i++)
+     if (update(instance.actions[k].add[i], c_pre + cost(k)))
+       done = false;
+ }
+      }
+    }
+  }
+}
+void CostTable::closure(const ACF& cost, const index_set& nd)
+{
+  bool r_sel[instance.n_actions()];
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    r_sel[k] = instance.actions[k].sel;
+    if (instance.actions[k].del.first_common_element(nd) != no_such_index)
+      instance.actions[k].sel = false;
+  }
+  closure(cost);
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    instance.actions[k].sel = r_sel[k];
+}
+bool CostTable::compatible
+(index_type a, index_type b, bool opt_resources) const
+{
+  if (!instance.non_interfering(a, b)) return false;
+  if (!instance.lock_compatible(a, b)) return false;
+  if (opt_resources) {
+    if (!instance.resource_compatible(a, b)) return false;
+  }
+  return true;
+}
+void CostTable::compute_H1(const ACF& cost)
+{
+  bool_vec init(instance.init_atoms, instance.n_atoms());
+  compute_H1(cost, init);
+}
+void CostTable::compute_H1(const ACF& cost, const bool_vec& init)
+{
+  stats.start();
+  bool_vec f(false, instance.n_actions());
+  if (!pre_cost) pre_cost = new hsps::rational[instance.n_actions()];
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    pre_cost[k] = POS_INF;
+    if ((instance.actions[k].pre.length() == 0) && instance.actions[k].sel)
+      f[k] = true;
+  }
+  for (index_type k = 0; k < instance.n_atoms(); k++) {
+    if (init[k]) {
+      val(k) = CostNode::Value(0, true);
+      for (index_type i = 0; i < instance.atoms[k].req_by.length(); i++) {
+ if (instance.actions[instance.atoms[k].req_by[i]].sel)
+   f[instance.atoms[k].req_by[i]] = true;
+      }
+    }
+    else val(k) = CostNode::Value(POS_INF, false);
+  }
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type k = 0; k < instance.n_actions(); k++) if (f[k]) {
+      if (stats.break_signal_raised()) return;
+      hsps::rational c_pre = eval(instance.actions[k].pre);
+      if ((c_pre).finite() && (c_pre < pre_cost[k])) {
+ for (index_type i = 0; i < instance.actions[k].add.length(); i++)
+   update(instance.actions[k].add[i], c_pre + cost(k), f);
+ pre_cost[k] = c_pre;
+ done = false;
+      }
+      f[k] = false;
+    }
+  }
+  stats.stop();
+}
+void CostTable::compute_H1max(const ACF& cost, const bool_vec& init)
+{
+  stats.start();
+  bool_vec f(false, instance.n_actions());
+  if (!pre_cost) pre_cost = new hsps::rational[instance.n_actions()];
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    pre_cost[k] = POS_INF;
+    if ((instance.actions[k].pre.length() == 0) &&
+ instance.actions[k].sel)f[k] = true;
+    else f[k] = false;
+  }
+  for (index_type k = 0; k < instance.n_atoms(); k++) {
+    if (init[k]) {
+      val(k) = CostNode::Value(0, true);
+      for (index_type i = 0; i < instance.atoms[k].req_by.length(); i++) {
+ if (instance.actions[instance.atoms[k].req_by[i]].sel)
+   f[instance.atoms[k].req_by[i]] = true;
+      }
+    }
+    else val(k) = CostNode::Value(POS_INF, false);
+  }
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type k = 0; k < instance.n_actions(); k++) if (f[k]) {
+      if (stats.break_signal_raised()) return;
+      hsps::rational c_pre = eval(instance.actions[k].pre);
+      if ((c_pre).finite() && (c_pre < pre_cost[k])) {
+ for (index_type i = 0; i < instance.actions[k].add.length(); i++)
+   update(instance.actions[k].add[i], hsps::rational::max(c_pre,cost(k)), f);
+ pre_cost[k] = c_pre;
+ done = false;
+      }
+      f[k] = false;
+    }
+  }
+  stats.stop();
+}
+void CostTable::compute_H2(const ACF& cost)
+{
+  bool_vec init(instance.init_atoms, instance.n_atoms());
+  compute_H2(cost, init);
+}
+void CostTable::compute_H2(const ACF& cost, const bool_vec& init)
+{
+  if (trace_level > 2) {
+    std::cerr << "computing H2..." << std::endl;
+  }
+  stats.start();
+  for (index_type i = 0; i < instance.n_atoms(); i++) {
+    if (init[i])
+      val(i) = CostNode::Value(0, true);
+    else
+      val(i) = CostNode::Value(POS_INF, false);
+    for (index_type j = i + 1; j < instance.n_atoms(); j++) {
+      if (init[i] && init[j])
+ next(i).val(j) = CostNode::Value(0, true);
+      else
+ next(i).val(j) = CostNode::Value(POS_INF, false);
+    }
+  }
+  bool done = false;
+  while (!done) {
+    if (trace_level > 2) {
+      std::cerr << "begin iteration..." << std::endl;
+    }
+    done = true;
+    for (index_type a = 0; a < instance.n_actions(); a++) {
+      if (stats.break_signal_raised()) return;
+      Instance::Action& act = instance.actions[a];
+      hsps::rational c_pre = eval(act.pre);
+      if ((c_pre).finite()) {
+ for (index_type i = 0; i < instance.n_atoms(); i++) {
+   if (act.add.contains(i)) {
+     if (update(i, c_pre + cost(a))) done = false;
+     for (index_type j = 0; j < act.add.length(); j++)
+       if (act.add[j] > i)
+  if (update(act.add[j], i, c_pre + cost(a))) done = false;
+   }
+   else if (!act.del.contains(i)) {
+     for (index_type j = 0; j < act.add.length(); j++) {
+       hsps::rational c_join = hsps::rational::max(c_pre,eval(i));
+       if (!act.pre.contains(i)) {
+  for (index_type k = 0; k < act.pre.length(); k++)
+    c_join = hsps::rational::max(eval(act.pre[k], i),c_join);
+       }
+       if ((c_join).finite())
+  if (update(act.add[j], i, c_join + cost(a))) done = false;
+     }
+   }
+ }
+      }
+    }
+    if (trace_level > 2) {
+      std::cerr << "end iteration (done = " << done << ")" << std::endl;
+    }
+  }
+  stats.stop();
+}
+void CostTable::compute_H3(const ACF& cost)
+{
+  stats.start();
+  for (index_type i = 0; i < instance.n_atoms(); i++) {
+    if (instance.atoms[i].init)
+      val(i) = CostNode::Value(0, true);
+    else
+      val(i) = CostNode::Value(POS_INF, false);
+    for (index_type j = i + 1; j < instance.n_atoms(); j++) {
+      if (instance.atoms[i].init && instance.atoms[j].init)
+ next(i).val(j) = CostNode::Value(0, true);
+      else
+ next(i).val(j) = CostNode::Value(POS_INF, false);
+      for (index_type l = j + 1; l < instance.n_atoms(); l++) {
+ if (instance.atoms[i].init &&
+     instance.atoms[j].init &&
+     instance.atoms[l].init)
+   next(i).next(j).val(l) = CostNode::Value(0, true);
+ else
+   next(i).next(j).val(l) = CostNode::Value(POS_INF, false);
+      }
+    }
+  }
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type a = 0; a < instance.n_actions(); a++) {
+      if (stats.break_signal_raised()) return;
+      Instance::Action& act = instance.actions[a];
+      hsps::rational c_pre = eval(act.pre);
+      if ((c_pre).finite()) {
+ for (index_type i = 0; i < instance.n_atoms(); i++) {
+   if (act.add.contains(i)) {
+     if (update(i, c_pre + cost(a))) done = false;
+     for (index_type j = 0; j < act.add.length(); j++)
+       if (act.add[j] > i) {
+  if (update(i, act.add[j], c_pre + cost(a))) done = false;
+  for (index_type l = j + 1; l < act.add.length(); l++)
+    if (act.add[l] > i)
+      if (update(i, act.add[j], act.add[l], c_pre + cost(a)))
+        done = false;
+       }
+   }
+   else if (!act.del.contains(i)) {
+     hsps::rational c_join = hsps::rational::max(c_pre,eval(i));
+     if (!act.pre.contains(i)) {
+       for (index_type k = 0; k < act.pre.length(); k++)
+  c_join = hsps::rational::max(eval(act.pre[k], i),c_join);
+     }
+     if ((c_join).finite()) {
+       for (index_type j = 0; j < act.add.length(); j++) {
+  if (update(i, act.add[j], c_join + cost(a))) done = false;
+  for (index_type l = j + 1; l < act.add.length(); l++)
+    if (update(i, act.add[j], act.add[l], c_join + cost(a)))
+      done = false;
+       }
+       for (index_type j = i + 1; j < instance.n_atoms(); j++)
+  if (!act.del.contains(j)) {
+    hsps::rational c_jj = hsps::rational::max(c_join,eval(i, j));
+    if (!act.pre.contains(j)) {
+      for (index_type k = 0; k < act.pre.length(); k++)
+        c_jj = hsps::rational::max(eval(act.pre[k], j),c_jj);
+    }
+    if ((c_jj).finite()) {
+      for (index_type l = 0; l < act.add.length(); l++)
+        if (update(i, j, act.add[l], c_jj + cost(a)))
+   done = false;
+    }
+  }
+     }
+   }
+ }
+      }
+    }
+  }
+  stats.stop();
+}
+void CostTable::compute_H2C(const ACF& cost, bool opt_resources)
+{
+  stats.start();
+  for (index_type i = 0; i < instance.n_atoms(); i++) {
+    if (instance.atoms[i].init)
+      val(i) = CostNode::Value(0, true);
+    else
+      val(i) = CostNode::Value(POS_INF, false);
+    for (index_type j = i + 1; j < instance.n_atoms(); j++) {
+      if (instance.atoms[i].init && instance.atoms[j].init)
+ next(i).val(j) = CostNode::Value(0, true);
+      else
+ next(i).val(j) = CostNode::Value(POS_INF, false);
+    }
+  }
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type a = 0; a < instance.n_actions(); a++) {
+      if (stats.break_signal_raised()) return;
+      Instance::Action& act = instance.actions[a];
+      hsps::rational c_pre = eval(act.pre);
+      if ((c_pre).finite()) {
+ for (index_type i = 0; i < instance.n_atoms(); i++) {
+   if (act.add.contains(i)) {
+     if (update(i, c_pre + cost(a))) done = false;
+     for (index_type j = 0; j < act.add.length(); j++)
+       if (act.add[j] > i)
+  if (update(act.add[j], i, c_pre + cost(a))) done = false;
+   }
+          else if (!act.del.contains(i)) {
+     for (index_type j = 0; j < act.add.length(); j++) {
+       hsps::rational c_join = hsps::rational::max(c_pre,eval(i));
+       if (!act.pre.contains(i)) {
+  for (index_type k = 0; k < act.pre.length(); k++)
+    c_join = hsps::rational::max(eval(act.pre[k], i),c_join);
+       }
+       if ((c_join).finite())
+  if (update(act.add[j], i, c_join + cost(a))) done = false;
+     }
+   }
+ }
+ for (index_type b = a + 1; b < instance.n_actions(); b++) {
+   Instance::Action& act_b = instance.actions[b];
+   if (compatible(a, b, opt_resources)) {
+     hsps::rational c_b = eval(act_b.pre);
+     if ((c_b).finite()) {
+       hsps::rational c_join = hsps::rational::max(c_pre,c_b);
+       for (index_type i = 0; i < act.pre.length(); i++)
+  for (index_type j = 0; j < act_b.pre.length(); j++)
+    c_join = hsps::rational::max(eval(act.pre[i], act_b.pre[j]),c_join);
+       hsps::rational c_conc = hsps::rational::max(hsps::rational::max(c_pre + cost(a),c_b + cost(b)),c_join + hsps::rational::min(cost(a),cost(b)));
+       if ((c_conc).finite()) {
+  for (index_type i = 0; i < act.add.length(); i++)
+    for (index_type j = 0; j < act_b.add.length(); j++)
+      if (update(act.add[i], act_b.add[j], c_conc))
+        done = false;
+       }
+     }
+   }
+ }
+      }
+    }
+  }
+  stats.stop();
+}
+void CostTable::verify_H2C
+(const ACF& cost, bool opt_resources, bool opt_verbose)
+{
+  for (index_type i = 0; i < instance.n_atoms(); i++) {
+    Instance::Atom& atom1 = instance.atoms[i];
+    if (atom1.init) {
+      if (opt_verbose)
+ std::cerr << "atom " << atom1.name << " is initial" << std::endl;
+    }
+    else {
+      if (opt_verbose) {
+ std::cerr << "checking atom " << atom1.name << "..." << std::endl;
+      }
+      hsps::rational c_tab = eval(atom1.index);
+      hsps::rational c_min = POS_INF;
+      for (index_type k = 0; k < atom1.add_by.length(); k++) {
+ Instance::Action& act = instance.actions[atom1.add_by[k]];
+ hsps::rational c_act = eval(act.pre) + cost(act.index);
+ if (opt_verbose) {
+   std::cerr << act.name << ": " << c_act << std::endl;
+ }
+ c_min = hsps::rational::min(c_act,c_min);
+      }
+      if (opt_verbose) {
+ std::cerr << "min " << atom1.name << " = " << c_min << ", ";
+ if (c_min != c_tab) {
+   std::cerr << "error: H(" << atom1.name << ") = " << c_tab << std::endl;
+ }
+ else {
+   std::cerr << "ok" << std::endl;
+ }
+      }
+      else {
+ if (c_min > c_tab) {
+   std::cerr << "improvement: H(" << atom1.name << ") = " << c_min
+      << " (stored: " << c_tab << ")" << std::endl;
+ }
+      }
+    }
+    for (index_type j = i+1; j < instance.n_atoms(); j++) {
+      Instance::Atom& atom2 = instance.atoms[j];
+      if (atom1.init && atom2.init) {
+ if (opt_verbose)
+   std::cerr << "pair {" << atom1.name << ", " << atom2.name
+      << "} is initial" << std::endl;
+      }
+      else {
+ if (opt_verbose) {
+   std::cerr << "checking pair {" << atom1.name
+      << ", " << atom2.name << "}..." << std::endl;
+ }
+ hsps::rational c_tab = eval(atom1.index, atom2.index);
+ hsps::rational c_min = POS_INF;
+ for (index_type k = 0; k < atom1.add_by.length(); k++) {
+   Instance::Action& act1 = instance.actions[atom1.add_by[k]];
+   if (!act1.del.contains(atom2.index)) {
+     if (act1.add.contains(atom2.index)) {
+       hsps::rational c_both = eval(act1.pre) + cost(act1.index);
+       if (opt_verbose) {
+  std::cerr << act1.name << ": " << c_both << std::endl;
+       }
+       c_min = hsps::rational::min(c_both,c_min);
+     }
+     else {
+       index_set s0(act1.pre);
+       s0.insert(atom2.index);
+       hsps::rational c_1n = eval(s0) + cost(act1.index);
+       if (opt_verbose) {
+  std::cerr << act1.name << ", NOOP(" << atom2.name << "): "
+     << c_1n << std::endl;
+       }
+       c_min = hsps::rational::min(c_1n,c_min);
+       for (index_type l = 0; l < atom2.add_by.length(); l++) {
+  Instance::Action& act2 = instance.actions[atom2.add_by[l]];
+  if (compatible(act1.index, act2.index, opt_resources) &&
+      !act2.add.contains(atom1.index)) {
+    index_set s(act1.pre);
+    s.insert(act2.pre);
+    hsps::rational c_conc;
+    if (cost(act1.index) > cost(act2.index)) {
+      hsps::rational c_1 = eval(act1.pre) + cost(act1.index);
+      hsps::rational c_join = eval(s) + cost(act2.index);
+      c_conc = hsps::rational::max(c_1,c_join);
+    }
+    else {
+      hsps::rational c_2 = eval(act2.pre) + cost(act2.index);
+      hsps::rational c_join = eval(s) + cost(act1.index);
+      c_conc = hsps::rational::max(c_2,c_join);
+    }
+    if (opt_verbose) {
+      std::cerr << act1.name << ", " << act2.name << ": "
+         << c_conc << std::endl;
+    }
+    c_min = hsps::rational::min(c_conc,c_min);
+  }
+       }
+     }
+   }
+ }
+ for (index_type k = 0; k < atom2.add_by.length(); k++) {
+   Instance::Action& act = instance.actions[atom2.add_by[k]];
+   if (!act.del.contains(atom1.index) &&
+       !act.add.contains(atom1.index)) {
+     index_set s(act.pre);
+     s.insert(atom1.index);
+     hsps::rational c_2n = eval(s) + cost(act.index);
+     if (opt_verbose) {
+       std::cerr << "NOOP(" << atom1.name << "), " << act.name << ": "
+   << c_2n << std::endl;
+     }
+     c_min = hsps::rational::min(c_2n,c_min);
+   }
+ }
+ if (opt_verbose) {
+   std::cerr << "min {" << atom1.name << ", " << atom2.name << "} = "
+      << c_min << ", ";
+   if (c_min != c_tab) {
+     std::cerr << "error: H(" << atom1.name << ", " << atom2.name
+        << ") = " << c_tab << std::endl;
+   }
+   else {
+     std::cerr << "ok" << std::endl;
+   }
+ }
+ else {
+   if (c_min > c_tab) {
+     std::cerr << "improvement: H(" << atom1.name << "," << atom2.name
+        << ") = " << c_min << " (stored: " << c_tab << ")"
+        << std::endl;
+   }
+ }
+      }
+    }
+  }
+}
+void CostTable::compute_action_cost()
+{
+  if (!pre_cost) pre_cost = new hsps::rational[instance.n_actions()];
+  if (!per_cost) per_cost = new hsps::rational[instance.n_actions()];
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    pre_cost[k] = eval(instance.actions[k].pre);
+    index_set per_set(instance.actions[k].pre);
+    per_set.subtract(instance.actions[k].del);
+    per_cost[k] = eval(per_set);
+  }
+}
+void CostTable::compute_hm_graph_min
+(const ACF& cost,
+ const index_set& s,
+ index_set_graph& g)
+{
+  index_type n = g.node_with_label(s);
+  assert(n != no_such_index);
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    if (instance.actions[k].add.have_common_element(s) &&
+ !instance.actions[k].del.have_common_element(s)) {
+      index_set r(s);
+      r.subtract(instance.actions[k].add);
+      r.insert(instance.actions[k].pre);
+      index_type rn = g.node_with_label(r);
+      if (rn == no_such_index) {
+ rn = g.add_node(r);
+ CostNode::Value* v = find(r);
+ if (v)
+   compute_hm_graph_min(cost, r, g);
+ else
+   compute_hm_graph_max(cost, r, g);
+      }
+      if (!g.adjacent(rn, n))
+ g.add_edge(rn, n, EMPTYSET);
+      g.edge_label(rn, n).insert(k);
+    }
+}
+void CostTable::compute_hm_graph_max
+(const ACF& cost,
+ const index_set& s,
+ index_set_graph& g)
+{
+  index_type n = g.node_with_label(s);
+  assert(n != no_such_index);
+  index_set_vec ss;
+  find_all(s, ss);
+  for (index_type k = 0; k < ss.length(); k++) {
+    index_type sn = g.node_with_label(ss[k]);
+    if (sn == no_such_index) {
+      sn = g.add_node(ss[k]);
+      compute_hm_graph_min(cost, ss[k], g);
+    }
+    if (!g.adjacent(sn, n))
+      g.add_edge(sn, n);
+  }
+}
+void CostTable::compute_hm_graph
+(const ACF& cost, const index_set& s, index_set_graph& g)
+{
+  g.init(1);
+  g.node_label(0) = s;
+  CostNode::Value* v = find(s);
+  if (v) {
+    compute_hm_graph_min(cost, s, g);
+  }
+  else {
+    compute_hm_graph_max(cost, s, g);
+  }
+}
+LinearScanH2Eval::LinearScanH2Eval(Instance& i, Statistics& s)
+  : CostTable(i, s), n_pairs(0), pairs(0), values(0), complete(false)
+{
+}
+LinearScanH2Eval::~LinearScanH2Eval()
+{
+  if (pairs)
+    delete[] pairs;
+  if (values)
+    delete[] values;
+}
+void LinearScanH2Eval::compile_finite()
+{
+  if (pairs)
+    delete[] pairs;
+  if (values)
+    delete[] values;
+  n_pairs = 0;
+  complete = true;
+  Entry* list = entries(true, false, true, false);
+  if (list == 0) return;
+  for (Entry* e = list; e != 0; e = e->next)
+    if (e->set.length() <= 2)
+      n_pairs += 1;
+    else
+      complete = false;
+  if (n_pairs == 0) return;
+  pairs = new index_pair[n_pairs];
+  values = new hsps::rational[n_pairs];
+  index_type i = 0;
+  Entry* last = list->last();
+  while (last != 0) {
+    assert(i < n_pairs);
+    if (last->set.length() == 1) {
+      pairs[i].first = last->set[0];
+      pairs[i].second = last->set[0];
+      values[i] = last->val.val;
+      i += 1;
+      last = last->prev;
+    }
+    else if (last->set.length() == 2) {
+      pairs[i].first = last->set[0];
+      pairs[i].second = last->set[1];
+      values[i] = last->val.val;
+      i += 1;
+      last = last->prev;
+    }
+    else {
+      Entry* p = last->prev;
+      last->unlink();
+      delete last;
+      last = p;
+    }
+  }
+  assert(i == n_pairs);
+  list->delete_list();
+  std::cerr << "h^2 compiled: " << n_pairs << " pairs, complete = "
+     << complete << std::endl;
+}
+hsps::rational LinearScanH2Eval::eval(const bool_vec& s)
+{
+  for (index_type k = 0; k < n_pairs; k++)
+    if (s[pairs[k].first] && s[pairs[k].second])
+      return values[k];
+  if (complete)
+    return 0;
+  else
+    return CostNode::eval(s);
+}
+ForwardH1::ForwardH1
+(Instance& i, const index_set& g, const ACF& c, Statistics& s)
+  : Heuristic(i), goals(g), cost(c), table(0)
+{
+  table = new CostTable(instance, s);
+}
+ForwardH1::~ForwardH1()
+{
+  delete table;
+}
+hsps::rational ForwardH1::eval(const index_set& s)
+{
+  bool_vec s1(s, instance.n_atoms());
+  table->compute_H1(cost, s1);
+  return table->eval(goals);
+}
+hsps::rational ForwardH1::eval(const bool_vec& s)
+{
+  table->compute_H1(cost, s);
+  return table->eval(goals);
+}
+ForwardH2::ForwardH2
+(Instance& i, const index_set& g, const ACF& c, Statistics& s)
+  : Heuristic(i), goals(g), cost(c), table(0)
+{
+  table = new CostTable(instance, s);
+}
+ForwardH2::~ForwardH2()
+{
+  delete table;
+}
+hsps::rational ForwardH2::eval(const index_set& s)
+{
+  bool_vec s1(s, instance.n_atoms());
+  table->compute_H2(cost, s1);
+  return table->eval(goals);
+}
+hsps::rational ForwardH2::eval(const bool_vec& s)
+{
+  table->compute_H2(cost, s);
+  return table->eval(goals);
+}
+}

--- a/pr/seq-opt-hspsf/enumerators.ccx
+++ b/pr/seq-opt-hspsf/enumerators.ccx
@@ -1,0 +1,1824 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+IterativeEnumerator::~IterativeEnumerator()
+{
+}
+SubsetEnumerator::SubsetEnumerator(index_type _n)
+  : n(_n), in(false, _n)
+{
+}
+bool SubsetEnumerator::first()
+{
+  in.assign_value(false, n);
+  return true;
+}
+bool SubsetEnumerator::next()
+{
+  index_type p = 0;
+  while ((p < n) && in[p]) p += 1;
+  if (p < n) {
+    for (index_type k = 0; k < p; k++) in[k] = false;
+    in[p] = true;
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+const bool_vec& SubsetEnumerator::current_set() const
+{
+  return in;
+}
+void SubsetEnumerator::current_set(const index_set& elements, index_set& set)
+{
+  set.clear();
+  for (index_type k = 0; k < n; k++)
+    if (in[k]) set.append(elements[k]);
+}
+void SubsetEnumerator::current_set(index_set& set)
+{
+  set.clear();
+  for (index_type k = 0; k < n; k++)
+    if (in[k]) set.append(k);
+}
+index_type SubsetEnumerator::current_set_size()
+{
+  index_type s = 0;
+  for (index_type k = 0; k < n; k++) if (in[k]) s += 1;
+  return s;
+}
+void SubsetEnumerator::all_sets(index_set_vec& sets)
+{
+  sets.clear();
+  bool ok = first();
+  while (ok) {
+    index_set& s = sets.append();
+    current_set(s);
+    ok = next();
+  }
+}
+mSubsetEnumerator::mSubsetEnumerator(index_type _n, index_type _m)
+  : SubsetEnumerator(_n), m(_m)
+{
+  assert(m > 0);
+}
+count_type mSubsetEnumerator::m_of_n()
+{
+  if (m > n) return 1;
+  count_type r = 1;
+  for (index_type k = n; k > (n - m); k--) {
+    r = (r * k);
+  }
+  for (index_type k = 2; k <= m; k++) {
+    r = (r / k);
+  }
+  return r;
+}
+bool mSubsetEnumerator::first()
+{
+  for (index_type k = 0; (k < m) && (k < n); k++) in[k] = true;
+  for (index_type k = m; k < n; k++) in[k] = false;
+  return true;
+}
+bool mSubsetEnumerator::next()
+{
+  if ((m >= n) || (n == 0)) return false;
+  if (!in[n - 1]) {
+    index_type p = n - 1;
+    while (!in[p]) p -= 1;
+    assert(in[p]);
+    in[p] = false;
+    in[p + 1] = true;
+    return true;
+  }
+  else {
+    index_type p_last_out = n - 1;
+    while (in[p_last_out] && (p_last_out > 0)) p_last_out -= 1;
+    assert(!in[p_last_out]);
+    index_type p_next_in = p_last_out;
+    while (!in[p_next_in] && (p_next_in > 0)) p_next_in -= 1;
+    if (!in[p_next_in]) return false;
+    index_type n_rem_in = n - p_last_out;
+    in[p_next_in] = false;
+    for (index_type k = 0; k < n_rem_in; k++) in[p_next_in + k + 1] = true;
+    for (index_type k = p_next_in + n_rem_in + 1; k < n; k++) in[k] = false;
+  }
+}
+kAssignmentEnumerator::kAssignmentEnumerator(index_type _n, index_type _k)
+  : n(_n), k(_k), a(0, _k)
+{
+  assert(k > 0);
+}
+bool kAssignmentEnumerator::first()
+{
+  for (index_type i = 0; i < n; i++) a[i] = 0;
+  return true;
+}
+bool kAssignmentEnumerator::next()
+{
+  index_type e = n - 1;
+  while (e > 0) {
+    a[e] = ((a[e] + 1) % k);
+    if (a[e] > 0) return true;
+    e -= 1;
+  }
+  a[0] = ((a[0] + 1) % k);
+  if (a[0] > 0) return true;
+  return false;
+}
+void kAssignmentEnumerator::current_assignment(index_set_vec& sets)
+{
+  sets.set_length(k);
+  for (index_type i = 0; i < k; i++) sets[i].clear();
+  for (index_type i = 0; i < n; i++) sets[a[i]].insert(i);
+}
+CorrespondanceEnumerator::CorrespondanceEnumerator
+(const index_vec& v0, const index_vec& v1)
+  : a(v0), b(v1), c(no_such_index, v0.length(), false), f(true, v0.length())
+{
+}
+index_type CorrespondanceEnumerator::first_free
+(index_type x, const index_vec& vec, const bool_vec& f_vec)
+{
+  for (index_type i = 0; i < vec.length(); i++)
+    if ((vec[i] == x) && f_vec[i]) return i;
+  return no_such_index;
+}
+index_type CorrespondanceEnumerator::next_free
+(index_type x, const index_vec& vec, const bool_vec& f_vec, index_type k)
+{
+  for (index_type i = k + 1; i < vec.length(); i++)
+    if ((vec[i] == x) && f_vec[i]) return i;
+  return no_such_index;
+}
+bool CorrespondanceEnumerator::find(index_type p)
+{
+  if (p == a.length()) return true;
+  index_type i = first_free(a[p], b, f);
+  while (i != no_such_index) {
+    c[p] = i;
+    f[i] = false;
+    bool ok = find(p + 1);
+    if (ok) return true;
+    c[p] = no_such_index;
+    f[i] = true;
+    i = next_free(a[p], b, f, i);
+  }
+  return false;
+}
+bool CorrespondanceEnumerator::first()
+{
+  if (a.length() != b.length()) return false;
+  c.assign_value(no_such_index, a.length());
+  f.assign_value(true, a.length());
+  return find(0);
+}
+bool CorrespondanceEnumerator::next()
+{
+  index_type p = a.length();
+  while (p > 0) {
+    index_type i = c[p - 1];
+    f[i] = true;
+    c[p - 1] = no_such_index;
+    i = next_free(a[p - 1], b, f, i);
+    while (i != no_such_index) {
+      c[p - 1] = i;
+      f[i] = false;
+      bool ok = find(p);
+      if (ok) return true;
+      c[p - 1] = no_such_index;
+      f[i] = true;
+      i = next_free(a[p - 1], b, f, i);
+    }
+    p -= 1;
+  }
+  return false;
+}
+void write_correspondance(::std::ostream& s, const index_vec& c)
+{
+  for (index_type k = 0; k < c.length(); k++) {
+    if (k > 0) s << ", ";
+    s << k << " <-> " << c[k];
+  }
+}
+PermutationEnumerator::PermutationEnumerator(index_type n)
+  : e(index_vec(0, n), index_vec(0, n))
+{
+}
+bool PermutationEnumerator::first()
+{
+  return e.first();
+}
+bool PermutationEnumerator::next()
+{
+  return e.next();
+}
+void RecursivekPartitionEnumerator::partition(index_type cn, index_type ck)
+{
+  if (done) return;
+  if (cn < ck) return;
+  if (cn == ck) {
+    for (index_type i = 0; i < ck; i++) ass[i] = i;
+    solution();
+  }
+  else if (ck == 1) {
+    for (index_type i = 0; i < cn; i++) ass[i] = 0;
+    solution();
+  }
+  else {
+    ass[cn - 1] = ck - 1;
+    partition(cn - 1, ck - 1);
+    for (index_type i = 0; i < ck; i++) {
+      ass[cn - 1] = i;
+      partition(cn - 1, ck);
+    }
+  }
+}
+void RecursivekPartitionEnumerator::construct()
+{
+  sets.assign_value(index_set(), k);
+  for (index_type i = 0; i < n; i++)
+    sets[ass[i]].insert(i);
+}
+void RecursivekPartitionEnumerator::construct(const index_set& set)
+{
+  sets.assign_value(index_set(), k);
+  for (index_type i = 0; i < n; i++)
+    sets[ass[i]].insert(set[i]);
+}
+void RecursivekPartitionEnumerator::solution()
+{
+}
+RecursivekPartitionEnumerator::RecursivekPartitionEnumerator
+(index_type _n, index_type _k)
+  : ass(0, _n), n(_n), k(_k), sets(EMPTYSET, _k), done(false)
+{
+}
+RecursivekPartitionEnumerator::~RecursivekPartitionEnumerator()
+{
+}
+void RecursivekPartitionEnumerator::partition()
+{
+  done = false;
+  partition(n, k);
+}
+RecursivePartitionEnumerator::RecursivePartitionEnumerator(index_type _n)
+  : RecursivekPartitionEnumerator(_n, _n)
+{
+}
+void RecursivePartitionEnumerator::partition()
+{
+  for (k = 1; k <= n; k++) {
+    RecursivekPartitionEnumerator::partition();
+    if (done) return;
+  }
+}
+void RecursivePartitionEnumerator::partition_bounded
+(index_type min, index_type max)
+{
+  if (min < 1) min = 1;
+  if (max > n) max = n;
+  for (k = min; k <= max; k++) {
+    RecursivekPartitionEnumerator::partition();
+    if (done) return;
+  }
+}
+void CountPartitions::solution()
+{
+  c += 1;
+}
+index_type CountPartitions::count()
+{
+  c = 0;
+  partition();
+  return c;
+}
+void PrintPartitions::solution()
+{
+  construct();
+  ::std::cerr << sets << ::std::endl;
+}
+}

--- a/pr/seq-opt-hspsf/exec.ccx
+++ b/pr/seq-opt-hspsf/exec.ccx
@@ -1,0 +1,10373 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class PDDL_Name;
+class PDDL_Base {
+ public:
+  static bool use_default_function_value;
+  static hsps::rational default_function_value;
+  static bool use_strict_borrow_definition;
+  static bool use_extended_borrow_definition;
+  static bool del_before_add_semantics;
+  static bool compact_resource_effects;
+  static bool compile_away_disjunctive_preconditions;
+  static bool check_precondition_consistency;
+  static bool compile_away_conditional_effects;
+  static bool compile_away_plan_constraints;
+  static bool compile_away_object_functions;
+  static bool compile_for_validator;
+  static bool create_all_atoms;
+  static bool create_all_actions;
+  static bool number_multiple_action_instances;
+  static bool exclude_all_dkel_items;
+  static string_set excluded_dkel_tags;
+  static string_set required_dkel_tags;
+  static bool strict_set_export;
+  static bool best_effort;
+  static bool write_PDDL31;
+  static bool write_warnings;
+  static bool write_info;
+  static bool write_trace;
+  static bool trace_print_context;
+  static bool name_instance_by_problem_file;
+  static const char* instance_name_prefix;
+  enum symbol_class {
+    sym_object,
+    sym_typename,
+    sym_predicate,
+    sym_object_function,
+    sym_function,
+    sym_action,
+    sym_variable,
+    sym_misc,
+    sym_preference,
+    sym_set,
+    sym_meta_variable
+  };
+  enum metric_class {
+    metric_none,
+    metric_makespan,
+    metric_minimize,
+    metric_maximize
+  };
+  enum mode_keyword {
+    md_none,
+    md_start,
+    md_end,
+    md_all,
+    md_init,
+    md_pos_goal,
+    md_neg_goal
+  };
+  enum partial_value { p_false, p_true, p_unknown };
+  enum expression_class {
+    exp_fun,
+    exp_list,
+    exp_const,
+    exp_add,
+    exp_sub,
+    exp_mul,
+    exp_div,
+    exp_time,
+    exp_preference
+  };
+  enum relation_type {
+    rel_equal,
+    rel_greater,
+    rel_greater_equal,
+    rel_less,
+    rel_less_equal
+  };
+  enum formula_class { fc_false,
+         fc_true,
+         fc_atom,
+         fc_equality,
+         fc_negation,
+         fc_conjunction,
+         fc_disjunction,
+         fc_equivalence,
+         fc_implication,
+         fc_universal,
+         fc_existential,
+         fc_list
+  };
+  struct Symbol;
+  struct TypeSymbol;
+  struct Atom;
+  struct FTerm;
+  struct FChangeAtom;
+  struct SetOf;
+  struct ListExpression;
+  struct ActionSymbol;
+  struct Reference;
+  struct IrrelevantItem;
+  typedef lvector<TypeSymbol*> type_vec;
+  typedef lvector<Atom*> atom_vec;
+  typedef lvector<FChangeAtom*> ch_atom_vec;
+  typedef lvector<SetOf*> atom_set_vec;
+  typedef lvector<Reference*> ref_vec;
+  typedef lvector<IrrelevantItem*> irrelevant_vec;
+  struct TypeSet : public type_vec {
+    TypeSet() : type_vec(0, 0) { };
+    TypeSet(const TypeSet& s) : type_vec(s) { };
+    TypeSet(TypeSymbol* t) : type_vec(t, 1) { };
+    index_type n_elements() const;
+    Symbol* get_element(index_type n);
+    bool is_object() const;
+    bool subtype_or_equal(const TypeSet& s) const;
+    bool subtype_or_equal(TypeSymbol* t) const;
+    void print(std::ostream& s) const;
+    void write_type(std::ostream& s) const;
+  };
+  struct Symbol {
+    symbol_class sym_class;
+    char* print_name;
+    TypeSet sym_types;
+    bool defined_in_problem;
+    bool visible;
+    Symbol(symbol_class c, char* n)
+      : sym_class(c), print_name(n), defined_in_problem(false), visible(true) { };
+    Symbol(char* n)
+      : sym_class(sym_object), print_name(n), defined_in_problem(false), visible(true) { };
+    void print(std::ostream& s) const;
+  };
+  typedef zero_init_pair<Symbol*> symbol_pair;
+  typedef lvector<Symbol*> symbol_vec;
+  typedef svector<Symbol*> symbol_set;
+  typedef lvector<symbol_pair> symbol_pair_vec;
+  static bool extend_substitution(Symbol* out, Symbol* in, symbol_pair_vec& u);
+  static bool print_substitution(std::ostream& s, const symbol_pair_vec& u);
+  static bool print_inequality(std::ostream& s, const symbol_pair_vec& neq);
+  static bool substitution_violates_inequality(const symbol_pair_vec& neq,
+            const symbol_pair_vec& u);
+  static index_type find_matching_atom(Atom* a, atom_vec& v);
+  static index_type find_matching_atom(Atom* a, mode_keyword m, atom_vec& v);
+  static index_type find_matching_fluent_atom
+    (FChangeAtom* a, mode_keyword m, ch_atom_vec& v);
+  struct TypeSymbol : public Symbol {
+    symbol_vec elements;
+    bool is_base_type;
+    TypeSymbol(char* n) : Symbol(sym_typename, n), elements(0, 0),
+  is_base_type(false) { };
+    void add_element(Symbol* e);
+    bool is_object() const { return (strcmp(print_name, "object") == 0); };
+    bool subtype_or_equal(TypeSymbol* t) const;
+    bool subtype_or_equal(const TypeSet& t) const;
+    void print(std::ostream& s) const;
+  };
+  struct VariableSymbol : public Symbol {
+    Symbol* value;
+    FTerm* binding;
+    VariableSymbol(char* n) : Symbol(sym_variable, n), value(0), binding(0) {};
+    bool equality_type_check(Symbol* s);
+    void print(std::ostream& s);
+  };
+  typedef lvector<VariableSymbol*> variable_vec;
+  struct ParamSymbol : public Symbol {
+    variable_vec param;
+    ParamSymbol(symbol_class c, char* n) : Symbol(c, n), param(0, 0) { };
+  };
+  struct PredicateSymbol : public ParamSymbol {
+    bool pos_pre;
+    bool neg_pre;
+    bool added;
+    bool deleted;
+    bool locked;
+    bool modded;
+    ptr_table init;
+    ptr_table pos_goal;
+    ptr_table neg_goal;
+    ptr_table pos_prop;
+    ptr_table neg_prop;
+    irrelevant_vec irr_ins;
+    PredicateSymbol(char* n) : ParamSymbol(sym_predicate, n),
+  pos_pre(false), neg_pre(false), added(false), deleted(false),
+  locked(false), modded(false), irr_ins(0, 0) { };
+    bool is_static() const { return !modded; };
+    bool is_equality() const { return (strcmp(print_name, "=") == 0); };
+    void instantiate(Instance& ins);
+    void initialise_missing(const symbol_vec& p,
+       atom_vec* created,
+       index_type i = 0);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+  };
+  struct ObjectFunctionSymbol : public ParamSymbol {
+    bool modded;
+    ptr_table init;
+    ObjectFunctionSymbol(char* n)
+      : ParamSymbol(sym_object_function, n), modded(false) { };
+    bool is_static() const { return !modded; };
+    void print(std::ostream& s);
+  };
+  struct FunctionSymbol : public ParamSymbol {
+    bool modified;
+    bool integral;
+    bool linear;
+    bool conditioned;
+    bool increased;
+    bool decreased;
+    bool assigned;
+    bool borrowed;
+    ptr_table init;
+    FunctionSymbol(char* n) : ParamSymbol(sym_function, n),
+  modified(false), integral(true), linear(true), conditioned(false),
+  increased(false), decreased(false), assigned(false), borrowed(false)
+    { };
+    bool is_static() const
+    { return !modified; };
+    bool is_reusable() const
+    { return borrowed && !increased && !decreased && !assigned; };
+    bool is_consumable() const
+    { return !borrowed && !increased && decreased && !assigned; };
+    interval eval_init_bounds(ptr_table* p, index_type i, ListExpression* r);
+    void print(std::ostream& s);
+  };
+  struct AtomBase {
+    symbol_vec param;
+    mode_keyword at;
+    hsps::rational at_time;
+    AtomBase() : param(0, 0), at(md_none), at_time(0) { };
+    AtomBase(mode_keyword t) : param(0, 0), at(t), at_time(0) { };
+    AtomBase(AtomBase* b);
+    bool equals(AtomBase& b);
+    void free_variables(variable_vec& v);
+    bool occurs(Symbol* s);
+    void fill_in_args(AtomBase* b);
+    void collect_bound_variables(variable_vec& v);
+    void insert(ptr_table& t);
+    static bool print_bindings;
+    void print(std::ostream& s) const;
+    void print_instance(std::ostream& s);
+  };
+  typedef lvector<AtomBase*> atom_base_vec;
+  struct Atom : AtomBase {
+    PredicateSymbol* pred;
+    Atom(PredicateSymbol* p) : pred(p) { };
+    Atom(PredicateSymbol* p, mode_keyword t) : AtomBase(t), pred(p) { };
+    Atom(PredicateSymbol* p, variable_vec& a, bool as_value)
+      : pred(p)
+    {
+      param.set_length(a.length());
+      for (index_type k = 0; k < a.length(); k++)
+ param[k] = (as_value ? a[k]->value : a[k]);
+    };
+    Atom(PredicateSymbol* p, Symbol* a0)
+      : pred(p)
+    {
+      param.append(a0);
+    };
+    Atom(Atom* a) : AtomBase(a), pred(a->pred) { };
+    bool equals(Atom& a);
+    bool is_static() const {
+      return ((at == md_init) ||
+       (at == md_pos_goal) ||
+       (at == md_neg_goal) ||
+       pred->is_static());
+    };
+    bool check();
+    Instance::Atom* find_prop(Instance& ins, bool neg, bool create);
+    void build(Instance& ins, bool neg, index_type p);
+    Atom* instantiate_partially();
+    partial_value partial_eval(ptr_table* r, index_type p);
+    partial_value partial_eval();
+    bool initial_value();
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    void print(std::ostream& s, bool neg) const;
+    void print(std::ostream& s) const { print(s, false); };
+  };
+  struct CAtom : public Atom {
+    symbol_pair_vec neq;
+    CAtom(Atom* a) : Atom(a), neq(symbol_pair(0, 0), 0) { };
+    CAtom(CAtom* s) : Atom(s), neq(s->neq) { };
+    CAtom(const Atom* a, symbol_pair_vec& u);
+    CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool instance_of(CAtom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(CAtom* a, symbol_pair_vec& u);
+    void print(std::ostream& s);
+  };
+  typedef lvector<CAtom*> catom_vec;
+  struct FTerm : AtomBase {
+    ObjectFunctionSymbol* fun;
+    FTerm(ObjectFunctionSymbol* f) : fun(f) { };
+    bool equals(FTerm& a);
+    void print(std::ostream& s) const;
+  };
+  struct OInitAtom : AtomBase {
+    ObjectFunctionSymbol* fun;
+    Symbol* val;
+    OInitAtom(ObjectFunctionSymbol* f) : fun(f), val(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<OInitAtom*> obj_init_atom_vec;
+  struct FInitAtom : AtomBase {
+    FunctionSymbol* fun;
+    hsps::rational val;
+    Instance::resource_ref res;
+    FInitAtom(FunctionSymbol* f) : fun(f), val(0) { };
+    FInitAtom(FChangeAtom* a);
+    bool is_static() const { return fun->is_static(); };
+    void print(std::ostream& s);
+  };
+  typedef lvector<FInitAtom*> fun_init_atom_vec;
+  struct Expression;
+  typedef lvector<Expression*> exp_vec;
+  struct Expression {
+    expression_class exp_class;
+    Expression(expression_class c) : exp_class(c) { };
+    static bool print_nary;
+    bool is_static();
+    bool is_constant();
+    bool is_integral();
+    hsps::rational eval_static();
+    bool eval_partial(hsps::rational& val);
+    interval eval_bounds();
+    hsps::rational eval_init();
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    hsps::rational eval_delta(Symbol* preference, hsps::rational p_value, hsps::rational d_value);
+    Expression* copy();
+    Expression* simplify();
+    void collect_constants(exp_vec& c);
+    void mark_functions_in_condition();
+    hsps::rational integrify();
+    void substitute_for_time(Expression* e);
+    Expression* substitute_for_preference(Symbol* n, Expression* e);
+    bool equals(Expression* e);
+    void print_sum(std::ostream& s, bool grnd);
+    void print_product(std::ostream& s, bool grnd);
+    void print(std::ostream& s, bool grnd);
+  };
+  struct ListExpression : public Expression {
+    Symbol* sym;
+    ListExpression* rest;
+    ListExpression(Symbol* s, ListExpression* r) :
+      Expression(exp_list), sym(s), rest(r) { };
+    bool match(AtomBase* atom);
+  };
+  struct FunctionExpression : public Expression {
+    FunctionSymbol* fun;
+    ListExpression* args;
+    FunctionExpression(FunctionSymbol* f, ListExpression* a) :
+      Expression(exp_fun), fun(f), args(a) { };
+    bool match(FChangeAtom* atom);
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    FChangeAtom* make_atom_base();
+  };
+  struct ConstantExpression : public Expression {
+    hsps::rational val;
+    ConstantExpression(hsps::rational v) :
+      Expression(exp_const), val(v) { };
+  };
+  struct TimeExpression : public Expression {
+    Expression* time_exp;
+    TimeExpression() :
+      Expression(exp_time), time_exp(0) { };
+    TimeExpression(Expression* e) :
+      Expression(exp_time), time_exp(e) { };
+  };
+  struct BinaryExpression : public Expression {
+    Expression* first;
+    Expression* second;
+    BinaryExpression(expression_class c, Expression* e1, Expression* e2) :
+      Expression(c), first(e1), second(e2) { };
+  };
+  struct PreferenceExpression : public Expression {
+    Symbol* name;
+    PreferenceExpression(Symbol* n) :
+      Expression(exp_preference), name(n) { };
+  };
+  struct Relation {
+    relation_type rel;
+    mode_keyword at;
+    Expression* first;
+    Expression* second;
+    Relation(relation_type r, Expression* e1, Expression* e2) :
+      rel(r), at(md_none), first(e1), second(e2) { };
+    Relation(relation_type r, mode_keyword m, Expression* e1, Expression* e2) :
+      rel(r), at(m), first(e1), second(e2) { };
+    Expression* match_gteq_constant(FChangeAtom* atom);
+    FunctionExpression* match_lteq_fun(FChangeAtom* atom);
+    bool is_static();
+    partial_value partial_eval();
+    void print(std::ostream& s, bool grnd);
+  };
+  typedef lvector<Relation*> relation_vec;
+  struct FChangeAtom : AtomBase {
+    FunctionSymbol* fun;
+    Expression* val;
+    FChangeAtom(FunctionSymbol* f) :
+      fun(f), val(0) { };
+    FChangeAtom(FunctionSymbol* f, mode_keyword t) :
+      AtomBase(t), fun(f), val(0) { };
+    FChangeAtom(FChangeAtom* a, hsps::rational v) :
+      AtomBase(a), fun(a->fun), val(new ConstantExpression(v)) { };
+    bool equals(FChangeAtom& a);
+    bool fluent_equals(FChangeAtom& a);
+    bool fluent_and_mode_equals(FChangeAtom& a);
+    FChangeAtom* find_fluent_equals(ch_atom_vec& vec);
+    Instance::Resource* find_resource(Instance& ins);
+    void print(std::ostream& s);
+  };
+  struct Formula {
+    formula_class fc;
+    Formula(formula_class c) : fc(c) { };
+    void rename_variables_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_variables_2(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_2(PDDL_Base::symbol_pair_vec& sub);
+    Formula* simplify();
+    void write_otter(std::ostream& s) const;
+    void print(std::ostream& s) const;
+    void untype(PDDL_Base* base);
+  };
+  typedef lvector<Formula*> formula_vec;
+  struct AFormula : public Formula, public Atom {
+    AFormula(Atom* a) :
+      Formula(fc_atom), Atom(a) { };
+    AFormula(PredicateSymbol* p) :
+      Formula(fc_atom), Atom(p) { };
+    AFormula(PredicateSymbol* p, variable_vec& a) :
+      Formula(fc_atom), Atom(p, a, false) { };
+    void print(std::ostream& s) const;
+    void write_otter(std::ostream& s) const;
+  };
+  struct EqFormula : public Formula {
+    Symbol* t1;
+    Symbol* t2;
+    EqFormula(Symbol* s1, Symbol* s2) :
+      Formula(fc_equality), t1(s1), t2(s2) { };
+    void write_otter(std::ostream& s) const;
+  };
+  struct NFormula : public Formula {
+    Formula* f;
+    NFormula(Formula* g) : Formula(fc_negation), f(g) { };
+  };
+  struct BFormula : public Formula {
+    Formula* f1;
+    Formula* f2;
+    BFormula(formula_class c, Formula* g1, Formula* g2) :
+      Formula(c), f1(g1), f2(g2) { };
+  };
+  struct CFormula : public Formula {
+    formula_vec parts;
+    CFormula(formula_class c) : Formula(c), parts(0, 0) { };
+    CFormula(formula_class c, Formula* f1, Formula* f2) :
+      Formula(c), parts(0, 0)
+    {
+      parts.append(f1);
+      parts.append(f2);
+    };
+    void add(Formula* f) { parts.append(f); };
+    void add(formula_vec& f) { parts.append(f); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct QFormula : public Formula {
+    variable_vec vars;
+    Formula* f;
+    QFormula(formula_class c) : Formula(c), vars(0, 0), f(0) { };
+    QFormula(formula_class c, Formula* g) : Formula(c), vars(0, 0), f(g) { };
+    QFormula(formula_class c, variable_vec& v, Formula* g) :
+      Formula(c), vars(0, 0), f(g)
+    {
+      for (index_type k = 0; k < v.length(); k++) vars.append(v[k]);
+    };
+    void add(PDDL_Base::VariableSymbol* v) { vars.append(v); };
+    void add(PDDL_Base::variable_vec& v) { vars.append(v); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct TypeConstraint {
+    VariableSymbol* var;
+    TypeSymbol* typ;
+    TypeConstraint(VariableSymbol* v, TypeSymbol* t) : var(v), typ(t) { };
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+  };
+  typedef lvector<TypeConstraint*> type_constraint_vec;
+  struct Context {
+    variable_vec param;
+    atom_vec pos_con;
+    atom_vec neg_con;
+    type_constraint_vec type_con;
+    Context() : param(0, 0), pos_con(0, 0), neg_con(0, 0), type_con(0, 0) { };
+    Context(const Context* c) : param(c->param), pos_con(c->pos_con),
+  neg_con(c->neg_con), type_con(c->type_con) { };
+    bool context_is_static() const;
+    bool occurs_in_context(Symbol* s);
+    void clear_arguments();
+    void set_mode(mode_keyword m);
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+    void print_assignment(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct DKEL_Item : public Context {
+    char* item_name;
+    Symbol* name;
+    string_set item_tags;
+    bool defined_in_problem;
+    bool included;
+    DKEL_Item(char* name) : item_name(name), name(0),
+  defined_in_problem(false), included(true) { };
+    DKEL_Item(const DKEL_Item* i) : Context(i), item_name(i->item_name),
+  name(i->name), item_tags(i->item_tags),
+  defined_in_problem(i->defined_in_problem), included(i->included) { };
+    bool item_is_included(string_set& ex_tags, string_set& req_tags);
+    void print_begin(std::ostream& s);
+    void print_end(std::ostream& s);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SetOf : public Context {
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    SetOf() : pos_atoms(0, 0), neg_atoms(0, 0) { };
+    SetOf(const SetOf* s)
+      : Context(s), pos_atoms(s->pos_atoms), neg_atoms(s->neg_atoms)
+    { };
+    SetOf(Atom* a)
+    { pos_atoms.append(a); };
+    SetOf(Atom* a, bool n)
+    { if (n) neg_atoms.append(a); else pos_atoms.append(a); };
+    bool is_static() const;
+    void set_mode(mode_keyword m);
+    partial_value partial_eval(bool as_disjunction = false);
+    partial_value partial_eval(index_type p, bool as_disjunction = false);
+    void instantiate_as_set(Instance& ins, index_set& s);
+    void instantiate_as_effect(Instance& ins, index_set& s_add,
+          index_set& s_del);
+    void instantiate_conditional(Instance& ins, rule_set& s_pos,
+     rule_set& s_neg);
+    SetOf* instantiate_partially();
+    void compile(atom_vec& pos_ins, atom_vec& neg_ins, index_type p);
+    void compile_non_static(atom_set_vec& ins, index_type p);
+    void print(std::ostream& s);
+    void print_as_disjunction(std::ostream& s);
+    void build_set(Instance& ins, index_set& s, index_type p);
+    void build_effect(Instance& ins, index_set& s_add, index_set& s_del,
+        index_type p);
+    void build_conditional(Instance& ins, rule_set& s_pos, rule_set& s_neg,
+      index_type p);
+  };
+  struct QCNumericEffect : public Context {
+    FChangeAtom* atom;
+    QCNumericEffect() : atom(0) { };
+    QCNumericEffect(FChangeAtom* a) : atom(a) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<QCNumericEffect*> qc_numeric_effect_vec;
+  enum set_constraint_keyword { sc_at_least, sc_at_most, sc_exactly };
+  struct SetConstraint : public DKEL_Item {
+    set_constraint_keyword sc_type;
+    index_type sc_count;
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    atom_set_vec atom_sets;
+    SetConstraint() : DKEL_Item(":invariant"), sc_type(sc_at_least),
+  sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0), atom_sets(0, 0) { };
+    SetConstraint(const DKEL_Item* item) : DKEL_Item(item),
+  sc_type(sc_at_least), sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0),
+  atom_sets(0, 0) { };
+    void build(Instance& ins, index_type p);
+    void instantiate(Instance& ins);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InvariantFormula : public DKEL_Item {
+    Formula* f;
+    InvariantFormula(Formula* g)
+      : DKEL_Item(":invariant"), f(g) { };
+    InvariantFormula(const DKEL_Item* item, Formula* g)
+      : DKEL_Item(item), f(g) { };
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct Reference : public AtomBase {
+    Symbol* name;
+    bool neg;
+    bool has_args;
+    index_set index;
+    Reference(Symbol* n) : name(n), neg(false), has_args(true) { };
+    Reference(Symbol* n, bool ng, bool ha)
+      : name(n), neg(ng), has_args(ha) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    void* find_action();
+    void find(const name_vec& names, index_set& ind);
+    Reference* instantiate_partially();
+    void print(std::ostream& s);
+  };
+  struct IrrelevantItem : public DKEL_Item {
+    Reference* entity;
+    IrrelevantItem() : DKEL_Item(":irrelevant"), entity(0) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    IrrelevantItem* instantiate_partially();
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SequentialTaskNet : public Context {
+    ref_vec tasks;
+    ActionSymbol* abs_act;
+    SequentialTaskNet() : tasks(0, 0), abs_act(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<SequentialTaskNet*> task_net_vec;
+  struct SetSymbol : public Symbol {
+    ptr_table set_table;
+    lvector<index_set*> sets;
+    name_vec names;
+    SetSymbol(char* n) : Symbol(sym_set, n), sets(0, 0), names(0, 0) { };
+  };
+  struct SetName : public AtomBase {
+    SetSymbol* sym;
+    SetName(SetSymbol* s) : sym(s) { };
+    index_set* find();
+    SetName* instantiate_partially();
+    void print(std::ostream& s);
+    void print_instance(std::ostream& s);
+  };
+  struct ActionSymbol : public ParamSymbol {
+    atom_vec pos_pre;
+    atom_vec neg_pre;
+    atom_set_vec set_pre;
+    atom_set_vec dis_pre;
+    relation_vec num_pre;
+    atom_vec adds;
+    atom_vec dels;
+    atom_set_vec set_eff;
+    atom_vec cons;
+    atom_set_vec cond_eff;
+    atom_vec locks;
+    atom_vec enables;
+    ch_atom_vec reqs;
+    ch_atom_vec incs;
+    ch_atom_vec decs;
+    ch_atom_vec fass;
+    qc_numeric_effect_vec qc_incs;
+    qc_numeric_effect_vec qc_decs;
+    qc_numeric_effect_vec qc_fass;
+    Expression* dmin;
+    Expression* dmax;
+    irrelevant_vec irr_ins;
+    ref_vec refs;
+    task_net_vec exps;
+    ptr_table instances;
+    SetName* part;
+    const char* assoc;
+    ActionSymbol(char* n) : ParamSymbol(sym_action, n), pos_pre(0, 0),
+  neg_pre(0, 0), set_pre(0, 0), dis_pre(0, 0), num_pre(0, 0),
+  adds(0, 0), dels(0, 0), set_eff(0, 0), cons(0, 0), cond_eff(0, 0),
+  locks(0, 0), enables(0, 0), reqs(0, 0), incs(0, 0), decs(0, 0),
+  fass(0, 0), qc_incs(0, 0), qc_decs(0, 0), qc_fass(0, 0), dmin(0),
+  dmax(0), irr_ins(0, 0), refs(0, 0), exps(0, 0), part(0), assoc(0) { };
+    void build(Instance& ins, index_type p, Expression* cost_exp);
+    Instance::Action& build_action(Instance& ins,
+       PDDL_Name* name,
+       index_type& count,
+       const index_set& pre,
+       const index_set& add,
+       const index_set& del,
+       const index_set& lck,
+       const index_cost_vec& r_use,
+       const index_cost_vec& r_cons,
+       hsps::rational dmin,
+       hsps::rational dmax,
+       hsps::rational dur,
+       hsps::rational cost);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          index_vec& s,
+          index_type p);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc);
+    void build_actions_with_dc_and_ce(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          const rule_set& pce,
+          const rule_set& nce,
+          const bool_vec& ece);
+    index_type param_index(VariableSymbol* p);
+    void get_param_inequalities(symbol_pair_vec& neq);
+    void set_arguments(const symbol_vec& args);
+    void set_arguments(const ptr_table::key_vec& args);
+    void clear_arguments();
+    void* find_instance();
+    bool is_abstract();
+    void post_process();
+    void instantiate(Instance& ins, Expression* cost_exp);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InputPlanStep {
+    Reference* act;
+    hsps::rational start_time;
+    InputPlanStep() : act(0), start_time(0) { };
+    InputPlanStep(Reference* a, hsps::rational t) : act(a), start_time(t) { };
+  };
+  struct InputPlan {
+    Symbol* name;
+    bool is_opt;
+    lvector<InputPlanStep*> steps;
+    InputPlan() : name(0), is_opt(false), steps(0, 0) { };
+    bool export_to_instance(Instance& ins, const index_vec& map, Plan& p);
+    void print(std::ostream& s);
+  };
+  struct HTableEntry {
+    atom_vec atoms;
+    bool_vec neg;
+    hsps::rational cost;
+    bool opt;
+    HTableEntry() : atoms(0, 0), neg(false, 0), cost(0), opt(false) { };
+  };
+  struct SimpleReferenceSet : public Context {
+    Reference* ref;
+    SimpleReferenceSet(Reference* r) : ref(r) { };
+    bool build(const name_vec& names, index_set& set, index_type p);
+    void print(std::ostream& s);
+  };
+  typedef lvector<SimpleReferenceSet*> refs_vec;
+  struct ReferenceSet : public Context {
+    refs_vec refs;
+    Symbol* name;
+    ReferenceSet() : refs(0, 0), name(0) { };
+    void add(SimpleReferenceSet* ref) { refs.append(ref); };
+    void build(const name_vec& names, index_set_vec& sets, index_type p);
+    void print(std::ostream& s);
+  };
+  struct CPG {
+    atom_vec atoms;
+    index_vec atom_first_arg;
+    bool_vec neg;
+    symbol_vec args;
+    type_vec arg_types;
+    CPG() : atoms(0, 0), neg(false, 0), args(0, 0), arg_types(0, 0) { };
+    CPG(CPG& g, index_vec& s);
+    void make_key(ptr_table::key_vec& key);
+    void make_typed_key(ptr_table::key_vec& key);
+    void make_parameters(variable_vec& params);
+    ListExpression* make_argument_list(index_type first);
+    void add_asserting_effects(ActionSymbol* act,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          bool strict);
+    void add_destroying_effects(ActionSymbol* act,
+    ParamSymbol* pf,
+    PredicateSymbol* p,
+    bool p_val,
+    PredicateSymbol* g,
+    FunctionSymbol* f,
+    Expression* f_val,
+    bool strict);
+    bool initial_value();
+    void add_asserting_effects(index_type c_atom,
+          ActionSymbol* act,
+          index_type c_eff,
+          bool_vec& sat,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          symbol_pair_vec& eq,
+          symbol_pair_vec& neq,
+          bool strict);
+    void add_propositional_effect(ActionSymbol* act,
+      PredicateSymbol* p, bool p_val,
+      index_type c_atom, Atom* a_eff,
+      bool strict);
+    void add_fluent_effect(ActionSymbol* act,
+      FunctionSymbol* f, Expression* f_val,
+      index_type c_atom, Atom* a_eff);
+    void add_effect_conditions(Context* e, ParamSymbol* pf, bool_vec& sat,
+          symbol_vec& subs, symbol_pair_vec& eq,
+          symbol_pair_vec& neq);
+  };
+  enum goal_class { goal_pos_atom, goal_neg_atom, goal_relation, goal_task,
+      goal_conjunction, goal_disjunction, goal_forall,
+      goal_exists, goal_always, goal_sometime,
+      goal_at_most_once, goal_within, goal_always_within,
+      goal_sometime_before, goal_sometime_after };
+  struct Goal {
+    goal_class g_class;
+    Goal(goal_class c) : g_class(c) { };
+    bool is_state();
+    bool is_propositional();
+    bool is_singular();
+    bool makeCPG(CPG& g);
+    bool makeCPG(CPG& g, index_vec& s);
+    void instantiate(Instance& ins, hsps::rational deadline);
+    void instantiate(Instance& ins, index_set& set, Symbol* p, index_type i);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Goal*> goal_vec;
+  struct AtomicGoal : public Goal {
+    Atom* atom;
+    AtomicGoal(Atom* a, bool neg)
+      : Goal(neg ? goal_neg_atom : goal_pos_atom), atom(a) { };
+    void print(std::ostream& s);
+  };
+  struct NumericGoal : public Goal {
+    Relation* rel;
+    NumericGoal(Relation* r) : Goal(goal_relation), rel(r) { };
+    void print(std::ostream& s);
+  };
+  struct TaskGoal : public Goal {
+    Reference* task;
+    TaskGoal(Reference* r) : Goal(goal_task), task(r) { };
+    void print(std::ostream& s);
+  };
+  struct ConjunctiveGoal : public Goal {
+    goal_vec goals;
+    ConjunctiveGoal() : Goal(goal_conjunction), goals(0, 0) { };
+    ConjunctiveGoal(goal_class gc) : Goal(gc), goals(0, 0) { };
+    void print(std::ostream& s);
+  };
+  struct DisjunctiveGoal : public ConjunctiveGoal {
+    DisjunctiveGoal() : ConjunctiveGoal(goal_disjunction) { };
+    void print(std::ostream& s);
+  };
+  struct QuantifiedGoal : public Goal, public Context {
+    Goal* goal;
+    QuantifiedGoal() : Goal(goal_forall), goal(0) { };
+    QuantifiedGoal(goal_class gc) : Goal(gc), goal(0) { };
+    void print(std::ostream& s);
+  };
+  struct SimpleSequenceGoal : public Goal {
+    Goal* constraint;
+    SimpleSequenceGoal(goal_class c, Goal* g) : Goal(c), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredSequenceGoal : public Goal {
+    Goal* trigger;
+    Goal* constraint;
+    TriggeredSequenceGoal(goal_class c, Goal* t, Goal* g)
+      : Goal(c), trigger(t), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct DeadlineGoal : public Goal {
+    Goal* goal;
+    hsps::rational at;
+    DeadlineGoal(hsps::rational t, Goal* g) : Goal(goal_within), goal(g), at(t) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredDeadlineGoal : public Goal {
+    Goal* trigger;
+    Goal* goal;
+    hsps::rational delay;
+    TriggeredDeadlineGoal(Goal* t, hsps::rational d, Goal* g)
+      : Goal(goal_always_within), trigger(t), delay(d), goal(g) { };
+    void print(std::ostream& s);
+  };
+  struct Preference {
+    Symbol* name;
+    Goal* goal;
+    Preference() : name(0), goal(0) { };
+    Preference(Symbol* n) : name(n), goal(0) { };
+    Preference(Symbol* n, Goal* g) : name(n), goal(g) { };
+    bool is_state() { return goal->is_state(); };
+    bool is_propositional() { return goal->is_propositional(); };
+    hsps::rational value(metric_class metric_type, Expression* m);
+    void instantiate(SoftInstance& ins,
+       metric_class metric_type,
+       Expression* m);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Preference*> preference_vec;
+  char* domain_name;
+  char* problem_name;
+  char* domain_file;
+  char* problem_file;
+  bool ready_to_instantiate;
+  char* problem_file_basename();
+  char* enum_problem_filename(const char* s, index_type i);
+  StringTable& tab;
+  type_vec dom_types;
+  type_vec dom_base_types;
+  TypeSymbol* dom_top_type;
+  symbol_vec dom_constants;
+  PredicateSymbol* dom_eq_pred;
+  PredicateSymbol* dom_assign_pred;
+  Symbol* dom_undefined_obj;
+  static PredicateSymbol* current_eq_predicate;
+  lvector<PredicateSymbol*> dom_predicates;
+  lvector<ObjectFunctionSymbol*> dom_object_functions;
+  lvector<FunctionSymbol*> dom_functions;
+  lvector<ActionSymbol*> dom_actions;
+  lvector<SetConstraint*> dom_sc_invariants;
+  lvector<InvariantFormula*> dom_f_invariants;
+  lvector<IrrelevantItem*> dom_irrelevant;
+  atom_vec dom_init;
+  obj_init_atom_vec dom_obj_init;
+  fun_init_atom_vec dom_fun_init;
+  goal_vec dom_goals;
+  preference_vec dom_preferences;
+  ref_vec goal_tasks;
+  metric_class metric_type;
+  Expression* metric;
+  hsps::rational serial_length;
+  hsps::rational parallel_length;
+  lvector<InputPlan*> input_plans;
+  lvector<HTableEntry*> h_table;
+  lvector<ReferenceSet*> input_sets;
+  lvector<SetSymbol*> partitions;
+  static ActionSymbol* src_action_symbol(ptr_pair* p);
+  TypeSymbol* find_type(const char* name);
+  PredicateSymbol* find_predicate(const char* name);
+  FunctionSymbol* find_function(const char* name);
+  bool find_initial_fact(const char* pname, const symbol_vec& arg);
+  hsps::rational find_function_value(const char* fname, const symbol_vec& arg);
+  index_type find_element_satisfying(const symbol_vec& elements,
+         const char* pname,
+         symbol_vec& arg,
+         index_type element_arg_p);
+  void find_elements_satisfying(const symbol_vec& elements,
+    const char* pname,
+    symbol_vec& arg,
+    index_type element_arg_p,
+    index_set& sats);
+  Atom* goal_to_atom(Goal* g);
+  bool goal_to_atom_vec(Goal* g, atom_vec& av);
+  PDDL_Base(StringTable& t);
+  ~PDDL_Base();
+  void set_variable_type(variable_vec& vec, TypeSymbol* t);
+  void set_variable_type(variable_vec& vec, const TypeSet& t);
+  void set_type_type(type_vec& vec, TypeSymbol* t);
+  void set_constant_type(symbol_vec& vec, TypeSymbol* t);
+  void clear_context(variable_vec& vec);
+  void clear_context(variable_vec& vec, index_type n_min, index_type n_max);
+  bool merge_type_vectors(type_vec& v0, type_vec& v1);
+  void make_parameters(type_vec& t, const char* prefix, variable_vec& v);
+  Atom* make_atom_from_prop(ptr_pair& src, bool& neg);
+  Symbol* gensym(symbol_class c, const char* p, const TypeSet& t);
+  Symbol* gensym(symbol_class c, const char* p, TypeSymbol* t);
+  Symbol* gensym_i(symbol_class c, const char* p, index_type i, TypeSymbol* t);
+  Symbol* gensym_s(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t);
+  Symbol* gensym_n(symbol_class c, const char* p, const Name* n, TypeSymbol* t);
+  void new_variable_substitution(Atom* a,
+     symbol_pair_vec& u,
+     symbol_pair_vec& new_u);
+  Atom* new_meta_atom(PredicateSymbol* p);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& u);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+  void extend_cc(CAtom* l, catom_vec& m, catom_vec& nm,
+   lvector< swapable_pair<catom_vec> >& x,
+   index_type d);
+  void find_cc();
+  void post_process();
+  void instantiate(Instance& ins);
+  void instantiate_soft(SoftInstance& ins);
+  void instantiate_atom_set(Instance& ins, atom_vec& a, index_set& s);
+  index_type n_plans() const { return input_plans.length(); };
+  bool export_plan(index_type i, Instance& ins, const index_vec& map, Plan& p);
+  bool export_plan(index_type i, Instance& ins, Plan& p);
+  void export_heuristic(Instance& ins,
+   const index_vec& map,
+   bool opt_maximize,
+   Heuristic& h);
+  void export_sets(const name_vec& names, index_set_vec& sets);
+  void export_action_partitions(name_vec& names, index_set_vec& sets);
+  void lift_DKEL_Items(const Instance& ins);
+  PredicateSymbol* find_type_predicate(Symbol* type_sym);
+  void untype();
+  void compile_preferences();
+  void compile_constraints_1();
+  void compile_constraints_2();
+  void select_preferences(const bool_vec& sel);
+  void metric_to_goal(hsps::rational bound);
+  void compile_set_conditions_and_effects();
+  void compile_object_functions();
+  Expression* replace_violations_1(Expression* exp,
+       CPG* cpg[],
+       FunctionSymbol* f_violated[]);
+  Goal* compile_constraint_1(Goal* g, index_type i, const Symbol* n,
+        symbol_vec& aut_states, index_type n_ra);
+  AtomicGoal* make_automaton_type_a(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_e(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_o(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sb(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sa(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  void make_automaton_transition(Symbol* s_from,
+     Symbol* s_to,
+     bool is_accept,
+     CPG* f, bool neg_f,
+     CPG* g, bool neg_g,
+     PredicateSymbol* p_state,
+     PredicateSymbol* p_accept,
+     PredicateSymbol* p_synch);
+  void add_precondition_formula(ActionSymbol* a, CPG* f, bool is_neg);
+  Goal* compile_constraint_2(Goal* g, const Symbol* n);
+  Goal* compile_always_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_sometime_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_at_most_once_constraint(SimpleSequenceGoal* g,
+     const Symbol* n);
+  Goal* compile_sometime_before_constraint(TriggeredSequenceGoal* g,
+        const Symbol* n);
+  void compile_set_conditions_and_effects(ActionSymbol* act);
+  void compile_set_conditions_and_effects(ActionSymbol* act,
+       variable_vec& i_param,
+       variable_vec& d_param,
+       index_type p);
+  Atom* make_binding_atom(VariableSymbol* v);
+  void compile_object_functions(ActionSymbol* act, Symbol* undefined_value);
+  void compile_object_functions_for_validator(ActionSymbol* act);
+  Goal* compile_object_functions(Goal* g);
+  void write_declarations(std::ostream& s);
+  void write_action(std::ostream& s, ActionSymbol* act);
+  void write_set_precondition(std::ostream& s, SetOf* set);
+  void write_disjunctive_set_precondition(std::ostream& s, SetOf* set);
+  void write_set_effect(std::ostream& s, SetOf* set);
+  void write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn);
+  void write_objects(std::ostream& s, bool defined_in_problem);
+  void write_init(std::ostream& s);
+  void write_goal(std::ostream& s);
+  void write_metric(std::ostream& s);
+  void write_dkel_items(std::ostream& s, bool defined_in_problem);
+  void write_domain_begin(std::ostream& s);
+  void write_problem_begin(std::ostream& s);
+  void write_end(std::ostream& s);
+  void write_dkel_domain(std::ostream& s, bool leave_open);
+  void write_dkel_problem(std::ostream& s, bool leave_open);
+  void write_plans(std::ostream& s);
+  void write_heuristic_table(std::ostream& s);
+  void write_sets(std::ostream& s);
+  void print(std::ostream& s);
+};
+class InstanceName : public Name {
+  char* domain_name;
+  char* problem_name;
+ public:
+  InstanceName(char* d, char* p) : domain_name(d), problem_name(p) { };
+  virtual ~InstanceName() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class PDDL_Name : public Name {
+ protected:
+  bool neg;
+  PDDL_Base::Symbol* sym;
+  PDDL_Base::symbol_vec arg;
+  bool vis;
+  bool_vec avis;
+ public:
+  static char catc;
+  static bool obscure_symbol_names;
+  PDDL_Name(PDDL_Base::Symbol* s)
+    : neg(false), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, bool n)
+    : neg(n), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::symbol_vec a, bool n)
+    : neg(n), sym(s), arg(a), vis(true), avis(true, a.length()) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n);
+  void add(PDDL_Base::Symbol* s);
+  void add(PDDL_Base::Symbol* s, bool v);
+  PDDL_Base::Symbol* symbol() { return sym; };
+  PDDL_Base::symbol_vec& args() { return arg; };
+  index_type argc() { return arg.length(); };
+  bool is_neg() { return neg; };
+  virtual ~PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class Numbered_PDDL_Name : public PDDL_Name {
+  index_type copy;
+ public:
+  Numbered_PDDL_Name(PDDL_Base::Symbol* sym, index_type c)
+    : PDDL_Name(sym), copy(c) { };
+  Numbered_PDDL_Name(PDDL_Name* n, index_type c);
+  virtual ~Numbered_PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+};
+}
+namespace hsps {
+ExecError::~ExecError()
+{
+}
+ExecError::ErrorSeverity ExecError::severity_of_error() const
+{
+  switch (type_of_error()) {
+  case ExecError::warning_redundant_action:
+    return severity_warning;
+  case ExecError::error_unachieved_goal:
+    return severity_plan_failure;
+  case ExecError::error_unsatisfied_precondition:
+  case ExecError::error_incompatible_actions:
+  case ExecError::error_resource_conflict:
+  case ExecError::error_resource_shortage:
+  default:
+    return severity_execution_failure;
+  }
+}
+const char* ExecError::error_severity_string(ErrorSeverity s)
+{
+  switch (s) {
+  case ExecError::severity_none:
+    return "none";
+  case ExecError::severity_warning:
+    return "warning";
+  case ExecError::severity_plan_failure:
+    return "plan failure";
+  case ExecError::severity_execution_failure:
+    return "execution failure";
+  default:
+    return "unknown error";
+  }
+}
+const char* ExecError::error_type_string(ErrorType t)
+{
+  switch (t) {
+  case ExecError::error_unsatisfied_precondition:
+    return "unsatisfied precondition";
+  case ExecError::error_incompatible_actions:
+    return "incompatible actions";
+  case ExecError::error_resource_conflict:
+    return "resource conflict";
+  case ExecError::error_resource_shortage:
+    return "resource shortage";
+  case ExecError::error_unachieved_goal:
+    return "unsatisifed goal";
+  case ExecError::warning_redundant_action:
+    return "redundant action";
+  default:
+    return "unknown error";
+  }
+}
+void ExecError::remap_step(const index_vec& map)
+{
+  if (step != no_such_index) step = map[step];
+}
+ExecError* ExecError::copy() const
+{
+  return new ExecError(type_of_error(), time_of_error(), step_of_error());
+}
+void ExecError::write(::std::ostream& s) const
+{
+  s << '[' << std::resetiosflags(std::ios::scientific) << ((time_of_error()).decimal());
+  if (step_of_error() != no_such_index) {
+    s << " (step #" << step_of_error() << ")";
+  }
+  else {
+    s << " (no step)";
+  }
+  s << ']' << error_type_string(type_of_error());
+}
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t)
+{
+  return s << ExecError::error_type_string(t);
+}
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity se)
+{
+  return s << ExecError::error_severity_string(se);
+}
+ExecErrorSet::~ExecErrorSet()
+{
+  for (index_type k = 0; k < length(); k++) {
+    assert((*this)[k]);
+    delete (*this)[k];
+  }
+}
+void ExecErrorSet::ignore_error_type(ExecError::ErrorType t)
+{
+  ignored_error_types.insert(t);
+}
+void ExecErrorSet::ignore_error_severity(ExecError::ErrorSeverity s)
+{
+  switch (s) {
+  case ExecError::severity_warning:
+    ignored_error_types.insert(ExecError::warning_redundant_action);
+    break;
+  case ExecError::severity_plan_failure:
+    ignored_error_types.insert(ExecError::error_unachieved_goal);
+    break;
+  case ExecError::severity_execution_failure:
+    ignored_error_types.insert(ExecError::error_unsatisfied_precondition);
+    ignored_error_types.insert(ExecError::error_incompatible_actions);
+    ignored_error_types.insert(ExecError::error_resource_conflict);
+    ignored_error_types.insert(ExecError::error_resource_shortage);
+    break;
+  }
+}
+void ExecErrorSet::clear_ignored_error_types()
+{
+  ignored_error_types.clear();
+}
+void ExecErrorSet::new_error(ExecError* e)
+{
+  if (ignore(e->type_of_error())) {
+    delete e;
+    return;
+  }
+  append(e);
+}
+bool ExecErrorSet::ignore(ExecError::ErrorType t)
+{
+  return ignored_error_types.contains(t);
+}
+void ExecErrorSet::remap_steps(const index_vec& map)
+{
+  for (index_type k = 0; k < length(); k++)
+    (*this)[k]->remap_step(map);
+}
+hsps::rational ExecErrorSet::earliest_time_of_error()
+{
+  hsps::rational t_min = POS_INF;
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k]->time_of_error() < t_min)
+      t_min = (*this)[k]->time_of_error();
+  return t_min;
+}
+ExecError::ErrorSeverity ExecErrorSet::greatest_error_severity()
+{
+  ExecError::ErrorSeverity s_max = ExecError::severity_none;
+  for (index_type k = 0; k < length(); k++) {
+    if ((*this)[k]->severity_of_error() > s_max)
+      s_max = (*this)[k]->severity_of_error();
+  }
+  return s_max;
+}
+ExecErrorSet* ExecErrorSet::earliest()
+{
+  hsps::rational t_min = earliest_time_of_error();
+  ExecErrorSet* s = new ExecErrorSet();
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k]->time_of_error() == t_min)
+      s->append((*this)[k]->copy());
+  return s;
+}
+ExecErrorSet* ExecErrorSet::earliest_of_type(ExecError::ErrorType t)
+{
+  ExecErrorSet* s1 = all_of_type(t);
+  if (s1->length() == 0) return s1;
+  ExecErrorSet* s0 = s1->earliest();
+  delete s1;
+  return s0;
+}
+ExecErrorSet* ExecErrorSet::all_of_type(ExecError::ErrorType t)
+{
+  ExecErrorSet* s = new ExecErrorSet();
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k]->type_of_error() == t)
+      s->append((*this)[k]->copy());
+  return s;
+}
+ExecErrorSet* ExecErrorSet::all_of_severity(ExecError::ErrorSeverity s)
+{
+  ExecErrorSet* ns = new ExecErrorSet();
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k]->severity_of_error() == s)
+      ns->append((*this)[k]->copy());
+  return ns;
+}
+index_type ExecErrorSet::count_of_type(ExecError::ErrorType t)
+{
+  index_type n = 0;
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k]->type_of_error() == t) n += 1;
+  return n;
+}
+bool ExecErrorSet::executable()
+{
+  return (greatest_error_severity() < ExecError::severity_execution_failure);
+}
+bool ExecErrorSet::valid()
+{
+  return (greatest_error_severity() < ExecError::severity_plan_failure);
+}
+void ExecErrorSet::write(::std::ostream& s) const
+{
+  s << "{";
+  for (index_type k = 0; k < length(); k++) {
+    if (k > 0) s << "; ";
+    (*this)[k]->write(s);
+  }
+  s << "}";
+}
+ExecError* UnsatisfiedPreconditionError::copy()
+{
+  return new UnsatisfiedPreconditionError(ins, act, pre, holds,
+       time_of_error(), step_of_error());
+}
+void UnsatisfiedPreconditionError::write(::std::ostream& s) const
+{
+  s << "[" << std::resetiosflags(std::ios::scientific) << ((time_of_error()).decimal()) << "] precondition "
+    << ins.atoms[pre].name << " of " << ins.actions[act].name << " false";
+}
+ExecError* RedundantActionWarning::copy()
+{
+  return
+    new RedundantActionWarning(ins, act, time_of_error(), step_of_error());
+}
+void RedundantActionWarning::write(::std::ostream& s) const
+{
+  s << "[" << std::resetiosflags(std::ios::scientific) << ((time_of_error()).decimal()) << "] action "
+    << ins.actions[act].name << " is redundant";
+}
+ExecError* IncompatibleActionError::copy()
+{
+  return new IncompatibleActionError(ins, act0, act1,
+         time_of_error(), step_of_error());
+}
+void IncompatibleActionError::write(::std::ostream& s) const
+{
+  s << "[" << std::resetiosflags(std::ios::scientific) << ((time_of_error()).decimal()) << "] action "
+    << ins.actions[act0].name << " incompatible with "
+    << ins.actions[act1].name;
+}
+ExecError* ResourceConflictError::copy()
+{
+  return new ResourceConflictError(ins, res, c_acts, c_steps,
+       time_of_error(), step_of_error());
+}
+void ResourceConflictError::write(::std::ostream& s) const
+{
+  s << "[" << std::resetiosflags(std::ios::scientific) << ((time_of_error()).decimal()) << "] actions ";
+  hsps::rational sum = 0;
+  for (index_type k = 0; k < c_acts.length(); k++) {
+    if (k > 0) s << ",";
+    s << ins.actions[c_acts[k]].name;
+    sum += ins.actions[c_acts[k]].use[res];
+  }
+  s << " use " << std::resetiosflags(std::ios::scientific) << ((sum).decimal()) << " of resource "
+    << ins.resources[res].name
+    << " with capacity " << std::resetiosflags(std::ios::scientific) << ((ins.resources[res].init).decimal());
+}
+ExecError* ResourceShortageError::copy()
+{
+  return new ResourceShortageError(ins, res, avail, act,
+       time_of_error(), step_of_error());
+}
+void ResourceShortageError::write(::std::ostream& s) const
+{
+  s << "[" << std::resetiosflags(std::ios::scientific) << ((time_of_error()).decimal()) << "] action "
+    << ins.actions[act].name
+    << " requires " << std::resetiosflags(std::ios::scientific) << ((ins.actions[act].cons[res]).decimal())
+    << " of resource " << ins.resources[res].name
+    << ", only " << std::resetiosflags(std::ios::scientific) << ((avail).decimal()) << " available";
+}
+ExecError* UnachievedGoalError::copy()
+{
+  return new UnachievedGoalError(ins, atom, time_of_error(), step_of_error());
+}
+void UnachievedGoalError::write(::std::ostream& s) const
+{
+  s << "[" << std::resetiosflags(std::ios::scientific) << ((time_of_error()).decimal()) << "] goal "
+    << ins.atoms[atom].name << " not achieved";
+}
+bool ExecState::extended_action_definition = false;
+ExecState::ExecState(Instance& i)
+  : instance(i),
+    atoms(false, instance.n_atoms()),
+    res(0, instance.n_resources()),
+    abs_t(0),
+    delta_t(0),
+    dur(POS_INF),
+    trace_level(0)
+{
+  for (index_type k = 0; k < instance.n_resources(); k++)
+    res[k] = instance.resources[k].init;
+}
+ExecState::ExecState(Instance& i, index_set g)
+  : instance(i),
+    atoms(g, instance.n_atoms()),
+    res(0, instance.n_resources()),
+    abs_t(0),
+    delta_t(0),
+    dur(POS_INF),
+    trace_level(0)
+{
+  for (index_type k = 0; k < instance.n_resources(); k++)
+    res[k] = instance.resources[k].init;
+}
+ExecState::ExecState(Instance& i, const bool_vec& g)
+  : instance(i),
+    atoms(g),
+    res(0, instance.n_resources()),
+    abs_t(0),
+    delta_t(0),
+    dur(POS_INF),
+    trace_level(0)
+{
+  for (index_type k = 0; k < instance.n_resources(); k++)
+    res[k] = instance.resources[k].init;
+}
+ExecState::ExecState(const ExecState& s)
+  : ProgressionState(s),
+    instance(s.instance),
+    atoms(s.atoms),
+    res(s.res),
+    actions(s.actions),
+    abs_t(s.abs_t),
+    delta_t(s.delta_t),
+    dur(s.dur),
+    trace_level(s.trace_level)
+{
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    atoms[k] = s.atoms[k];
+}
+ExecState::~ExecState()
+{
+}
+void ExecState::set_trace_level(int level)
+{
+  trace_level = level;
+}
+hsps::rational ExecState::delta_cost()
+{
+  return delta_t;
+}
+hsps::rational ExecState::est_cost()
+{
+  return 0;
+}
+bool ExecState::is_final(ExecErrorSet* errors)
+{
+  bool ok = true;
+  for (index_type k = 0; k < instance.goal_atoms.length(); k++)
+    if (!atoms[instance.goal_atoms[k]]) {
+      if (errors) {
+ errors->new_error(new UnachievedGoalError
+     (instance, instance.goal_atoms[k], abs_t));
+      }
+      ok = false;
+    }
+  return ok;
+}
+bool ExecState::is_final()
+{
+  return is_final(0);
+}
+bool ExecState::is_max()
+{
+  return false;
+}
+hsps::rational ExecState::expand(Search& s, hsps::rational bound)
+{
+  ::std::cerr << "program error: can't expand ExecState " << *this << ::std::endl;
+  exit(255);
+}
+void ExecState::store(hsps::rational cost, bool opt)
+{
+  ::std::cerr << "program error: can't store ExecState " << *this << ::std::endl;
+  exit(255);
+}
+void ExecState::reevaluate()
+{
+}
+int ExecState::compare(const State& s) {
+  const ExecState& ws = (const ExecState&)s;
+  for (index_type k = 0; k < instance.n_atoms(); k++) {
+    if (!atoms[k] && ws.atoms[k]) return -1;
+    if (atoms[k] && !ws.atoms[k]) return 1;
+  }
+  if (actions.length() < ws.actions.length()) return -1;
+  else if (actions.length() > ws.actions.length()) return 1;
+  else {
+    for (index_type k = 0; k < actions.length(); k++) {
+      if (actions[k].act < ws.actions[k].act) return -1;
+      else if (actions[k].act > ws.actions[k].act) return 1;
+      else {
+ if (actions[k].rem < ws.actions[k].rem) return -1;
+ if (actions[k].rem > ws.actions[k].rem) return 1;
+      }
+    }
+  }
+  if (delta_t < ws.delta_t) return -1;
+  if (delta_t > ws.delta_t) return 1;
+  return 0;
+}
+index_type ExecState::hash() {
+  index_type val = instance.atom_set_hash(atoms);
+  for (index_type k = 0; k < actions.length(); k++)
+    val = instance.action_set_hash(actions[k].act, val);
+  return val;
+}
+State* ExecState::new_state(index_set& s)
+{
+  return new ExecState(instance, s);
+}
+State* ExecState::copy()
+{
+  return new ExecState(*this);
+}
+void ExecState::insert(Plan& p)
+{
+  p.advance(delta_t);
+  for (index_type k = 0; k < actions.length(); k++)
+    if (actions[k].rem == instance.actions[actions[k].act].dur)
+      p.insert(k);
+}
+void ExecState::write_plan(::std::ostream& s)
+{
+  index_set acts;
+  finishing_actions(acts);
+  bool first = true;
+  for (index_type k = 0; k < acts.length(); k++) {
+    if (!first) s << ", ";
+    first = false;
+    s << "finish:" << instance.actions[acts[k]].name;
+  }
+  starting_actions(acts);
+  for (index_type k = 0; k < acts.length(); k++) {
+    if (!first) s << ", ";
+    first = false;
+    s << "start:" << instance.actions[acts[k]].name;
+  }
+}
+void ExecState::write(::std::ostream& s)
+{
+  index_set currently_locked;
+  for (index_type k = 0; k < actions.length(); k++)
+    currently_locked.insert(instance.actions[actions[k].act].lck);
+  s << ";; [" << std::resetiosflags(std::ios::scientific) << ((current_time()).decimal()) << ", "
+    << std::resetiosflags(std::ios::scientific) << ((end_time()).decimal()) << "]" << ::std::endl;
+  s << "(:init";
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (atoms[k] && !currently_locked.contains(k))
+      s << " " << instance.atoms[k].name;
+  s << ::std::endl;
+  amt_vec in_use(0, instance.n_resources());
+  for (index_type k = 0; k < actions.length(); k++) {
+    for (index_type r = 0; r < instance.n_resources(); r++)
+      in_use[r] += instance.actions[actions[k].act].use[r];
+  }
+  for (index_type r = 0; r < instance.n_resources(); r++)
+    s << " (= " << instance.resources[r].name << " "
+      << std::resetiosflags(std::ios::scientific) << ((res[r]).decimal()) << ") ;; " << std::resetiosflags(std::ios::scientific) << ((in_use[r]).decimal())
+      << " in use" << ::std::endl;
+  for (index_type k = 0; k < actions.length(); k++) {
+    s << " ;; " << instance.actions[actions[k].act].name << ", "
+      << std::resetiosflags(std::ios::scientific) << ((actions[k].rem).decimal()) << " remaining" << ::std::endl;
+  }
+  s << ")" << ::std::endl;
+}
+bool ExecState::applicable
+(Instance::Action& a, ExecErrorSet* errors, index_type step)
+{
+  bool pre_ok = true;
+  bool compat_ok = true;
+  bool res_ok = true;
+  bool cons_ok = true;
+  for (index_type k = 0; k < a.pre.length(); k++) {
+    bool is_sat = atoms[a.pre[k]];
+    if (!is_sat) {
+      if (trace_level > 0) {
+ ::std::cerr << "action " << a.name << ": precondition "
+    << instance.atoms[a.pre[k]].name << " not satisfied"
+    << ::std::endl;
+      }
+      if (errors) {
+ index_set s(atoms);
+ UnsatisfiedPreconditionError* upe =
+   new UnsatisfiedPreconditionError(instance, a.index, a.pre[k], s,
+        abs_t, step);
+ errors->new_error(upe);
+      }
+      pre_ok = false;
+    }
+  }
+  if (extended_action_definition) {
+    assert(a.src);
+    ptr_pair* p = (ptr_pair*)a.src;
+    PDDL_Base::ActionSymbol* act = (PDDL_Base::ActionSymbol*)p->first;
+  }
+  amt_vec in_use(0, instance.n_resources());
+  for (index_type k = 0; k < actions.length(); k++) {
+    if (!instance.non_interfering(a.index, actions[k].act) ||
+ !instance.lock_compatible(a.index, actions[k].act)) {
+      if (trace_level > 0) {
+ ::std::cerr << "action " << a.name << ": conflict with "
+      << instance.actions[k].name << ::std::endl;
+      }
+      if (errors) {
+ IncompatibleActionError* iae =
+   new IncompatibleActionError(instance, a.index, k, abs_t, step);
+ errors->new_error(iae);
+      }
+      compat_ok = false;
+    }
+    for (index_type r = 0; r < instance.n_resources(); r++)
+      in_use[r] += instance.actions[k].req(r);
+  }
+  for (index_type r = 0; r < instance.n_resources(); r++) {
+    if (a.cons[r] > res[r]) {
+      if (trace_level > 0) {
+ ::std::cerr << "action " << a.name << ": not enough of resource "
+    << instance.resources[r].name << " remaining"
+    << ::std::endl;
+      }
+      if (errors) {
+ ResourceShortageError* rse =
+   new ResourceShortageError(instance, r, res[r], a.index, abs_t, step);
+ errors->new_error(rse);
+      }
+      cons_ok = false;
+    }
+    if ((in_use[r] + a.req(r)) > res[r]) {
+      if (trace_level > 0) {
+ ::std::cerr << "action " << a.name << ": not enough of resource "
+    << instance.resources[r].name << " free" << ::std::endl;
+      }
+      if (errors) {
+ ResourceConflictError* rce =
+   new ResourceConflictError(instance, r, abs_t, step);
+ for (index_type k = 0; k < actions.length(); k++)
+   if (instance.actions[actions[k].act].req(r) > 0) {
+     if (actions[k].step != no_such_index)
+       rce->add_action(actions[k].act, actions[k].step);
+     else
+       rce->add_action(actions[k].act);
+   }
+ if (step != no_such_index)
+   rce->add_action(a.index, step);
+ else
+   rce->add_action(a.index);
+ errors->new_error(rce);
+      }
+      res_ok = false;
+    }
+  }
+  return (pre_ok && compat_ok && res_ok && cons_ok);
+}
+void ExecState::apply
+(Instance::Action& a, ExecErrorSet* errors, index_type step)
+{
+  exec_act e(a.index, a.dur, step);
+  if (extended_action_definition)
+    e.start_state = (ExecState*)copy();
+  for (index_type k = 0; k < a.del.length(); k++) atoms[a.del[k]] = false;
+  if (extended_action_definition)
+    apply_conditional_delete_effects(a, e.start_state, atoms);
+  actions.append(e);
+}
+void ExecState::apply_conditional_delete_effects
+(Instance::Action& a, const ExecState* start_state, bool_vec& to)
+{
+  assert(a.src);
+  assert(start_state);
+  PDDL_Base::ActionSymbol* act =
+    PDDL_Base::src_action_symbol((ptr_pair*)a.src);
+  if (act->cond_eff.length() == 0) return;
+  for (index_type k = 0; k < act->cond_eff.length(); k++) {
+    rule_set pe;
+    rule_set ne;
+    act->cond_eff[k]->instantiate_conditional(instance, pe, ne);
+    for (index_type i = 0; i < ne.length(); i++) {
+      bool app = true;
+      for (index_type j = 0; (j < ne[i].antecedent.length()) && app; j++)
+ if (!start_state->atoms[ne[i].antecedent[j]]) app = false;
+      if (app) {
+ to[ne[i].consequent] = false;
+      }
+    }
+  }
+}
+void ExecState::active_conditional_add_effects
+(Instance::Action& a, const ExecState* start_state, bool_vec& eff)
+{
+  assert(a.src);
+  assert(start_state);
+  PDDL_Base::ActionSymbol* act =
+    PDDL_Base::src_action_symbol((ptr_pair*)a.src);
+  if (act->cond_eff.length() == 0) return;
+  for (index_type k = 0; k < act->cond_eff.length(); k++) {
+    rule_set pe;
+    rule_set ne;
+    act->cond_eff[k]->instantiate_conditional(instance, pe, ne);
+    for (index_type i = 0; i < pe.length(); i++) {
+      bool app = true;
+      for (index_type j = 0; (j < pe[i].antecedent.length()) && app; j++)
+ if (!start_state->atoms[pe[i].antecedent[j]]) app = false;
+      if (app) {
+ eff[pe[i].consequent] = true;
+      }
+    }
+  }
+}
+void ExecState::advance(hsps::rational dt, ExecErrorSet* errors)
+{
+  bool_vec new_atoms(atoms);
+  bool_vec finishing(false, actions.length());
+  for (index_type k = 0; k < actions.length(); k++) {
+    actions[k].rem -= dt;
+    if (actions[k].rem <= 0) {
+      finishing[k] = true;
+      Instance::Action& a = instance.actions[actions[k].act];
+      if (trace_level > 1) {
+ ::std::cerr << "action " << a.name << " started at "
+      << std::resetiosflags(std::ios::scientific) << ((abs_t + dt - a.dur).decimal()) << " as step "
+      << actions[k].step << " finishing at "
+      << std::resetiosflags(std::ios::scientific) << ((abs_t + dt - actions[k].rem).decimal())
+      << "..." << ::std::endl;
+      }
+      bool_vec added(false, instance.n_atoms());
+      added.insert(a.add);
+      if (extended_action_definition) {
+ active_conditional_add_effects(a, actions[k].start_state, added);
+ delete actions[k].start_state;
+ actions[k].start_state = 0;
+      }
+      bool is_red = true;
+      for (index_type i = 0; i < instance.n_atoms(); i++) if (added[i]) {
+ if (!atoms[i]) is_red = false;
+ new_atoms[i] = true;
+      }
+      if (is_red) {
+ if (trace_level > 0) {
+   ::std::cerr << "action " << a.name << " finishing at "
+        << std::resetiosflags(std::ios::scientific) << ((abs_t + dt - actions[k].rem).decimal())
+        << " is redundant (no effect)" << ::std::endl;
+ }
+ if (errors) {
+   RedundantActionWarning* raw =
+     new RedundantActionWarning(instance, k, abs_t+dt, actions[k].step);
+   errors->new_error(raw);
+ }
+      }
+    }
+  }
+  atoms.assign_copy(new_atoms);
+  actions.remove(finishing);
+  abs_t += dt;
+  delta_t = dt;
+}
+void ExecState::finish(ExecErrorSet* errors)
+{
+  advance(max_delta(), errors);
+}
+void ExecState::clip(hsps::rational at_t)
+{
+  if (at_t >= abs_t) {
+    dur = at_t - abs_t;
+  }
+  else {
+    ::std::cerr << "error: can't clip state " << this << " at "
+       << at_t << " since it only starts at " << abs_t
+       << ::std::endl;
+    exit(255);
+  }
+}
+void ExecState::intersect(const bool_vec& atms)
+{
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (!atms[k]) atoms[k] = false;
+}
+hsps::rational ExecState::current_time() const
+{
+  return abs_t;
+}
+hsps::rational ExecState::end_time() const
+{
+  return (abs_t + dur);
+}
+void ExecState::current_atoms(index_set& atms) const
+{
+  atms.clear();
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (atoms[k]) atms.insert(k);
+}
+const bool_vec& ExecState::current_atoms() const
+{
+  return atoms;
+}
+void ExecState::current_actions(index_set& acts) const
+{
+  acts.clear();
+  for (index_type k = 0; k < actions.length(); k++)
+    acts.insert(actions[k].act);
+}
+index_type ExecState::n_current_actions() const
+{
+  return actions.length();
+}
+void ExecState::starting_actions(index_set& acts) const
+{
+  acts.clear();
+  for (index_type k = 0; k < actions.length(); k++)
+    if (actions[k].rem == instance.actions[actions[k].act].dur)
+      acts.insert(actions[k].act);
+}
+void ExecState::finishing_actions(index_set& acts) const
+{
+  acts.clear();
+  for (index_type k = 0; k < actions.length(); k++)
+    if (actions[k].rem <= dur)
+      acts.insert(actions[k].act);
+}
+hsps::rational ExecState::min_delta() const
+{
+  hsps::rational d = POS_INF;
+  for (index_type k = 0; k < actions.length(); k++)
+    d = hsps::rational::min(d,actions[k].rem);
+  return d;
+}
+hsps::rational ExecState::max_delta() const
+{
+  hsps::rational d = 0;
+  for (index_type k = 0; k < actions.length(); k++)
+    d = hsps::rational::max(d,actions[k].rem);
+  return d;
+}
+void ExecState::current_resource_use(amt_vec& in_use) const
+{
+  for (index_type r = 0; r < instance.n_resources(); r++) in_use[r] = 0;
+  for (index_type k = 0; k < actions.length(); k++) {
+    for (index_type r = 0; r < instance.n_resources(); r++)
+      if (instance.resources[r].reusable())
+ in_use[r] += instance.actions[actions[k].act].use[r];
+  }
+}
+void ExecState::current_resource_levels(amt_vec& avail, amt_vec& in_use) const
+{
+  for (index_type r = 0; r < instance.n_resources(); r++) avail[r] = res[r];
+  for (index_type r = 0; r < instance.n_resources(); r++) in_use[r] = 0;
+  for (index_type k = 0; k < actions.length(); k++) {
+    for (index_type r = 0; r < instance.n_resources(); r++)
+      in_use[r] += instance.actions[actions[k].act].use[r];
+  }
+}
+void ExecState::current_resource_levels
+(index_type r, hsps::rational& avail, hsps::rational& in_use) const
+{
+  assert(r < instance.n_resources());
+  avail = res[r];
+  in_use = 0;
+  for (index_type k = 0; k < actions.length(); k++) {
+    in_use += instance.actions[actions[k].act].use[r];
+  }
+}
+bool ExecState::check_atoms(const index_set& set) const
+{
+  for (index_type k = 0; k < set.length(); k++)
+    if (!atoms[set[k]]) return false;
+  return true;
+}
+bool ExecState::check_atoms(const index_set& set, index_set& holds) const
+{
+  holds.clear();
+  for (index_type k = 0; k < set.length(); k++)
+    if (atoms[set[k]]) holds.insert(set[k]);
+  return (holds.length() == set.length());
+}
+Timeline::~Timeline()
+{
+}
+hsps::rational Timeline::total_time()
+{
+  if (n_intervals() == 0) {
+    ::std::cerr << "error: total time of zero-interval makespan is undefined"
+       << ::std::endl;
+  }
+  hsps::rational s = interval_start_time(0);
+  hsps::rational t = interval_end_time(n_intervals() - 1);
+  if ((s).finite() && (t).finite()) {
+    return t - s;
+  }
+  else {
+    return POS_INF;
+  }
+}
+void BasicTimeline::set_point(hsps::rational t)
+{
+  index_type k = 0;
+  while (k < points.length()) {
+    if (t < points[k]) {
+      points.insert(t, k);
+      return;
+    }
+    k += 1;
+  }
+  points.append(t);
+}
+void BasicTimeline::clip_start(hsps::rational t)
+{
+  if (points.length() == 0) {
+    points.assign_value(t, 1);
+  }
+  else {
+    if (points[0] > t) points.insert(t, 0);
+  }
+  open_start = false;
+}
+void BasicTimeline::clip_end(hsps::rational t)
+{
+  if (points.length() == 0) {
+    points.assign_value(t, 1);
+  }
+  else {
+    if (points[points.length() - 1] < t) points.append(t);
+  }
+  open_end = false;
+}
+BasicTimeline::BasicTimeline()
+  : points(0, 0), open_start(true), open_end(true)
+{
+}
+BasicTimeline::~BasicTimeline()
+{
+}
+index_type BasicTimeline::n_intervals()
+{
+  return (points.length() + (open_start ? 1 : 0) + (open_end ? 1 : 0) - 1);
+}
+index_type BasicTimeline::n_points()
+{
+  return points.length();
+}
+index_type BasicTimeline::interval_start_point(index_type i)
+{
+  if (open_start) {
+    if (i == 0) return no_such_index;
+    else {
+      if (i > points.length()) {
+ ::std::cerr << "invalid interval " << i
+    << " in BasicTimeline::interval_start_point"
+    << ::std::endl;
+ exit(255);
+      }
+      return i - 1;
+    }
+  }
+  else {
+    if (i >= points.length()) {
+      ::std::cerr << "invalid interval " << i
+  << " in BasicTimeline::interval_start_point"
+  << ::std::endl;
+      exit(255);
+    }
+    return i;
+  }
+}
+index_type BasicTimeline::interval_end_point(index_type i)
+{
+  if (open_start) {
+    if (i > points.length()) {
+      ::std::cerr << "invalid interval " << i
+  << " in BasicTimeline::interval_end_point"
+  << ::std::endl;
+      exit(255);
+    }
+    else if (i == points.length()) {
+      if (open_end) return no_such_index;
+      else {
+ ::std::cerr << "invalid interval " << i
+    << " in BasicTimeline::interval_end_point"
+    << ::std::endl;
+ exit(255);
+      }
+    }
+    else {
+      return i;
+    }
+  }
+  else {
+    if ((i + 1) < points.length()) {
+      return i + 1;
+    }
+    else if (((i + 1) == points.length()) && open_end) {
+      return no_such_index;
+    }
+    else {
+      ::std::cerr << "invalid interval " << i
+  << " in BasicTimeline::interval_end_point"
+  << ::std::endl;
+      exit(255);
+    }
+  }
+}
+hsps::rational BasicTimeline::point_time(index_type i)
+{
+  if (i >= points.length()) {
+    ::std::cerr << "error: invalid point " << i
+       << " in BasicTimeline::point_time"
+       << ::std::endl;
+    exit(255);
+  }
+  return points[i];
+}
+hsps::rational BasicTimeline::interval_start_time(index_type i)
+{
+  index_type j = interval_start_point(i);
+  if (j == no_such_index) return NEG_INF;
+  return point_time(j);
+}
+hsps::rational BasicTimeline::interval_end_time(index_type i)
+{
+  index_type j = interval_end_point(i);
+  if (j == no_such_index) return POS_INF;
+  return point_time(j);
+}
+void BasicTimeline::write(::std::ostream& s)
+{
+  for (index_type i = 0; i < n_intervals(); i++) {
+    if (i > 0) s << ", ";
+    s << '[' << interval_start_time(i) << ',' << interval_end_time(i) << ']';
+  }
+}
+ResourceProfile::ResourceProfile
+(Instance& ins, index_type r, ExecTrace& trace)
+  : instance(ins),
+    res(r),
+    avail(0, 1),
+    in_use(0, 1),
+    a_start(EMPTYSET, 1),
+    a_finish(EMPTYSET, 1),
+    max_req(0)
+{
+  if (trace.length() == 0) {
+    ::std::cerr << "error: can't construct resource profile from empty trace"
+  << ::std::endl;
+    exit(255);
+  }
+  clip_start(trace[0]->current_time());
+  trace[0]->current_resource_levels(res, avail[0], in_use[0]);
+  index_set s;
+  trace[0]->starting_actions(s);
+  for (index_type j = 0; j < s.length(); j++)
+    if (instance.actions[s[j]].req(res) > 0) {
+      a_start[0].insert(s[j]);
+      max_req = hsps::rational::max(max_req,instance.actions[s[j]].req(res));
+    }
+  index_type i = 0;
+  for (index_type k = 1; k < trace.length(); k++) {
+    index_type n_start = 0;
+    index_type n_finish = 0;
+    trace[k]->starting_actions(s);
+    for (index_type j = 0; j < s.length(); j++)
+      if (instance.actions[s[j]].req(res) > 0) {
+ n_start += 1;
+ max_req = hsps::rational::max(max_req,instance.actions[s[j]].req(res));
+      }
+    trace[k - 1]->finishing_actions(s);
+    for (index_type j = 0; j < s.length(); j++)
+      if (instance.actions[s[j]].req(res) > 0)
+ n_finish += 1;
+    if (n_start + n_finish > 0) {
+      if (trace[k]->current_time() > interval_start_time(i)) {
+ set_point(trace[k]->current_time());
+ i += 1;
+ trace[k]->current_resource_levels(res, avail[i], in_use[i]);
+      }
+    }
+    a_start.inc_length_to(i + 1, EMPTYSET);
+    trace[k]->starting_actions(s);
+    for (index_type j = 0; j < s.length(); j++)
+      if (instance.actions[s[j]].req(res) > 0) {
+ a_start[i].insert(s[j]);
+ max_req = hsps::rational::max(max_req,instance.actions[s[j]].req(res));
+      }
+    a_finish.inc_length_to(i + 1, EMPTYSET);
+    trace[k - 1]->finishing_actions(s);
+    for (index_type j = 0; j < s.length(); j++)
+      if (instance.actions[s[j]].req(res) > 0)
+ a_finish[i].insert(s[j]);
+    trace[k]->current_resource_levels(res, avail[i], in_use[i]);
+  }
+  if ((trace.final_state()->end_time()).finite())
+    clip_end(trace.final_state()->end_time());
+}
+ResourceProfile::~ResourceProfile()
+{
+}
+void ResourceProfile::set_makespan(hsps::rational t)
+{
+  clip_end(t);
+}
+hsps::rational ResourceProfile::amount_available(index_type i)
+{
+  if (i >= n_intervals()) {
+    ::std::cerr << "error: invalid interval " << i
+       << " in ResourceProfile::amount_available"
+       << ::std::endl;
+    exit(255);
+  }
+  return avail[i];
+}
+hsps::rational ResourceProfile::amount_in_use(index_type i)
+{
+  if (i >= n_intervals()) {
+    ::std::cerr << "error: invalid interval " << i
+       << " in ResourceProfile::amount_in_use"
+       << ::std::endl;
+    exit(255);
+  }
+  return in_use[i];
+}
+index_type ResourceProfile::first_use_interval(index_type i)
+{
+  while (i < n_intervals()) {
+    if (amount_in_use(i) > 0) return i;
+    i += 1;
+  }
+  return no_such_index;
+}
+hsps::rational ResourceProfile::amount_free(index_type i)
+{
+  if (i >= n_intervals()) {
+    ::std::cerr << "error: invalid interval " << i
+       << " in ResourceProfile::amount_free"
+       << ::std::endl;
+    exit(255);
+  }
+  return (avail[i] - in_use[i]);
+}
+hsps::rational ResourceProfile::possible_unexpected_loss_to(index_type i)
+{
+  assert(i < n_intervals());
+  hsps::rational pul = 0;
+  for (index_type j = 0; j <= i; j++)
+    for (index_type k = 0; k < a_finish[j].length(); k++)
+      pul += instance.actions[a_finish[j][k]].use[res];
+  return pul;
+}
+hsps::rational ResourceProfile::tolerable_unexpected_loss()
+{
+  hsps::rational tul = POS_INF;
+  for (index_type i = 0; i < n_intervals(); i++) if (in_use[i] > 0) {
+    hsps::rational pul_to_i = possible_unexpected_loss_to(i);
+    if (pul_to_i > amount_free(i))
+      tul = hsps::rational::min(amount_free(i),tul);
+  }
+  return tul;
+}
+hsps::rational ResourceProfile::min_free_from(index_type i)
+{
+  if (i >= n_intervals()) {
+    ::std::cerr << "error: invalid interval " << i
+       << " in ResourceProfile::amount_available"
+       << ::std::endl;
+    exit(255);
+  }
+  hsps::rational f = amount_free(i);
+  for (index_type j = i + 1; j < n_intervals(); j++)
+    f = hsps::rational::min(f,amount_free(j));
+  return f;
+}
+index_type ResourceProfile::first_min_free_interval(index_type i)
+{
+  hsps::rational f = POS_INF;
+  index_type p = no_such_index;
+  for (index_type j = i; j < n_intervals(); j++)
+    if (amount_free(j) < f) {
+      f = amount_free(j);
+      p = j;
+    }
+  return p;
+}
+hsps::rational ResourceProfile::min_free()
+{
+  return min_free_from(0);
+}
+hsps::rational ResourceProfile::peak_use()
+{
+  return (instance.resources[res].init - min_free_from(0));
+}
+hsps::rational ResourceProfile::min_peak_use()
+{
+  return max_req;
+}
+hsps::rational ResourceProfile::total_consumption()
+{
+  return (instance.resources[res].init - amount_available(n_intervals() - 1));
+}
+void ResourceProfile::write(::std::ostream& s)
+{
+  for (index_type i = 0; i < n_intervals(); i++) {
+    for (index_type k = 0; k < a_finish[i].length(); k++)
+      s << " - finish " << instance.actions[a_finish[i][k]].name << ::std::endl;
+    for (index_type k = 0; k < a_start[i].length(); k++)
+      s << " - start " << instance.actions[a_start[i][k]].name << ::std::endl;
+    s << "[" << std::resetiosflags(std::ios::scientific) << ((interval_start_time(i)).decimal())
+      << "," << std::resetiosflags(std::ios::scientific) << ((interval_end_time(i)).decimal())
+      << "]: a = " << std::resetiosflags(std::ios::scientific) << ((amount_available(i)).decimal())
+      << ", u = " << std::resetiosflags(std::ios::scientific) << ((amount_in_use(i)).decimal())
+      << ", f = " << std::resetiosflags(std::ios::scientific) << ((amount_free(i)).decimal())
+      << ", tl = ";
+    if (i < (n_intervals() - 1)) {
+      s << std::resetiosflags(std::ios::scientific) << ((min_free_from(i + 1)).decimal());
+    }
+    else {
+      s << std::resetiosflags(std::ios::scientific) << ((amount_available(i)).decimal());
+    }
+    s << ::std::endl;
+  }
+}
+double ResourceProfile::GANTT_EXTRA_WIDTH = 10;
+double ResourceProfile::GANTT_EXTRA_HEIGHT = 10;
+void ResourceProfile::writeGantt(::std::ostream& s)
+{
+  double pic_width = (points[points.length() - 1] - points[0]).decimal();
+  double pic_height = instance.resources[res].init.decimal();
+  s << "\\newcommand{\\ganttunitwidth}{" << Schedule::GANTT_UNIT_WIDTH << "}"
+    << ::std::endl;
+  s << "\\newcommand{\\ganttunitheight}{" << Schedule::GANTT_UNIT_HEIGHT << "}"
+    << ::std::endl;
+  s << "\\newcommand{\\ganttextrawidth}{" << GANTT_EXTRA_WIDTH << "}"
+    << ::std::endl;
+  s << "\\newcommand{\\gantthalfextrawidth}{" << GANTT_EXTRA_WIDTH/2 << "}"
+    << ::std::endl;
+  s << "\\newcommand{\\ganttextraheight}{" << GANTT_EXTRA_HEIGHT << "}"
+    << ::std::endl;
+  s << "\\newcommand{\\gantttextxoff}{" << Schedule::GANTT_TEXT_XOFF << "}"
+    << ::std::endl;
+  s << "\\newcommand{\\gantttextyoff}{" << Schedule::GANTT_TEXT_YOFF << "}"
+    << ::std::endl;
+  s << "\\newcount\\xzero" << ::std::endl;
+  s << "\\newcount\\xone" << ::std::endl;
+  s << "\\newcount\\yzero" << ::std::endl;
+  s << "\\newcount\\yone" << ::std::endl;
+  s << "\\xzero=" << pic_width << "\\ganttunitwidth" << ::std::endl;
+  s << "\\advance\\xzero by \\ganttextrawidth\\ganttunitwidth" << ::std::endl;
+  s << "\\yzero=" << pic_height << "\\ganttunitheight" << ::std::endl;
+  s << "\\advance\\yzero by \\ganttextraheight\\ganttunitheight" << ::std::endl;
+  s << "\\begin{picture}(\\xzero,\\yzero)(0,0)" << ::std::endl;
+  s << "\\xzero=0" << ::std::endl;
+  s << "\\xone=" << pic_width << "\\ganttunitwidth" << ::std::endl;
+  s << "\\advance\\xone by \\ganttextrawidth\\ganttunitwidth" << ::std::endl;
+  s << "\\yzero=\\ganttextraheight\\ganttunitheight" << ::std::endl;
+  s << "\\drawline(\\xzero,\\yzero)(\\xone,\\yzero)" << ::std::endl;
+  s << "\\xzero=\\gantthalfextrawidth\\ganttunitwidth" << ::std::endl;
+  s << "\\yzero=0" << ::std::endl;
+  s << "\\yone=" << pic_height << "\\ganttunitheight" << ::std::endl;
+  s << "\\advance\\yone by \\ganttextraheight\\ganttunitheight" << ::std::endl;
+  s << "\\drawline(\\xzero,\\yzero)(\\xzero,\\yone)" << ::std::endl;
+  for (index_type k = 0; k < n_intervals(); k++) {
+    double x0 = interval_start_time(k).decimal();
+    s << "\\xzero=" << x0 << "\\ganttunitwidth" << ::std::endl;
+    s << "\\advance\\xzero by \\gantthalfextrawidth\\ganttunitwidth"
+      << ::std::endl;
+    s << "\\yzero=0" << ::std::endl;
+    s << "\\yone=" << pic_height << "\\ganttunitheight" << ::std::endl;
+    s << "\\advance\\yone by \\ganttextraheight\\ganttunitheight" << ::std::endl;
+    if (interval_start_time(k) > interval_start_time(0)) {
+      s << "\\dashline{1}(\\xzero,\\yzero)(\\xzero,\\yone)"
+ << ::std::endl;
+    }
+    s << "\\advance\\xzero by \\gantttextxoff" << ::std::endl;
+    s << "\\put(\\xzero,0){\\makebox(0,0)[lb]{\\smash{{\\footnotesize{\\tt "
+      << std::resetiosflags(std::ios::scientific) << ((interval_start_time(k)).decimal()) << "}}}}}" << ::std::endl;
+  }
+  for (index_type k = 0; k < n_intervals(); k++) {
+    double x0 = interval_start_time(k).decimal();
+    double x1 = interval_end_time(k).decimal();
+    double y0 = amount_available(k).decimal();
+    double y1 = amount_in_use(k).decimal();
+    s << "\\xzero=" << x0 << "\\ganttunitwidth" << ::std::endl;
+    s << "\\advance\\xzero by \\gantthalfextrawidth\\ganttunitwidth"
+      << ::std::endl;
+    if ((interval_end_time(k)).finite()) {
+      s << "\\xone=" << x1 << "\\ganttunitwidth" << ::std::endl;
+      s << "\\advance\\xone by \\gantthalfextrawidth\\ganttunitwidth"
+ << ::std::endl;
+    }
+    else {
+      s << "\\xone=" << pic_width << "\\ganttunitwidth" << ::std::endl;
+      s << "\\advance\\xone by \\ganttextrawidth\\ganttunitwidth" << ::std::endl;
+    }
+    s << "\\yzero=" << y0 << "\\ganttunitheight" << ::std::endl;
+    s << "\\advance\\yzero by \\ganttextraheight\\ganttunitheight"
+      << ::std::endl;
+    s << "\\drawline(\\xzero,\\yzero)(\\xone,\\yzero)" << ::std::endl;
+    s << "\\yone=" << y1 << "\\ganttunitheight" << ::std::endl;
+    s << "\\advance\\yone by \\ganttextraheight\\ganttunitheight" << ::std::endl;
+    s << "\\dashline{1}(\\xzero,\\yone)(\\xone,\\yone)" << ::std::endl;
+  }
+  s << "\\end{picture}" << ::std::endl;
+  s << ::std::endl << "{\\small\\begin{tabular}{|l|l|}"
+    << ::std::endl << "\\hline"
+    << ::std::endl << "\\multicolumn{2}{|c|}{Events}\\\\"
+    << ::std::endl << "\\hline"
+    << ::std::endl;
+  for (index_type i = 0; i < n_intervals(); i++) {
+    for (index_type k = 0; k < a_finish[i].length(); k++) {
+      if (k == 0) s << std::resetiosflags(std::ios::scientific) << ((interval_start_time(i)).decimal());
+      s << " & " << " finish ";
+      instance.actions[a_finish[i][k]].name->write(s, Name::NC_LATEX);
+      s << "\\\\" << ::std::endl;
+    }
+    for (index_type k = 0; k < a_start[i].length(); k++) {
+      if ((k + a_finish[i].length()) == 0)
+ s << std::resetiosflags(std::ios::scientific) << ((interval_start_time(i)).decimal());
+      s << " & " << " start ";
+      instance.actions[a_start[i][k]].name->write(s, Name::NC_LATEX);
+      s << "\\\\" << ::std::endl;
+    }
+    if ((a_start[i].length() + a_finish[i].length()) > 0) {
+      s << "\\hline" << ::std::endl;
+    }
+  }
+  s << "\\end{tabular}}" << ::std::endl;
+}
+ExecTrace::ExecTrace(Instance& ins)
+  : lvector<ExecState*>(0, 0), instance(ins)
+{
+}
+ExecTrace::~ExecTrace()
+{
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k]) delete (*this)[k];
+}
+index_type ExecTrace::n_intervals()
+{
+  return length();
+}
+index_type ExecTrace::n_points()
+{
+  if (length() == 0) return 0;
+  if ((final_state()->end_time()).finite()) return length() + 1;
+  return length();
+}
+index_type ExecTrace::interval_start_point(index_type i)
+{
+  if (i >= length()) {
+    ::std::cerr << "error: invalid interval " << i
+       << " in ExecTrace::interval_start_point"
+       << ::std::endl;
+    exit(255);
+  }
+  return i;
+}
+index_type ExecTrace::interval_end_point(index_type i)
+{
+  if (i >= length()) {
+    ::std::cerr << "error: invalid interval " << i
+       << " in ExecTrace::interval_end_point"
+       << ::std::endl;
+    exit(255);
+  }
+  if (i == (length() - 1)) {
+    if ((final_state()->end_time()).finite()) return i + 1;
+    return no_such_index;
+  }
+  else {
+    return i + 1;
+  }
+}
+hsps::rational ExecTrace::point_time(index_type i)
+{
+  if (i > length()) {
+    ::std::cerr << "error: invalid point " << i
+       << " in ExecTrace::point_time"
+       << ::std::endl;
+    exit(255);
+  }
+  else if (i == length()) {
+    if ((final_state()->end_time()).finite()) {
+      return final_state()->end_time();
+    }
+    else {
+      ::std::cerr << "error: invalid point " << i
+  << " in ExecTrace::point_time (open last interval)"
+  << ::std::endl;
+      exit(255);
+    }
+  }
+  else {
+    return (*this)[i]->current_time();
+  }
+}
+hsps::rational ExecTrace::interval_start_time(index_type i)
+{
+  if (i >= length()) {
+    ::std::cerr << "error: invalid interval " << i
+       << " in ExecTrace::interval_start_time"
+       << ::std::endl;
+    exit(255);
+  }
+  return (*this)[i]->current_time();
+}
+hsps::rational ExecTrace::interval_end_time(index_type i)
+{
+  if (i >= length()) {
+    ::std::cerr << "error: invalid interval " << i
+       << " in ExecTrace::interval_start_time"
+       << ::std::endl;
+    exit(255);
+  }
+  return (*this)[i]->end_time();
+}
+ExecState* ExecTrace::final_state()
+{
+  if (length() > 0) {
+    return (*this)[length() - 1];
+  }
+  else {
+    return 0;
+  }
+}
+ExecTrace* ExecTrace::copy()
+{
+  ExecTrace* t = new ExecTrace(instance);
+  for (index_type k = 0; k < length(); k++) {
+    assert((*this)[k]);
+    t->append((ExecState*)(*this)[k]->copy());
+  }
+  return t;
+}
+ExecTrace* ExecTrace::necessary_trace()
+{
+  assert(length() > 0);
+  ExecTrace* t = copy();
+  bool_vec nec(instance.goal_atoms, instance.n_atoms());
+  for (index_type k = length(); k > 0; k--) {
+    (*t)[k - 1]->intersect(nec);
+    index_set af;
+    (*t)[k - 1]->finishing_actions(af);
+    for (index_type i = 0; i < af.length(); i++)
+      nec.subtract(instance.actions[af[i]].add);
+    index_set as;
+    (*t)[k - 1]->starting_actions(as);
+    for (index_type i = 0; i < as.length(); i++)
+      nec.insert(instance.actions[as[i]].pre);
+  }
+  return t;
+}
+void ExecTrace::clip_last_state(hsps::rational at_t)
+{
+  if (length() > 0) {
+    (*this)[length() - 1]->clip(at_t);
+  }
+}
+void ExecTrace::write(::std::ostream& s)
+{
+  for (index_type k = 0; k < length(); k++) {
+    (*this)[k]->write(s);
+  }
+}
+void ExecTrace::peak_resource_use(amt_vec& res)
+{
+  res.assign_value(0, instance.n_resources());
+  amt_vec cur(0, instance.n_resources());
+  for (index_type k = 0; k < length(); k++) {
+    (*this)[k]->current_resource_use(cur);
+    for (index_type r = 0; r < instance.n_resources(); r++)
+      if (cur[r] > res[r]) res[r] = cur[r];
+  }
+}
+bool ExecTrace::test_always(index_type p)
+{
+  for (index_type k = 0; k < length(); k++) {
+    if (!(*this)[k]->current_atoms()[p]) return false;
+  }
+  return true;
+}
+bool ExecTrace::test_sometime(index_type p)
+{
+  for (index_type k = 0; k < length(); k++) {
+    if ((*this)[k]->current_atoms()[p]) return true;
+  }
+  return false;
+}
+bool ExecTrace::test_sometime_after(index_type p, index_type q)
+{
+  bool f = false;
+  for (index_type k = 0; k < length(); k++) {
+    if (f) {
+      if ((*this)[k]->current_atoms()[q]) return true;
+    }
+    else {
+      if ((*this)[k]->current_atoms()[p]) f = true;
+      if ((*this)[k]->current_atoms()[q]) return true;
+    }
+  }
+  return !f;
+}
+bool ExecTrace::test_sometime_before(index_type p, index_type q)
+{
+  for (index_type k = 0; k < length(); k++) {
+    if ((*this)[k]->current_atoms()[q]) {
+      return true;
+    }
+    else if ((*this)[k]->current_atoms()[p]) {
+      return false;
+    }
+  }
+  return true;
+}
+bool ExecTrace::test_at_most_once(index_type p)
+{
+  bool f = false;
+  bool g = false;
+  for (index_type k = 0; k < length(); k++) {
+    if (g) {
+      if ((*this)[k]->current_atoms()[p]) return false;
+    }
+    else if (f) {
+      if (!(*this)[k]->current_atoms()[p]) g = true;
+    }
+    else {
+      if ((*this)[k]->current_atoms()[p]) f = true;
+    }
+  }
+  return true;
+}
+void ExecTrace::extract_always_within(bool_matrix& c, cost_matrix& t)
+{
+  assert(length() > 0);
+  c.assign_value(false, instance.n_atoms(), instance.n_atoms());
+  t.assign_value(0, instance.n_atoms(), instance.n_atoms());
+  bool_matrix is_open(false, instance.n_atoms(), instance.n_atoms());
+  cost_matrix open_since(0, instance.n_atoms(), instance.n_atoms());
+  for (index_type k = 0; k < length(); k++) {
+    hsps::rational tk = (*this)[k]->current_time();
+    for (index_type i = 0; i < instance.n_atoms(); i++) {
+      for (index_type j = 0; j < instance.n_atoms(); j++) {
+ if ((*this)[k]->current_atoms()[i] && !is_open[i][j]) {
+   is_open[i][j] = true;
+   open_since[i][j] = tk;
+   c[i][j] = true;
+ }
+ if ((*this)[k]->current_atoms()[j] && is_open[i][j]) {
+   is_open[i][j] = false;
+   hsps::rational d = (tk - open_since[i][j]);
+   t[i][j] = hsps::rational::max(d,t[i][j]);
+ }
+      }
+    }
+  }
+  for (index_type i = 0; i < instance.n_atoms(); i++)
+    for (index_type j = 0; j < instance.n_atoms(); j++)
+      if (is_open[i][j]) c[i][j] = false;
+}
+bool Schedule::write_traits = true;
+Schedule::Schedule(Instance& i)
+  : instance(i),
+    end_t(0),
+    action_set(EMPTYSET),
+    n_tracks(0),
+    ann_name(0),
+    ann_optimal(false),
+    traits(0, 0),
+    current_t(0),
+    finished(false),
+    trace_level(Instance::default_trace_level)
+{
+}
+Schedule::Schedule(const Schedule& s)
+  : instance(s.instance),
+    steps(s.steps),
+    end_t(s.end_t),
+    action_set(s.action_set),
+    action_vec(s.action_vec),
+    n_tracks(s.n_tracks),
+    ann_name(s.ann_name),
+    ann_optimal(s.ann_optimal),
+    traits(0, 0),
+    current_t(s.current_t),
+    finished(s.finished),
+    trace_level(Instance::default_trace_level)
+{
+}
+Schedule::~Schedule()
+{
+  for (index_type k = 0; k < traits.length(); k++)
+    delete traits[k];
+}
+index_type Schedule::length() const
+{
+  return steps.length();
+}
+hsps::rational Schedule::makespan() const
+{
+  return end_t;
+}
+hsps::rational Schedule::cost() const
+{
+  hsps::rational c = 0;
+  for (index_type k = 0; k < steps.length(); k++)
+    c += instance.actions[steps[k].act].cost;
+  return c;
+}
+void Schedule::step_action_names(name_vec& nv)
+{
+  nv.assign_value(0, steps.length());
+  for (index_type k = 0; k < steps.length(); k++)
+    nv[k] = instance.actions[steps[k].act].name;
+}
+bool Schedule::step_in_interval
+(index_type s, hsps::rational i_start, hsps::rational i_end) const
+{
+  assert(s < steps.length());
+  if ((steps[s].at + instance.actions[steps[s].act].dur) <= i_start)
+    return false;
+  if (steps[s].at >= i_end)
+    return false;
+  return true;
+}
+index_type Schedule::step_action(index_type s) const
+{
+  assert(s < steps.length());
+  return steps[s].act;
+}
+const Name* Schedule::plan_name() const
+{
+  return ann_name;
+}
+bool Schedule::plan_is_optimal() const
+{
+  return ann_optimal;
+}
+void Schedule::clear()
+{
+  steps.clear();
+  end_t = 0;
+  current_t = 0;
+  finished = false;
+}
+void Schedule::protect(index_type atom)
+{
+}
+void Schedule::insert_step(hsps::rational at, index_type act)
+{
+  index_type k = 0;
+  while (k < steps.length()) {
+    if (at < steps[k].at) {
+      steps.insert(step(act, at), k);
+      return;
+    }
+    k += 1;
+  }
+  steps.append(step(act, at));
+}
+void Schedule::insert(index_type act)
+{
+  if (finished) {
+    ::std::cerr << "program error: schedule::insert called after schedule::end"
+       << ::std::endl;
+    exit(255);
+  }
+  insert_step(current_t, act);
+}
+void Schedule::advance(hsps::rational delta)
+{
+  current_t += delta;
+}
+void Schedule::set_start_time(hsps::rational t)
+{
+  if (steps.length() == 0) return;
+  hsps::rational d = (t - steps[0].at);
+  if (d != 0) {
+    for (index_type k = 0; k < steps.length(); k++) {
+      steps[k].at += d;
+    }
+    end_t += d;
+  }
+}
+void Schedule::compute_action_set_and_vec()
+{
+  action_set.clear();
+  action_vec.set_length(0);
+  for (index_type k = 0; k < steps.length(); k++) {
+    action_set.insert(steps[k].act);
+    action_vec.append(steps[k].act);
+  }
+}
+void Schedule::end()
+{
+  if (finished) {
+    ::std::cerr << "program error: schedule::end called twice" << ::std::endl;
+    exit(255);
+  }
+  end_t = 0;
+  for (index_type k = 0; k < steps.length(); k++)
+    end_t = hsps::rational::max(end_t,steps[k].at + instance.actions[steps[k].act].dur);
+  set_start_time(0);
+  assign_tracks();
+  compute_action_set_and_vec();
+  finished = true;
+}
+void Schedule::reduce(ExecErrorSet* warnings)
+{
+  if (!finished) {
+    ::std::cerr << "program error: schedule::remove_redundant_steps called before schedule::end" << ::std::endl;
+    exit(255);
+  }
+  bool_vec steps_to_remove(false, steps.length());
+  index_type k = 0;
+  while (k < warnings->length()) {
+    if (((*warnings)[k]->type_of_error() ==
+  ExecError::warning_redundant_action) &&
+ ((*warnings)[k]->step_of_error() != no_such_index)) {
+      steps_to_remove[(*warnings)[k]->step_of_error()] = true;
+      warnings->remove(k);
+    }
+    else {
+      k += 1;
+    }
+  }
+  if (trace_level > 0) {
+    ::std::cerr << "removing " << steps_to_remove.count(true)
+       << " redudant steps from plan";
+    if (plan_name()) ::std::cerr << " " << plan_name();
+    ::std::cerr << "..." << ::std::endl;
+  }
+  if (steps_to_remove.count(true) > 0) {
+    mapping map(steps.length());
+    steps.remove(steps_to_remove, map);
+    compute_action_set_and_vec();
+    for (index_type k = 0; k < traits.length(); k++) {
+      PlanPrecedenceRelation* pp =
+ (PlanPrecedenceRelation*)
+ traits[k]->cast_to("PlanPrecedenceRelation");
+      if (pp) {
+ graph p_new;
+ p_new.copy(pp->precedence_relation(), map);
+ delete traits[k];
+ traits[k] = new PlanPrecedenceRelation(this, p_new);
+      }
+    }
+    warnings->remap_steps(map);
+  }
+}
+void Schedule::set_name(const Name* n)
+{
+  ann_name = n;
+}
+void Schedule::set_optimal(bool o)
+{
+  ann_optimal = o;
+}
+void Schedule::add_trait(PlanTrait* t)
+{
+  traits.append(t);
+}
+const PlanTrait* Schedule::find_trait(const char* cn)
+{
+  for (index_type k = 0; k < traits.length(); k++) {
+    const PlanTrait* t = traits[k]->cast_to(cn);
+    if (t) return t;
+  }
+  return 0;
+}
+void Schedule::output(Plan& plan) const
+{
+  hsps::rational t = 0;
+  for (index_type k = 0; k < steps.length(); k++) {
+    hsps::rational dt = steps[k].at - t;
+    if (dt > 0) plan.advance(dt);
+    plan.insert(steps[k].act);
+    t = steps[k].at;
+  }
+  if (t < end_t) plan.advance(end_t - t);
+  plan.end();
+}
+void Schedule::output
+(Plan& plan, const index_vec& act_map) const
+{
+  hsps::rational t = 0;
+  for (index_type k = 0; k < steps.length(); k++) {
+    hsps::rational dt = steps[k].at - t;
+    if (dt > 0) plan.advance(dt);
+    plan.insert(act_map[steps[k].act]);
+    t = steps[k].at;
+  }
+  if (t < end_t) plan.advance(end_t - t);
+  plan.end();
+}
+void Schedule::write(::std::ostream& s, unsigned int c) const
+{
+  s << "(:plan";
+  if (ann_name) {
+    s << ::std::endl << "  :name ";
+    ann_name->write(s, c);
+  }
+  if (ann_optimal) {
+    s << ::std::endl << "  :opt";
+  }
+  for (index_type k = 0; k < steps.length(); k++) {
+    Instance::Action& act = instance.actions[steps[k].act];
+    s << ::std::endl << "  " << std::resetiosflags(std::ios::scientific) << ((steps[k].at).decimal())
+      << " : ";
+    if (Name::context_is_instance(c)) {
+      s << "(";
+      act.name->write(s, c);
+      s << ")";
+    }
+    else {
+      act.name->write(s, c);
+    }
+  }
+  s << ")" << ::std::endl;
+  s << ";; length: " << length() << ::std::endl;
+  s << ";; makespan: " << std::resetiosflags(std::ios::scientific) << ((makespan()).decimal()) << ::std::endl;
+  s << ";; cost: " << std::resetiosflags(std::ios::scientific) << ((cost()).decimal()) << ::std::endl;
+  if (write_traits) {
+    s << ";; " << traits.length() << " traits: ";
+    bool first = true;
+    for (index_type k = 0; k < traits.length(); k++) {
+      const ScheduleTrait* t =
+ (const ScheduleTrait*)traits[k]->cast_to("ScheduleTrait");
+      if (t) {
+ if (!first) s << ", ";
+ first = false;
+ t->write_short(s);
+      }
+    }
+  }
+  s << std::endl;
+}
+void Schedule::write_step_set(::std::ostream& s, const index_set& set) const
+{
+  for (index_type k = 0; k < set.length(); k++) {
+    if (k > 0) s << ", ";
+    s << "[" << steps[set[k]].at << " (#" << set[k] << ")] "
+      << instance.actions[steps[set[k]].act].name;
+  }
+}
+void Schedule::write_steps(::std::ostream& s) const
+{
+  index_set all;
+  all.fill(n_steps());
+  write_step_set(s, all);
+}
+hsps::rational Schedule::next_start_time(hsps::rational t) const
+{
+  hsps::rational next_t = POS_INF;
+  for (index_type k = 0; k < steps.length(); k++) {
+    hsps::rational d = steps[k].at - t;
+    if ((d > 0) && (d < (next_t - t))) next_t = steps[k].at;
+  }
+  return next_t;
+}
+hsps::rational Schedule::next_finish_time(hsps::rational t) const
+{
+  hsps::rational next_t = POS_INF;
+  for (index_type k = 0; k < steps.length(); k++) {
+    hsps::rational f = (steps[k].at + instance.actions[steps[k].act].dur);
+    if ((f > t) && (f < next_t)) next_t = f;
+  }
+  return next_t;
+}
+hsps::rational Schedule::last_finish_time() const
+{
+  hsps::rational next_t = 0;
+  for (index_type k = 0; k < steps.length(); k++) {
+    hsps::rational f = (steps[k].at + instance.actions[steps[k].act].dur);
+    if (f > next_t) next_t = f;
+  }
+  return next_t;
+}
+double Schedule::GANTT_UNIT_WIDTH = 1;
+double Schedule::GANTT_UNIT_HEIGHT = 1;
+double Schedule::GANTT_TEXT_XOFF = 0;
+double Schedule::GANTT_TEXT_YOFF = 0;
+hsps::rational Schedule::GANTT_TIME_MARK_INTERVAL = 100;
+bool Schedule::GANTT_ACTION_NAMES_ON_CHART = true;
+void Schedule::writeGantt(::std::ostream& s) const
+{
+  double pic_width = makespan().decimal();
+  double pic_height = (n_tracks + 2);
+  s << "\\newcommand{\\ganttunitwidth}{" << GANTT_UNIT_WIDTH << "}"
+    << ::std::endl;
+  s << "\\newcommand{\\ganttunitheight}{" << GANTT_UNIT_HEIGHT << "}"
+    << ::std::endl;
+  s << "\\newcommand{\\gantttextxoff}{" << GANTT_TEXT_XOFF << "}"
+    << ::std::endl;
+  s << "\\newcommand{\\gantttextyoff}{" << GANTT_TEXT_YOFF << "}"
+    << ::std::endl;
+  s << "\\newcount\\x" << ::std::endl;
+  s << "\\newcount\\y" << ::std::endl;
+  s << "\\begin{picture}("
+    << pic_width << "\\ganttunitwidth,"
+    << pic_height << "\\ganttunitheight)(0,0)"
+    << ::std::endl;
+  for (index_type k = 0; k < steps.length(); k++) {
+    Instance::Action& a = instance.actions[steps[k].act];
+    s << "%% [" << steps[k].at << "," << steps[k].at + a.dur
+      << "] " << a.name << " on track " << steps[k].track << ::std::endl;
+    double x0 = steps[k].at.decimal();
+    double x1 = (steps[k].at+a.dur).decimal();
+    double y0 = (steps[k].track + 1);
+    double y1 = (steps[k].track + 2);
+    s << "\\path(" << x0 << "\\ganttunitwidth," << y0
+      << "\\ganttunitheight)(" << x0 << "\\ganttunitwidth," << y1
+      << "\\ganttunitheight)(" << x1 << "\\ganttunitwidth," << y1
+      << "\\ganttunitheight)(" << x1 << "\\ganttunitwidth," << y0
+      << "\\ganttunitheight)(" << x0 << "\\ganttunitwidth," << y0
+      << "\\ganttunitheight)" << ::std::endl;
+    s << "\\x=" << x0 << "\\ganttunitwidth" << ::std::endl;
+    s << "\\advance\\x by \\gantttextxoff" << ::std::endl;
+    s << "\\y=" << y0 << "\\ganttunitheight" << ::std::endl;
+    s << "\\advance\\y by \\gantttextyoff" << ::std::endl;
+    if (GANTT_ACTION_NAMES_ON_CHART) {
+      s << "\\put(\\x,\\y){\\makebox(0,0)[lb]{\\smash{{\\footnotesize{\\tt ";
+      a.name->write(s, Name::NC_LATEX);
+      s << "}}}}}" << ::std::endl;
+    }
+    else {
+      s << "\\put(\\x,\\y){\\makebox(0,0)[lb]{\\smash{{\\footnotesize{\\tt "
+ << a.index << "}}}}}" << ::std::endl;
+    }
+  }
+  s << "\\end{picture}" << ::std::endl;
+  if (!GANTT_ACTION_NAMES_ON_CHART) {
+    s << ::std::endl << "{\\small\\begin{tabular}{|l|l|}"
+      << ::std::endl << "\\hline"
+      << ::std::endl << "\\multicolumn{2}{|c|}{Actions}\\\\"
+      << ::std::endl << "\\hline"
+      << ::std::endl;
+    for (index_type k = 0; k < action_set.length(); k++) {
+      s << "\\#" << action_set[k] << " & ";
+      instance.actions[action_set[k]].name->write(s, Name::NC_LATEX);
+      s << "\\\\" << ::std::endl << "\\hline" << ::std::endl;
+    }
+    s << "\\end{tabular}}" << ::std::endl;
+  }
+}
+void Schedule::assign_tracks()
+{
+  for (index_type k = 0; k < steps.length(); k++)
+    steps[k].track = no_such_index;
+  n_tracks = 0;
+  bool_vec occ(false, 0);
+  amt_vec occ_to;
+  hsps::rational t = 0;
+  while ((t).finite()) {
+    for (index_type k = 0; k < steps.length(); k++) if (steps[k].at == t) {
+      index_type p = occ.first(false);
+      if (p == no_such_index) {
+ occ.append(false);
+ p = occ.length() - 1;
+      }
+      occ[p] = true;
+      occ_to[p] = t + instance.actions[steps[k].act].dur;
+      steps[k].track = p;
+      if (p >= n_tracks) n_tracks = p + 1;
+    }
+    t = next_start_time(t);
+    for (index_type i = 0; i < occ.length(); i++) if (occ[i]) {
+      if (occ_to[i] <= t) occ[i] = false;
+    }
+  }
+}
+void Schedule::writeXML
+(::std::ostream& s, ExecErrorSet* errors, ExecTrace* trace, graph* prec,
+ index_type id) const
+{
+  s << "<schedule xmlns=\"http://dummy.net/pddlcat/schedule\" id=\""
+    << id << "\"";
+  if (plan_name()) {
+    s << " name=\"";
+    plan_name()->write(s, Name::NC_XML);
+    s << "\"";
+  }
+  s << " makespan=\"" << makespan() << "\">" << ::std::endl;
+  if (prec) {
+    if (prec->size() != steps.length()) {
+      ::std::cerr << "error in Schedule::writeXML: size of precedence graph "
+  << *prec << " does not match number of steps "
+  << steps.length() << ::std::endl;
+      exit(255);
+    }
+  }
+  s << "<actions>" << ::std::endl;
+  for (index_type k = 0; k < action_set.length(); k++) {
+    s << "<action id=\"" << action_set[k] << "\" name=\"";
+    instance.actions[action_set[k]].name->write(s, Name::NC_XML);
+    s << "\" duration=\"" << instance.actions[action_set[k]].dur
+      << "\">" << ::std::endl;
+    s << "<dump><![CDATA[" << ::std::endl;
+    instance.print_action(s, instance.actions[action_set[k]]);
+    s << "]]></dump>" << ::std::endl;
+    for (index_type i = 0; i < steps.length(); i++) {
+      if (steps[i].act == action_set[k]) {
+ s << "<link step=\"" << i << "\" type=\"occurs\"/>" << ::std::endl;
+      }
+    }
+    for (index_type i = 0; i < instance.n_resources(); i++) {
+      if (instance.actions[action_set[k]].use[i] > 0) {
+ s << "<link resource=\"" << i << "\" type=\"use\" amount=\""
+   << instance.actions[action_set[k]].use[i] << "\"/>" << ::std::endl;
+      }
+      if (instance.actions[action_set[k]].cons[i] > 0) {
+ s << "<link resource=\"" << i << "\" type=\"consume\" amount=\""
+   << instance.actions[action_set[k]].cons[i] << "\"/>" << ::std::endl;
+      }
+    }
+    s << "</action>" << ::std::endl;
+  }
+  s << "</actions>" << ::std::endl;
+  s << "<steps maxtrack=\"" << n_tracks - 1 << "\">" << ::std::endl;
+  for (index_type k = 0; k < steps.length(); k++) {
+    s << "<step id=\"" << k << "\" action=\"" << steps[k].act
+      << "\" start=\"" << std::resetiosflags(std::ios::scientific) << ((steps[k].at).decimal())
+      << "\" finish=\""
+      << std::resetiosflags(std::ios::scientific) << ((steps[k].at + instance.actions[steps[k].act].dur).decimal())
+      << "\" track=\"" << steps[k].track
+      << "\">" << ::std::endl;
+    for (index_type r = 0; r < instance.n_resources(); r++) {
+      if (instance.actions[steps[k].act].use[r] > 0) {
+ s << "<link resource=\"" << r << "\" type=\"use\" amount=\""
+   << instance.actions[steps[k].act].use[r] << "\"/>" << ::std::endl;
+      }
+      if (instance.actions[steps[k].act].cons[r] > 0) {
+ s << "<link resource=\"" << r << "\" type=\"consume\" amount=\""
+   << instance.actions[steps[k].act].cons[r] << "\"/>" << ::std::endl;
+      }
+    }
+    if (prec) {
+      for (index_type i = 0; i < steps.length(); i++)
+ if (prec->adjacent(k, i)) {
+   s << "<link step=\"" << i << "\" type=\"prec\"/>" << ::std::endl;
+ }
+    }
+    s << "</step>" << ::std::endl;
+  }
+  s << "</steps>" << ::std::endl;
+  if (errors) {
+    s << "<errors>" << ::std::endl;
+    for (index_type k = 0; k < errors->length(); k++) {
+      s << "<error id=\"error" << k << "\" type=\""
+ << ExecError::error_type_string((*errors)[k]->type_of_error())
+ << "\" severity=\""
+ << ExecError::error_severity_string((*errors)[k]->severity_of_error())
+ << "\" time=\"" << std::resetiosflags(std::ios::scientific) << (((*errors)[k]->time_of_error()).decimal())
+ << "\"";
+      if ((*errors)[k]->step_of_error() != no_such_index) {
+ s << " step=\"" << (*errors)[k]->step_of_error() << "\"";
+      }
+      s << ">" << ::std::endl;
+      s << "<dump><![CDATA[" << ::std::endl;
+      (*errors)[k]->write(s);
+      s << "]]></dump>" << ::std::endl;
+      if ((*errors)[k]->type_of_error() == ExecError::error_resource_conflict) {
+ ResourceConflictError* rce = (ResourceConflictError*)(*errors)[k];
+ s << "<link resource=\"" << rce->resource().index << "\"/>";
+ for (index_type i = 0; i < rce->conflict_actions().length(); i++) {
+   s << "<link action=\"" << rce->conflict_actions()[i] << "\"/>";
+ }
+ for (index_type i = 0; i < rce->conflict_steps().length(); i++) {
+   s << "<link step=\"" << rce->conflict_steps()[i] << "\"/>";
+ }
+      }
+      else if ((*errors)[k]->step_of_error() != no_such_index) {
+ s << "<link step=\"" << (*errors)[k]->step_of_error() << "\"/>";
+      }
+      s << "</error>" << ::std::endl;
+    }
+    s << "</errors>" << ::std::endl;
+  }
+  if (trace) {
+    s << "<resources>" << ::std::endl;
+    for (index_type k = 0; k < instance.n_resources(); k++) {
+      ResourceProfile* p = new ResourceProfile(instance, k, *trace);
+      p->set_makespan(makespan());
+      s << "<resource id=\"" << k << "\" name=\"";
+      instance.resources[k].name->write(s, Name::NC_XML);
+      s << "\" initial-capacity=\"" << std::resetiosflags(std::ios::scientific) << ((instance.resources[k].init).decimal())
+ << "\" peak-use=\"" << std::resetiosflags(std::ios::scientific) << ((p->peak_use()).decimal())
+ << "\" peak-use-percent=\""
+ << std::resetiosflags(std::ios::scientific) << (((p->peak_use() * 100) / instance.resources[k].init).decimal())
+ << "\" min-free=\"" << std::resetiosflags(std::ios::scientific) << ((p->min_free()).decimal())
+ << "\" tolerable-loss=\"" << std::resetiosflags(std::ios::scientific) << ((p->tolerable_unexpected_loss()).decimal())
+ << "\">" << ::std::endl;
+      s << "<dump><![CDATA[" << ::std::endl;
+      instance.print_resource(s, instance.resources[k]);
+      s << "]]></dump>" << ::std::endl;
+      s << "<profile name=\"available\">" << ::std::endl;
+      for (index_type i = 0; i < p->n_intervals(); i++) {
+ s << "<interval start=\"" << std::resetiosflags(std::ios::scientific) << ((p->interval_start_time(i)).decimal())
+   << "\" end=\"" << std::resetiosflags(std::ios::scientific) << ((p->interval_end_time(i)).decimal())
+   << "\" amount=\"" << std::resetiosflags(std::ios::scientific) << ((p->amount_available(i)).decimal())
+   << "\"/>" << ::std::endl;
+      }
+      s << "</profile>" << ::std::endl;
+      s << "<profile name=\"in_use\">" << ::std::endl;
+      for (index_type i = 0; i < p->n_intervals(); i++) {
+ s << "<interval start=\"" << std::resetiosflags(std::ios::scientific) << ((p->interval_start_time(i)).decimal())
+   << "\" end=\"" << std::resetiosflags(std::ios::scientific) << ((p->interval_end_time(i)).decimal())
+   << "\" amount=\"" << std::resetiosflags(std::ios::scientific) << ((p->amount_in_use(i)).decimal())
+   << "\"/>" << ::std::endl;
+      }
+      s << "</profile>" << ::std::endl;
+      s << "<profile name=\"free\">" << ::std::endl;
+      for (index_type i = 0; i < p->n_intervals(); i++) {
+ s << "<interval start=\"" << std::resetiosflags(std::ios::scientific) << ((p->interval_start_time(i)).decimal())
+   << "\" end=\"" << std::resetiosflags(std::ios::scientific) << ((p->interval_end_time(i)).decimal())
+   << "\" amount=\"" << std::resetiosflags(std::ios::scientific) << ((p->amount_free(i)).decimal())
+   << "\"/>" << ::std::endl;
+      }
+      s << "</profile>" << ::std::endl;
+      for (index_type i = 0; i < action_set.length(); i++) {
+ if (instance.actions[action_set[i]].use[k] > 0) {
+   s << "<link action=\"" << i << "\" type=\"use\" amount=\""
+     << instance.actions[action_set[i]].use[k] << "\"/>" << ::std::endl;
+ }
+ if (instance.actions[action_set[i]].cons[k] > 0) {
+   s << "<link action=\"" << i << "\" type=\"consume\" amount=\""
+     << instance.actions[action_set[i]].cons[k] << "\"/>" << ::std::endl;
+ }
+      }
+      for (index_type i = 0; i < steps.length(); i++) {
+ if (instance.actions[steps[i].act].use[k] > 0) {
+   s << "<link step=\"" << i << "\" type=\"use\" amount=\""
+     << instance.actions[steps[i].act].use[k] << "\"/>" << ::std::endl;
+ }
+ if (instance.actions[steps[i].act].cons[k] > 0) {
+   s << "<link step=\"" << i << "\" type=\"consume\" amount=\""
+     << instance.actions[steps[i].act].cons[k] << "\"/>" << ::std::endl;
+ }
+      }
+      s << "</resource>" << ::std::endl;
+    }
+    s << "</resources>" << ::std::endl;
+  }
+  s << "<traits>" << ::std::endl;
+  for (index_type k = 0; k < traits.length(); k++) {
+    const ScheduleTrait* t =
+      (const ScheduleTrait*)traits[k]->cast_to("ScheduleTrait");
+    if (t) {
+      t->writeXML(s);
+    }
+  }
+  s << "</traits>" << ::std::endl;
+  s << "</schedule>" << ::std::endl;
+}
+bool Schedule::simulate
+(ExecTrace* trace, ExecErrorSet* errors, bool finish) const
+{
+  if (trace_level > 0) {
+    ::std::cerr << "simulating (high resolution)..." << ::std::endl;
+  }
+  ExecState cs(instance, instance.init_atoms);
+  cs.set_trace_level(trace_level - 1);
+  if (trace) {
+    trace->append((ExecState*)cs.copy());
+  }
+  hsps::rational t = 0;
+  bool_vec done(false, steps.length());
+  bool executable = true;
+  while (t < POS_INF) {
+    bool any_starting = false;
+    for (index_type k = 0; k < steps.length(); k++)
+      if ((steps[k].at == t) && !done[k]) {
+ Instance::Action& act = instance.actions[steps[k].act];
+ if (!cs.applicable(act, errors, k)) {
+   if (trace_level > 0) {
+     ::std::cerr << steps[k].at << ": " << act.name << " NOT applicable"
+   << ::std::endl;
+   }
+   executable = false;
+   if (!finish) return false;
+ }
+ cs.apply(act, errors, k);
+ done[k] = true;
+ any_starting = true;
+      }
+    if (any_starting && trace) {
+      trace->clip_last_state(cs.current_time());
+      trace->append((ExecState*)cs.copy());
+    }
+    if (trace_level > 2) {
+      cs.write(::std::cerr);
+    }
+    if (cs.min_delta() == 0) {
+      std::cerr << "warning: zero duration state at " << t
+  << " in Schedule::simulate" << std::endl;
+    }
+    hsps::rational next_t = hsps::rational::min(t + cs.min_delta(),next_start_time(t));
+    if (next_t == t) {
+      std::cerr << "warning: empty interval at " << t
+  << " in Schedule::simulate (min delta = "
+  << cs.min_delta() << ", next start = "
+  << next_start_time(t) << ")"
+  << std::endl;
+    }
+    if (trace_level > 2) {
+      ::std::cerr << "at " << t << ": " << ::std::endl << cs;
+      ::std::cerr << "next_t = min(" << t + cs.min_delta()
+    << ", " << next_start_time(t) << ") = " << next_t
+    << ::std::endl;
+    }
+    if ((next_t).finite()) {
+      cs.advance(next_t - t, errors);
+      if (trace) {
+ trace->clip_last_state(cs.current_time());
+ trace->append((ExecState*)cs.copy());
+      }
+    }
+    else {
+      assert(cs.n_current_actions() == 0);
+    }
+    t = next_t;
+  }
+  bool accept = cs.is_final(errors);
+  if (trace_level > 0) {
+    if (accept) ::std::cerr << "goals achieved" << ::std::endl;
+    else ::std::cerr << "goals NOT achieved" << ::std::endl;
+  }
+  return (executable && accept);
+}
+bool Schedule::simulate_low_resolution
+(ExecTrace* trace, ExecErrorSet* errors, bool finish) const
+{
+  if (trace_level > 0) {
+    ::std::cerr << "simulating (low resolution)..." << ::std::endl;
+  }
+  ExecState cs(instance, instance.init_atoms);
+  cs.set_trace_level(trace_level - 1);
+  if (trace) {
+    trace->append((ExecState*)cs.copy());
+  }
+  if (trace_level > 1) {
+    cs.write(::std::cerr);
+  }
+  hsps::rational t = 0;
+  bool executable = true;
+  for (index_type k = 0; k < steps.length(); k++) {
+    hsps::rational dt = steps[k].at - t;
+    Instance::Action& act = instance.actions[steps[k].act];
+    if (dt > 0) cs.advance(dt, errors);
+    if (!cs.applicable(act, errors, k)) {
+      if (trace_level > 0) {
+ ::std::cerr << steps[k].at << ": " << act.name << " NOT applicable"
+    << ::std::endl;
+      }
+      executable = false;
+      if (!finish) return false;
+    }
+    cs.apply(act, errors, k);
+    if (trace) {
+      trace->clip_last_state(cs.current_time());
+      trace->append((ExecState*)cs.copy());
+    }
+    t = steps[k].at;
+  }
+  cs.finish(errors);
+  if (trace) {
+    trace->clip_last_state(cs.current_time());
+    trace->append((ExecState*)cs.copy());
+  }
+  if (trace_level > 1) {
+    cs.write(::std::cerr);
+  }
+  bool accept = cs.is_final(errors);
+  if (trace_level > 0) {
+    if (accept) ::std::cerr << "goals achieved" << ::std::endl;
+    else ::std::cerr << "goals NOT achieved" << ::std::endl;
+  }
+  return (executable && accept);
+}
+bool Schedule::simulate(index_set& achieved, ExecErrorSet* errors) const
+{
+  ExecTrace* trace = new ExecTrace(instance);
+  bool own_errors = false;
+  if (errors == 0) {
+    errors = new ExecErrorSet();
+    own_errors = true;
+  }
+  simulate(trace, errors);
+  bool ok = errors->executable();
+  achieved.clear();
+  if (ok) {
+    assert(trace->length() > 0);
+    index_type l = trace->length() - 1;
+    (*trace)[l]->current_atoms(achieved);
+  }
+  delete trace;
+  if (own_errors) delete errors;
+  return ok;
+}
+bool Schedule::simulate(amt_vec& rtl) const
+{
+  ExecTrace* trace = new ExecTrace(instance);
+  bool ok = simulate(trace);
+  if (ok) {
+    for (index_type k = 0; k < instance.n_resources(); k++) {
+      ResourceProfile* p = new ResourceProfile(instance, k, *trace);
+      rtl[k] = p->tolerable_unexpected_loss();
+      delete p;
+    }
+  }
+  delete trace;
+  return ok;
+}
+void Schedule::deorder(graph& prec) const
+{
+  prec.init(steps.length());
+  for (index_type i = 0; i < steps.length(); i++)
+    for (index_type j = 0; j < steps.length(); j++)
+      if ((steps[i].at + instance.actions[steps[i].act].dur) <= steps[j].at)
+ if (!instance.commutative(steps[i].act, steps[j].act) ||
+     !instance.lock_compatible(steps[i].act, steps[j].act))
+   prec.add_edge(i, j);
+}
+void Schedule::base_precedence_graph(graph& prec) const
+{
+  prec.init(steps.length());
+  for (index_type i = 0; i < steps.length(); i++)
+    for (index_type j = 0; j < steps.length(); j++)
+      if ((steps[i].at + instance.actions[steps[i].act].dur) <= steps[j].at)
+ prec.add_edge(i, j);
+}
+void Schedule::deorder(weighted_graph& prec) const
+{
+  prec.init(steps.length());
+  for (index_type i = 0; i < steps.length(); i++)
+    for (index_type j = 0; j < steps.length(); j++)
+      if ((steps[i].at + instance.actions[steps[i].act].dur) <= steps[j].at)
+ if (!instance.commutative(steps[i].act, steps[j].act) ||
+     !instance.lock_compatible(steps[i].act, steps[j].act))
+   prec.add_edge(i, j, instance.actions[steps[i].act].dur);
+}
+bool Schedule::schedule
+(const index_vec& acts, const graph& prec, index_vec* sindex)
+{
+  assert(prec.size() == acts.length());
+  graph p(prec);
+  index_set r;
+  index_vec s;
+  for (index_type k = 0; k < p.size(); k++)
+    if (p.in_degree(k) == 0) r.insert(k);
+  amt_vec f(0, instance.n_resources());
+  for (index_type k = 0; k < instance.n_resources(); k++)
+    f[k] = instance.resources[k].init;
+  clear();
+  while (s.length() < acts.length()) {
+    index_type n = no_such_index;
+    for (index_type k = 0; (k < r.length()) && (n == no_such_index); k++) {
+      bool can_go = true;
+      for (index_type i = 0; (i < instance.n_resources()) && can_go; i++)
+ if (f[i] < instance.actions[acts[r[k]]].req(i)) {
+   can_go = false;
+ }
+      if (can_go) n = r[k];
+    }
+    if (n != no_such_index) {
+      insert(n);
+      for (index_type i = 0; i < instance.n_resources(); i++)
+ f[i] -= instance.actions[acts[n]].req(i);
+      r.subtract(n);
+      s.append(n);
+    }
+    else {
+      hsps::rational eft = POS_INF;
+      index_set e;
+      for (index_type k = 0; k < steps.length(); k++) {
+ hsps::rational sft = steps[k].at + instance.actions[acts[steps[k].act]].dur;
+ if (sft > current_t) {
+   if (sft < eft) {
+     eft = sft;
+     e.assign_singleton(steps[k].act);
+   }
+   else if (sft == eft) {
+     e.insert(steps[k].act);
+   }
+ }
+      }
+      if ((eft).infinite()) {
+ if (trace_level > 1) {
+   ::std::cerr << "error: failed to schedule";
+   for (index_type k = 0; k < acts.length(); k++)
+     ::std::cerr << " " << k << ":" << instance.actions[acts[k]].name;
+   ::std::cerr << " with precedence graph " << prec
+      << ::std::endl;
+   for (index_type k = 0; k < steps.length(); k++) {
+     assert(steps[k].act < acts.length());
+     steps[k].act = acts[steps[k].act];
+   }
+   ::std::cerr << "current schedule:" << ::std::endl;
+   write(::std::cerr);
+   ::std::cerr << "current time = " << current_t << ::std::endl;
+   ::std::cerr << "ready set = ";
+   instance.write_action_set(::std::cerr, r);
+   ::std::cerr << ::std::endl;
+   ::std::cerr << "free resources:" << ::std::endl;
+   for (index_type i = 0; i < instance.n_resources(); i++) {
+     ::std::cerr << " " << instance.resources[i].name << " = "
+        << f[i] << ::std::endl;
+   }
+ }
+ return false;
+      }
+      else if (eft == current_t) {
+ std::cerr << "warning: empty interval at " << current_t
+    << " in Schedule::schedule" << std::endl;
+      }
+      for (index_type k = 0; k < e.length(); k++) {
+  for (index_type i = 0; i < p.size(); i++) {
+    p.remove_edge(e[k], i);
+    if ((p.in_degree(i) == 0) && !s.contains(i))
+      r.insert(i);
+  }
+ for (index_type i = 0; i < instance.n_resources(); i++)
+   f[i] += instance.actions[acts[e[k]]].use[i];
+      }
+      assert((eft - current_t) > 0);
+      advance(eft - current_t);
+    }
+  }
+  for (index_type k = 0; k < steps.length(); k++) {
+    assert(steps[k].act < acts.length());
+    steps[k].act = acts[steps[k].act];
+  }
+  end();
+  if (sindex) {
+    mapping::invert_map(s, *sindex);
+  }
+  return true;
+}
+bool Schedule::construct_conflict_free
+(const index_vec& acts,
+ const graph& prec,
+ index_set& cs,
+ index_vec& map)
+{
+  assert(prec.size() == acts.length());
+  lvector<s_status> s(s_pending, acts.length());
+  for (index_type k = 0; k < acts.length(); k++)
+    if (prec.in_degree(k) == 0) s[k] = s_ready;
+  amt_vec f(0, instance.n_resources());
+  for (index_type k = 0; k < instance.n_resources(); k++)
+    f[k] = instance.resources[k].init;
+  index_vec e;
+  clear();
+  cs.clear();
+  mapping::identity_map(acts.length(), map);
+  while (s.contains(s_pending) || s.contains(s_ready)) {
+    index_type next = s.first(s_ready);
+    if (next != no_such_index) {
+      for (index_type k = 0; k < instance.n_resources(); k++)
+ if (f[k] < instance.actions[acts[next]].req(k)) {
+   for (index_type i = 0; i < acts.length(); i++) {
+     if ((s[i] == s_executing) &&
+  (instance.actions[acts[i]].req(k) > 0))
+       cs.insert(i);
+     if ((s[i] == s_ready) &&
+  (instance.actions[acts[i]].req(k) > 0))
+       cs.insert(i);
+   }
+   return false;
+ }
+      insert(next);
+      s[next] = s_executing;
+      for (index_type k = 0; k < instance.n_resources(); k++)
+ f[k] -= instance.actions[acts[next]].req(k);
+      map[next] = steps.length() - 1;
+    }
+    else {
+      hsps::rational eft = POS_INF;
+      for (index_type k = 0; k < steps.length(); k++) {
+ if (s[steps[k].act] == s_executing) {
+   hsps::rational sft = steps[k].at + instance.actions[acts[steps[k].act]].dur;
+   if (sft >= current_t) {
+     if (sft < eft) {
+       eft = sft;
+       e.assign_value(steps[k].act, 1);
+     }
+     else if (sft == eft) {
+       e.append(steps[k].act);
+     }
+   }
+ }
+      }
+      if ((eft).infinite()) {
+ std::cerr << "ERROR! CYCLIC PRECEDENCE GRAPH!" << std::endl;
+ assert(!prec.acyclic());
+ return false;
+      }
+      if (eft == current_t) {
+ std::cerr << "warning: empty interval at " << current_t
+    << " in Schedule::construct" << std::endl;
+      }
+      for (index_type k = 0; k < e.length(); k++) {
+ s[e[k]] = s_finished;
+ for (index_type i = 0; i < instance.n_resources(); i++)
+   f[i] += instance.actions[acts[e[k]]].use[i];
+      }
+      for (index_type k = 0; k < acts.length(); k++)
+ if (s[k] == s_pending) {
+   bool now_ready = true;
+   for (index_type i = 0;
+        (i < prec.predecessors(k).length()) && now_ready; i++)
+     if (s[prec.predecessors(k)[i]] != s_finished)
+       now_ready = false;
+   if (now_ready)
+     s[k] = s_ready;
+ }
+      assert((eft - current_t) > 0);
+      advance(eft - current_t);
+    }
+  }
+  for (index_type k = 0; k < steps.length(); k++) {
+    assert(steps[k].act < acts.length());
+    steps[k].act = acts[steps[k].act];
+  }
+  end();
+  return true;
+}
+bool Schedule::construct_minimal_makespan
+(const index_vec& acts,
+ graph& prec,
+ const index_set& c,
+ hsps::rational& best,
+ index_vec& sindex)
+{
+  if (c.length() < 2) return false;
+  bool ok = false;
+  for (index_type i = 0; i < c.length(); i++)
+    for (index_type j = 0; j < c.length(); j++) if (i != j) {
+      assert(!prec.adjacent(c[j], c[i]));
+      pair_set e;
+      prec.add_edge_to_transitive_closure(c[i], c[j], e);
+      Schedule* s1 = new Schedule(instance);
+      index_set c1;
+      index_vec x1;
+      bool ok1 = s1->construct_conflict_free(acts, prec, c1, x1);
+      if (ok1) {
+ assert(c1.empty());
+ if (s1->makespan() < best) {
+   clear();
+   s1->output(*this);
+   sindex.assign_copy(x1);
+   best = makespan();
+ }
+      }
+      else {
+ ok1 = construct_minimal_makespan(acts, prec, c1, best, sindex);
+      }
+      if (ok1) ok = true;
+      prec.remove_edges(e);
+      delete s1;
+    }
+  return ok;
+}
+bool Schedule::construct_minimal_makespan
+(const index_vec& acts, const graph& prec, index_vec& sindex)
+{
+  index_set c;
+  bool ok = construct_conflict_free(acts, prec, c, sindex);
+  if (ok) {
+    assert(c.empty());
+    return true;
+  }
+  graph p(prec);
+  p.transitive_closure();
+  hsps::rational b = POS_INF;
+  return construct_minimal_makespan(acts, p, c, b, sindex);
+}
+bool Schedule::equivalent(const Schedule& s, index_vec* c) const
+{
+  graph p;
+  deorder(p);
+  assert(p.acyclic());
+  p.transitive_closure();
+  graph q;
+  s.deorder(q);
+  assert(q.acyclic());
+  q.transitive_closure();
+  if (trace_level > 1) {
+    ::std::cerr << "comparing plans (" << step_actions() << "," << p
+       << ") and (" << s.step_actions() << "," << q << ")..."
+       << ::std::endl;
+  }
+  CorrespondanceEnumerator e(step_actions(), s.step_actions());
+  bool more = e.first();
+  if (!more) {
+    if (trace_level > 1) {
+      ::std::cerr << " - no correspondence" << ::std::endl;
+    }
+    return false;
+  }
+  while (more) {
+    if (trace_level > 1) {
+      ::std::cerr << " - correspondance: " << e.current() << ::std::endl;
+    }
+    if (p.equals(q, e.current())) {
+      if (trace_level > 1) {
+ ::std::cerr << " - match!" << ::std::endl;
+      }
+      if (c) {
+ c->assign_copy(e.current());
+      }
+      return true;
+    }
+    if (trace_level > 1) {
+      ::std::cerr << " - precedence graphs differ:" << ::std::endl;
+      pair_set d0;
+      pair_set d1;
+      p.difference(q, e.current(), d0, d1);
+      ::std::cerr << "  in first but not second: " << d0 << ::std::endl;
+      ::std::cerr << "  in second but not first: " << d1 << ::std::endl;
+      p.write_graph_correspondance(::std::cerr, q, e.current(), "Precedence Graph Difference");
+    }
+    more = e.next();
+  }
+  if (trace_level > 1) {
+    ::std::cerr << " - no match" << ::std::endl;
+  }
+  return false;
+}
+bool Schedule::random_sequence
+(index_type ln_max, index_type ln_avg, bool continue_from_goal,
+ ExecTrace* trace, RNG& rnd)
+{
+  if (trace_level > 0) {
+    ::std::cerr << "constructing random plan (max l = " << ln_max
+  << ", E[l] = " << ln_avg
+  << (continue_from_goal ? ", continuing from goal states" :
+      ", stopping at first goal state")
+  << ")..." << ::std::endl;
+  }
+  clear();
+  ExecState cs(instance, instance.init_atoms);
+  cs.set_trace_level(trace_level - 1);
+  if (trace_level > 1) {
+    cs.write(::std::cerr);
+  }
+  if (trace) {
+    trace->append((ExecState*)cs.copy());
+  }
+  bool_vec app(false, instance.n_actions());
+  index_set s_app;
+  hsps::rational dt = 0;
+  while (true) {
+    for (index_type k = 0; k < instance.n_actions(); k++)
+      app[k] = cs.applicable(instance.actions[k], 0, no_such_index);
+    app.copy_to(s_app);
+    if (s_app.empty()) {
+      if (trace_level > 0) {
+ ::std::cerr << "dead end reached (l = " << length()
+    << ", current state = " << cs << ")" << ::std::endl;
+      }
+      end();
+      return false;
+    }
+    index_type sel = rnd.random_in_range(s_app.length());
+    advance(dt);
+    insert(s_app[sel]);
+    cs.apply(instance.actions[s_app[sel]], 0, no_such_index);
+    cs.advance(instance.actions[s_app[sel]].dur, 0);
+    dt = instance.actions[s_app[sel]].dur;
+    if (trace_level > 1) {
+      cs.write(::std::cerr);
+    }
+    if (trace) {
+      trace->append((ExecState*)cs.copy());
+    }
+    if (cs.is_final() && !continue_from_goal) {
+      if (trace_level > 0) {
+ ::std::cerr << "goal state reached (l = " << length()
+    << ", current state = " << cs << ")" << ::std::endl;
+      }
+      end();
+      return true;
+    }
+    if (ln_avg != no_such_index) {
+      bool stop = (rnd.random_in_range(ln_avg) == 0);
+      if (stop) {
+ if (trace_level > 0) {
+   ::std::cerr << "stop (l = " << length() << ")" << ::std::endl;
+ }
+ end();
+ return false;
+      }
+    }
+    if (ln_max != no_such_index) {
+      if (length() >= ln_max) {
+ if (trace_level > 0) {
+   ::std::cerr << "maximum length reached" << ::std::endl;
+ }
+ end();
+ return false;
+      }
+    }
+  }
+}
+ScheduleSet::ScheduleSet(Instance& i)
+  : plan_vec(0, 0), instance(i), props(0, 0),
+    trace_level(Instance::default_trace_level)
+{
+}
+ScheduleSet::ScheduleSet(ScheduleSet& s, const bool_vec& sel)
+  : plan_vec(0, 0), instance(s.instance), props(0, 0),
+    trace_level(s.trace_level)
+{
+  s.output(*this, sel);
+}
+ScheduleSet::~ScheduleSet()
+{
+  clear();
+}
+bool ScheduleSet::ScheduleProperties::dominates(const ScheduleProperties& p)
+{
+  if (!valid && p.valid) return false;
+  if (p.makespan < makespan) return false;
+  assert(n_resources == p.n_resources);
+  for (index_type k = 0; k < n_resources; k++) {
+    if (p.total_consumption[k] < total_consumption[k]) return false;
+    if (p.peak_use[k] < peak_use[k]) return false;
+    if (p.tolerable_loss[k] > tolerable_loss[k]) return false;
+  }
+  return true;
+}
+ScheduleSet::ScheduleProperties* ScheduleSet::compute_properties(Schedule* s)
+{
+  ScheduleProperties* p = new ScheduleProperties(instance.n_resources());
+  p->trace = new ExecTrace(instance);
+  p->valid = s->simulate(p->trace, 0, true);
+  p->makespan = s->makespan();
+  for (index_type k = 0; k < instance.n_resources(); k++) {
+    ResourceProfile* rp = new ResourceProfile(instance, k, *(p->trace));
+    p->peak_use[k] = rp->peak_use();
+    p->total_consumption[k] = rp->total_consumption();
+    p->tolerable_loss[k] = rp->tolerable_unexpected_loss();
+    delete rp;
+  }
+  return p;
+}
+void ScheduleSet::cache_properties(index_type i, ScheduleProperties* p)
+{
+  assert(i < length());
+  if (i >= props.length()) props.set_length(i + 1);
+  if (p) {
+    if (props[i]) delete props[i];
+    props[i] = p;
+  }
+  else if (props[i] == 0) {
+    props[i] = compute_properties((*this)[i]);
+  }
+}
+bool ScheduleSet::dominated(const ScheduleProperties& p, prop_vec& pv)
+{
+  for (index_type k = 0; k < pv.length(); k++) {
+    if (pv[k]->dominates(p)) return true;
+  }
+  return false;
+}
+void ScheduleSet::dominated(prop_vec& pv, bool_vec& dom)
+{
+  dom.assign_value(false, pv.length());
+  for (index_type k = 0; k < pv.length(); k++)
+    for (index_type i = 0; (i < pv.length()) && !dom[k]; i++) if (k != i) {
+      if (pv[i]->dominates(*(pv[k])) && !dom[i]) dom[k] = true;
+    }
+}
+bool ScheduleSet::dominated(const ScheduleProperties& p)
+{
+  for (index_type k = 0; k < length(); k++) {
+    cache_properties(k, 0);
+    if (props[k]->dominates(p)) return true;
+  }
+  return false;
+}
+void ScheduleSet::replace_schedule_with_properties
+(index_type i, Schedule* s, ScheduleProperties* p)
+{
+  assert(i < length());
+  if ((*this)[i]) delete (*this)[i];
+  (*this)[i] = s;
+  cache_properties(i, p);
+}
+void ScheduleSet::add_schedule_with_properties
+(Schedule* s, ScheduleProperties* p)
+{
+  index_type i = length();
+  append(s);
+  cache_properties(i, p);
+}
+void ScheduleSet::add_schedule(Schedule* s)
+{
+  append(s);
+}
+void ScheduleSet::add_schedule_if_different(Schedule* s)
+{
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k]->equivalent(*s)) {
+      delete s;
+      return;
+    }
+  append(s);
+}
+void ScheduleSet::remove(bool_vec& set)
+{
+  for (index_type k = 0; k < length(); k++) if (set[k]) {
+    if ((*this)[k]) delete (*this)[k];
+    if (k < props.length())
+      if (props[k]) delete props[k];
+  }
+  plan_vec::remove(set);
+  props.remove(set);
+}
+void ScheduleSet::clear()
+{
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k]) delete (*this)[k];
+  set_length(0);
+  for (index_type k = 0; k < props.length(); k++)
+    if (props[k]) delete props[k];
+  props.set_length(0);
+}
+void ScheduleSet::set_trace_level(int level)
+{
+  trace_level = level;
+}
+void ScheduleSet::reduce_plans()
+{
+  bool_vec ok(true, length());
+  for (index_type k = 0; k < length(); k++) {
+    ExecErrorSet* errors = new ExecErrorSet();
+    errors->ignore_error_type(ExecError::error_resource_conflict);
+    errors->ignore_error_type(ExecError::error_resource_shortage);
+    (*this)[k]->simulate(0, errors, true);
+    if (errors->valid()) {
+      if (trace_level > 0) {
+ ExecErrorSet* warnings =
+   errors->all_of_severity(ExecError::severity_warning);
+ if (warnings->length() > 0) {
+   ::std::cerr << "plan #" << k;
+   if ((*this)[k]->plan_name())
+     ::std::cerr << " (" << (*this)[k]->plan_name() << ")";
+   ::std::cerr << ": " << warnings->length() << " warnings:";
+   warnings->write(::std::cerr);
+   ::std::cerr << ::std::endl;
+ }
+ delete warnings;
+      }
+      (*this)[k]->reduce(errors);
+    }
+    else {
+      ok[k] = false;
+      if (trace_level > 0) {
+ ::std::cerr << "plan #" << k;
+ if ((*this)[k]->plan_name())
+   ::std::cerr << " (" << (*this)[k]->plan_name() << ")";
+ ::std::cerr << " not logically valid: "
+    << errors->length() << " errors:";
+ errors->write(::std::cerr);
+ ::std::cerr << ::std::endl;
+      }
+    }
+    delete errors;
+  }
+  if (trace_level > 0) {
+    ::std::cerr << "removing " << ok.count(false) << " logically invalid plans"
+       << ::std::endl;
+  }
+  ok.complement();
+  remove(ok);
+}
+void ScheduleSet::filter_invalid_plans()
+{
+  bool_vec ok(true, length());
+  for (index_type k = 0; k < length(); k++) {
+    ok[k] = (*this)[k]->simulate_low_resolution();
+    if (!ok[k] && (trace_level > 0)) {
+      ::std::cerr << "plan #" << k;
+      if ((*this)[k]->plan_name())
+ ::std::cerr << (*this)[k]->plan_name();
+      ::std::cerr << " not valid" << ::std::endl;
+    }
+  }
+  if (trace_level > 0) {
+    ::std::cerr << "removing " << ok.count(false) << " invalid plans"
+       << ::std::endl;
+  }
+  ok.complement();
+  remove(ok);
+}
+void ScheduleSet::filter_unschedulable_plans()
+{
+  bool_vec ok(true, length());
+  for (index_type k = 0; k < length(); k++) {
+    if (trace_level > 1) {
+      ::std::cerr << "trying to reschedule plan #" << k;
+      if ((*this)[k]->plan_name())
+ ::std::cerr << " (" << (*this)[k]->plan_name() << ")";
+      ::std::cerr << "..." << ::std::endl;
+    }
+    graph p;
+    (*this)[k]->deorder(p);
+    ok[k] = feasible(instance, (*this)[k]->step_actions(), p, 0);
+    if (trace_level > 0) {
+      if (!ok[k]) {
+ ::std::cerr << "plan #" << k;
+ if ((*this)[k]->plan_name())
+   ::std::cerr << " (" << (*this)[k]->plan_name() << ")";
+ ::std::cerr << " can not be scheduled" << ::std::endl;
+      }
+    }
+  }
+  if (trace_level > 0) {
+    ::std::cerr << "removing " << ok.count(false) << " unschedulable plans"
+       << ::std::endl;
+  }
+  ok.complement();
+  remove(ok);
+}
+void ScheduleSet::filter_equivalent_plans()
+{
+  bool_vec n(true, length());
+  for (index_type k = 0; k < length(); k++) {
+    for (index_type i = 0; (i < k) && n[k]; i++) if (n[i]) {
+      index_vec c;
+      if ((*this)[k]->equivalent(*(*this)[i], &c)) {
+ n[k] = false;
+ if (trace_level > 0) {
+   ::std::cerr << "plan #" << k;
+   if ((*this)[k]->plan_name())
+     ::std::cerr << " (" << (*this)[k]->plan_name() << ")";
+   ::std::cerr << " is equivalent to plan #" << i;
+   if ((*this)[i]->plan_name())
+     ::std::cerr << " (" << (*this)[i]->plan_name() << ")";
+   ::std::cerr << ::std::endl;
+ }
+ delete (*this)[k];
+ (*this)[k] = 0;
+      }
+    }
+    if ((n[k]) && (trace_level > 0)) {
+      ::std::cerr << "plan #" << k;
+      if ((*this)[k]->plan_name())
+ ::std::cerr << " (" << (*this)[k]->plan_name() << ")";
+      ::std::cerr << " is new" << ::std::endl;
+    }
+  }
+  n.complement();
+  remove(n);
+}
+void ScheduleSet::add_distinguishing_traits_1()
+{
+  if (empty()) return;
+  index_set all_acts;
+  for (index_type k = 0; k < length(); k++)
+    all_acts.insert((*this)[k]->plan_actions());
+  for (index_type k = 0; k < all_acts.length(); k++) {
+    index_vec n_occ(0, length());
+    index_set d_occ;
+    for (index_type i = 0; i < length(); i++) {
+      n_occ[i] = (*this)[i]->step_actions().count(all_acts[k]);
+      d_occ.insert(n_occ[i]);
+    }
+    if (d_occ.length() > 1) {
+      for (index_type i = 0; i < length(); i++) {
+ PlanActionOccurs* ao_trait =
+   new PlanActionOccurs((*this)[i], instance, all_acts[k], n_occ[i]);
+ if (n_occ[i] == d_occ[0]) ao_trait->set_min();
+ if (n_occ[i] == d_occ[d_occ.length() - 1]) ao_trait->set_max();
+ if (n_occ.count(n_occ[i]) == 1) ao_trait->set_unique();
+ (*this)[i]->add_trait(ao_trait);
+      }
+    }
+  }
+  for (index_type i = 0; i < length(); i++)
+    for (index_type j = i + 1; j < length(); j++) {
+      CorrespondanceEnumerator e((*this)[i]->step_actions(),
+     (*this)[j]->step_actions());
+      bool more = e.first();
+      if (more) {
+ graph pi;
+ (*this)[i]->base_precedence_graph(pi);
+ pi.transitive_closure();
+ graph pj;
+ (*this)[j]->base_precedence_graph(pj);
+ pj.transitive_closure();
+ pair_set ei;
+ pair_set ej;
+ pi.difference(pj, e.current(), ei, ej);
+ for (index_type k = 0; k < ej.length(); k++) {
+   if (!pj.adjacent(ej[k].first, ej[k].second)) {
+     std::cerr << "error: identified ordering " << ej[k].first
+        << " < " << ej[k].second << " does not hold!"
+        << std::endl;
+     std::cerr << "pi = " << pi << std::endl;
+     std::cerr << "pj = " << pj << std::endl;
+     exit(255);
+   }
+ }
+ more = e.next();
+ while (more) {
+   pair_set d0;
+   pair_set d1;
+   pi.difference(pj, e.current(), d0, d1);
+   ei.intersect(d0);
+   ej.intersect(d1);
+   more = e.next();
+ }
+ for (index_type k = 0; k < ei.length(); k++) {
+   if (trace_level > 1) {
+     std::cerr << "comparing plan #" << i << " and plan #" << j
+        << ": step #" << ei[k].first
+        << " before step #" << ei[k].second
+        << " is specific to plan #" << i << std::endl;
+   }
+   bool found = false;
+   for (index_type l=0; (l<(*this)[i]->traits.length())&&!found; l++) {
+     PlanStepOrder* pso_trait =
+       (PlanStepOrder*)(*this)[i]->traits[l]->cast_to("PlanStepOrder");
+     if (pso_trait) {
+       if (pso_trait->precedence() == ei[k]) found = true;
+     }
+   }
+   if (!found) {
+     PlanStepOrder* new_pso_trait =
+       new PlanStepOrder((*this)[i], instance, ei[k]);
+     (*this)[i]->add_trait(new_pso_trait);
+   }
+ }
+ for (index_type k = 0; k < ej.length(); k++) {
+   if (trace_level > 1) {
+     std::cerr << "comparing plan #" << i << " and plan #" << j
+        << ": step #" << ej[k].first
+        << " before step #" << ej[k].second
+        << " is specific to plan #" << j << std::endl;
+   }
+   bool found = false;
+   for (index_type l=0; (l<(*this)[j]->traits.length())&&!found; l++) {
+     PlanStepOrder* pso_trait =
+       (PlanStepOrder*)(*this)[j]->traits[l]->cast_to("PlanStepOrder");
+     if (pso_trait) {
+       if (pso_trait->precedence() == ej[k]) found = true;
+     }
+   }
+   if (!found) {
+     PlanStepOrder* new_pso_trait =
+       new PlanStepOrder((*this)[j], instance, ej[k]);
+     (*this)[j]->add_trait(new_pso_trait);
+   }
+ }
+      }
+    }
+}
+void ScheduleSet::add_distinguishing_traits_2()
+{
+  if (empty()) return;
+  cost_vec val(0, length());
+  cost_set vals;
+  for (index_type i = 0; i < length(); i++) {
+    val[i] = (*this)[i]->makespan();
+    vals.insert((*this)[i]->makespan());
+  }
+  if (vals.length() > 1) {
+    for (index_type i = 0; i < length(); i++) {
+      hsps::rational v = (*this)[i]->makespan();
+      PlanFeatureValue* fv_trait =
+ new PlanFeatureValue((*this)[i], PlanFeatureValue::makespan,
+        instance, no_such_index, v);
+      if (v == vals[0]) fv_trait->set_min();
+      if (v == vals[vals.length() - 1]) fv_trait->set_max();
+      if (val.count(v) == 1) fv_trait->set_unique();
+      (*this)[i]->add_trait(fv_trait);
+    }
+  }
+  if (instance.n_resources() > 0) {
+    lvector<ExecTrace*> trajs(0, 0);
+    for (index_type i = 0; i < length(); i++) {
+      ExecTrace* trace = new ExecTrace(instance);
+      bool ok = (*this)[i]->simulate(trace, 0, true);
+      trajs.append(trace);
+    }
+    for (index_type k = 0; k < instance.n_resources(); k++) {
+      cost_vec peak_use(0, length());
+      cost_vec amt_cons(0, length());
+      cost_vec tol_loss(0, length());
+      cost_set peak_use_vals;
+      cost_set amt_cons_vals;
+      cost_set tol_loss_vals;
+      for (index_type i = 0; i < length(); i++) {
+ ResourceProfile* rp = new ResourceProfile(instance, k, *(trajs[i]));
+ peak_use[i] = rp->peak_use();
+ peak_use_vals.insert(rp->peak_use());
+ amt_cons[i] = rp->total_consumption();
+ amt_cons_vals.insert(rp->total_consumption());
+ tol_loss[i] = rp->tolerable_unexpected_loss();
+ tol_loss_vals.insert(rp->tolerable_unexpected_loss());
+ delete rp;
+      }
+      for (index_type i = 0; i < length(); i++) {
+ if (peak_use_vals.length() > 1) {
+   hsps::rational v = peak_use[i];
+   PlanFeatureValue* fv_trait =
+     new PlanFeatureValue((*this)[i],
+     PlanFeatureValue::resource_peak_use,
+     instance, k, v);
+   if (v == peak_use_vals[0])
+     fv_trait->set_min();
+   if (v == peak_use_vals[peak_use_vals.length() - 1])
+     fv_trait->set_max();
+   if (peak_use.count(v) == 1)
+     fv_trait->set_unique();
+   (*this)[i]->add_trait(fv_trait);
+ }
+ if (amt_cons_vals.length() > 1) {
+   hsps::rational v = amt_cons[i];
+   PlanFeatureValue* fv_trait =
+     new PlanFeatureValue((*this)[i],
+     PlanFeatureValue::resource_total_consumption,
+     instance, k, v);
+   if (v == amt_cons_vals[0])
+     fv_trait->set_min();
+   if (v == amt_cons_vals[amt_cons_vals.length() - 1])
+     fv_trait->set_max();
+   if (amt_cons.count(v) == 1)
+     fv_trait->set_unique();
+   (*this)[i]->add_trait(fv_trait);
+ }
+ if (tol_loss_vals.length() > 1) {
+   hsps::rational v = tol_loss[i];
+   PlanFeatureValue* fv_trait =
+     new PlanFeatureValue((*this)[i],
+     PlanFeatureValue::resource_tolerable_loss,
+     instance, k, v);
+   if (v == tol_loss_vals[0])
+     fv_trait->set_min();
+   if (v == tol_loss_vals[tol_loss_vals.length() - 1])
+     fv_trait->set_max();
+   if (tol_loss.count(v) == 1)
+     fv_trait->set_unique();
+   (*this)[i]->add_trait(fv_trait);
+ }
+      }
+    }
+  }
+}
+bool ScheduleSet::common_precedence_constraints(graph& prec)
+{
+  assert(!empty());
+  (*this)[0]->base_precedence_graph(prec);
+  for (index_type k = 1; k < length(); k++) {
+    CorrespondanceEnumerator e((*this)[k]->step_actions(),
+          (*this)[0]->step_actions());
+    bool ok = e.first();
+    if (!ok) return false;
+    graph pk;
+    (*this)[k]->base_precedence_graph(pk);
+    graph p0;
+    p0.copy_and_rename(pk, e.current());
+    prec.intersect(p0);
+    ok = !e.next();
+    if (!ok) return false;
+  }
+  return true;
+}
+bool ScheduleSet::separating_precedence_constraints
+(ScheduleSet& s, pair_set& d0, pair_set& d1)
+{
+  graph p_this;
+  if (!common_precedence_constraints(p_this)) return false;
+  graph p_that;
+  if (!s.common_precedence_constraints(p_that)) return false;
+  CorrespondanceEnumerator e(s[0]->step_actions(),
+        (*this)[0]->step_actions());
+  bool ok = e.first();
+  if (!ok) return false;
+  graph p_trans;
+  p_trans.copy_and_rename(p_that, e.current());
+  ok = !e.next();
+  if (!ok) return false;
+  p_this.difference(p_trans, d0, d1);
+  return true;
+}
+void ScheduleSet::write_deordered_graphs(::std::ostream& s, bool w_names)
+{
+  for (index_type k = 0; k < length(); k++) {
+    graph p;
+    (*this)[k]->deorder(p);
+    p.transitive_reduction();
+    if (w_names) {
+      name_vec a_names;
+      (*this)[k]->step_action_names(a_names);
+      write_labeled_digraph<name_vec>
+ (s, p, a_names, false, (*this)[k]->plan_name()->to_cstring());
+    }
+    else {
+      write_labeled_digraph<index_vec>
+ (s, p, (*this)[k]->step_actions(), false,
+  (*this)[k]->plan_name()->to_cstring());
+    }
+  }
+}
+void ScheduleSet::writeXML(::std::ostream& s)
+{
+  s << "<schedule-set xmlns=\"http://dummy.net/pddlcat/schedule\">"
+    << ::std::endl;
+  for (index_type k = 0; k < length(); k++) {
+    ExecTrace* trace = new ExecTrace(instance);
+    ExecErrorSet* errors = new ExecErrorSet();
+    (*this)[k]->simulate(trace, errors, true);
+    graph p;
+    (*this)[k]->deorder(p);
+    p.transitive_closure();
+    (*this)[k]->writeXML(s, errors, trace, &p, k);
+    delete trace;
+    delete errors;
+  }
+  s << "</schedule-set>" << ::std::endl;
+}
+Plan* ScheduleSet::new_plan()
+{
+  Schedule* p = new Schedule(instance);
+  p->set_trace_level(trace_level);
+  append(p);
+  return p;
+}
+void ScheduleSet::output(PlanSet& to)
+{
+  for (index_type k = 0; k < length(); k++) {
+    Plan* p = to.new_plan();
+    if (p) {
+      (*this)[k]->output(*p);
+    }
+  }
+}
+void ScheduleSet::output(PlanSet& to, const bool_vec& s)
+{
+  for (index_type k = 0; k < length(); k++) if (s[k]) {
+    Plan* p = to.new_plan();
+    if (p) {
+      (*this)[k]->output(*p);
+    }
+  }
+}
+bool feasible
+(Instance& ins,
+ const index_vec& acts,
+ index_type r,
+ const index_set& a,
+ index_type i_a,
+ const index_set& b,
+ index_type i_b,
+ hsps::rational c_max,
+ graph& uc,
+ graph_vec* rfps,
+ index_type* rff)
+{
+  bool ok = false;
+  hsps::rational c = c_max - ins.actions[acts[b[i_b]]].cons[r];
+  pair_set e;
+  uc.add_edge_to_transitive_closure(a[i_a], b[i_b], e);
+  if ((ins.resources[r].init - c) >= ins.actions[acts[a[i_a]]].req(r)) {
+    if ((i_a + 1) == a.length()) {
+      if ((r + 1) == ins.n_resources()) {
+ if (rfps) rfps->append(uc);
+ ok = true;
+      }
+      else {
+ ok = feasible(ins, acts, r + 1, uc, rfps, rff);
+      }
+    }
+    else {
+      ok = feasible(ins, acts, r, a, i_a + 1, uc, rfps, rff);
+    }
+  }
+  else {
+    if ((i_b + 1) == b.length()) {
+      return false;
+    }
+    else {
+      ok = feasible(ins, acts, r, a, i_a, b, i_b + 1, c, uc, rfps, rff);
+    }
+  }
+  uc.remove_edges(e);
+  if (!ok || rfps) {
+    ok = (ok || feasible(ins, acts, r, a, i_a, b, i_b + 1, c, uc, rfps, rff));
+  }
+  return ok;
+}
+bool feasible
+(Instance& ins,
+ const index_vec& acts,
+ index_type r,
+ const index_set& a,
+ index_type i,
+ graph& uc,
+ graph_vec* rfps,
+ index_type* rff)
+{
+  assert(i < a.length());
+  while (true) {
+    index_set b_nec;
+    hsps::rational c_nec = 0;
+    index_set b_pos;
+    hsps::rational c_pos = 0;
+    for (index_type k = 0; k < a.length(); k++) if (k != i) {
+      if (ins.actions[acts[a[k]]].cons[r] > 0) {
+ if (uc.adjacent(a[k], a[i])) {
+   b_nec.insert(a[k]);
+   c_nec += ins.actions[acts[a[k]]].cons[r];
+ }
+ else if (!uc.adjacent(a[i], a[k])) {
+   b_pos.insert(a[k]);
+   c_pos += ins.actions[acts[a[k]]].cons[r];
+ }
+      }
+    }
+    if ((ins.resources[r].init - c_nec) < ins.actions[acts[a[i]]].req(r)) {
+      return false;
+    }
+    else if ((ins.resources[r].init - (c_nec + c_pos)) <
+      ins.actions[acts[a[i]]].req(r)) {
+      assert(b_pos.length() > 0);
+      return feasible(ins, acts, r, a, i, b_pos, 0, c_nec + c_pos, uc, rfps, rff);
+    }
+    else {
+      i += 1;
+      if (i == a.length()) {
+ if ((r + 1) == ins.n_resources()) {
+   if (rfps) rfps->append(uc);
+   return true;
+ }
+ else {
+   return feasible(ins, acts, r + 1, uc, rfps, rff);
+ }
+      }
+    }
+  }
+}
+bool feasible
+(Instance& ins,
+ const index_vec& acts,
+ index_type r,
+ graph& uc,
+ graph_vec* rfps,
+ index_type* rff)
+{
+  assert(r < ins.n_resources());
+  while (true) {
+    index_set a;
+    hsps::rational c_sum = 0;
+    hsps::rational u_max = 0;
+    for (index_type k = 0; k < acts.length(); k++)
+      if (ins.actions[acts[k]].req(r) > 0) {
+ a.insert(k);
+ u_max = hsps::rational::max(u_max,ins.actions[acts[k]].use[r]);
+ c_sum += ins.actions[acts[k]].cons[r];
+      }
+    if (ins.resources[r].init < u_max) {
+      std::cerr << "max use of resource " << ins.resources[r].name
+  << " = " << u_max << " exceeds capacity "
+  << ins.resources[r].init << std::endl;
+      if (rff)
+ *rff = r;
+      return false;
+    }
+    if ((ins.resources[r].init - c_sum) < u_max) {
+      bool ok = feasible(ins, acts, r, a, 0, uc, rfps, rff);
+      if (!ok) {
+ std::cerr << "can not resolve use/loss conflicts on resource "
+    << ins.resources[r].name << std::endl;
+ if (rff)
+   *rff = r;
+ return false;
+      }
+      return true;
+    }
+    else {
+      r += 1;
+      if (r == ins.n_resources()) {
+ if (rfps) rfps->append(uc);
+ if (rff) *rff = no_such_index;
+ return true;
+      }
+    }
+  }
+}
+bool feasible
+(Instance& ins,
+ const index_vec& acts,
+ const graph& prec,
+ graph_vec* rfps,
+ index_type* rff)
+{
+  if (rff)
+    *rff = no_such_index;
+  if (!prec.acyclic()) {
+    return false;
+  }
+  if (ins.n_resources() == 0) {
+    if (rfps) rfps->append(prec);
+    return true;
+  }
+  graph p(prec);
+  p.transitive_closure();
+  return feasible(ins, acts, 0, p, rfps, rff);
+}
+ScheduleTrait::~ScheduleTrait()
+{
+}
+void ScheduleTrait::write_meta_short(::std::ostream& s) const
+{
+  bool first = true;
+  if (is_min) {
+    s << "[min";
+    first = false;
+  }
+  if (is_max) {
+    s << (first ? "[" : ",") << "max";
+    first = false;
+  }
+  if (is_unique) {
+    s << (first ? "[" : ",") << "unique";
+    first = false;
+  }
+  if (!first) s << "]";
+}
+void ScheduleTrait::write_meta_attributes(::std::ostream& s) const
+{
+  s << " min=\"" << (is_min ? "true" : "false" )
+    << "\" max=\"" << (is_max ? "true" : "false" )
+    << "\" unique=\"" << (is_unique ? "true" : "false" )
+    << "\"";
+}
+const PlanTrait* ScheduleTrait::cast_to(const char* n) const
+{
+  if (strcmp(n, "ScheduleTrait") == 0) return this;
+  return 0;
+}
+void ScheduleTrait::write_detail(::std::ostream& s) const
+{
+  write_short(s);
+  s << ::std::endl;
+}
+const PlanTrait* EquivalentTo::cast_to(const char* class_name) const
+{
+  if (strcmp(class_name, "EquivalentTo") == 0) return this;
+  return ScheduleTrait::cast_to(class_name);
+}
+void EquivalentTo::write_short(::std::ostream& s) const
+{
+  assert(plan_set);
+  index_type i_eq = plan_set->first(s_eq);
+  if (i_eq != no_such_index) {
+    s << "equivalent to plan #" << i_eq;
+    if (s_eq->plan_name()) {
+      s << " (" << s_eq->plan_name() << ")";
+    }
+  }
+  else {
+    s << "equivalent to plan@" << s_eq << " (not in plan set)";
+  }
+}
+void EquivalentTo::write_detail(::std::ostream& s) const
+{
+  write_short(s);
+  index_type i_eq = plan_set->first(s_eq);
+  if (i_eq != no_such_index) {
+    s << ::std::endl << "correpondance: ";
+    write_correspondance(s, cor);
+    s << ::std::endl;
+    graph p;
+    graph q;
+    plan->deorder(p);
+    p.transitive_reduction();
+    s_eq->deorder(q);
+    q.transitive_reduction();
+    p.write_graph_correspondance(s, q, cor, "Correspondance Graph");
+  }
+}
+void EquivalentTo::writeXML(::std::ostream& s) const
+{
+  index_type i_eq = plan_set->first(s_eq);
+  if (i_eq != no_such_index) {
+    s << "<equivalent-to";
+    s << " plan=\"" << i_eq << "\"";
+    if (s_eq->plan_name()) {
+      s << " name=\"";
+      s_eq->plan_name()->write(s, Name::NC_XML);
+      s << "\"";
+    }
+    s << ">" << ::std::endl;
+    s << "<cgraph><![CDATA[" << ::std::endl;
+    graph p;
+    graph q;
+    plan->deorder(p);
+    p.transitive_reduction();
+    s_eq->deorder(q);
+    q.transitive_reduction();
+    p.write_graph_correspondance(s, q, cor, "Correspondance Graph");
+    s << "]]></cgraph>" << ::std::endl;
+    s << "</equivalent-to>" << ::std::endl;
+  }
+  else {
+    s << "<equivalent-to/>" << ::std::endl;
+  }
+}
+DerivedFrom::DerivedFrom
+(Schedule* p, ScheduleSet* ss,
+ DerivedFrom* a, const index_vec& m,
+ const index_pair& e)
+  : ScheduleTrait(p, ss), s_src(a->s_src)
+{
+  for (index_type k = 0; k < a->e_prec.length(); k++) {
+    assert(m[a->e_prec[k].first] != no_such_index);
+    assert(m[a->e_prec[k].second] != no_such_index);
+    e_prec.insert(index_pair(m[a->e_prec[k].first], m[a->e_prec[k].second]));
+  }
+  e_prec.insert(e);
+};
+const PlanTrait* DerivedFrom::cast_to(const char* class_name) const
+{
+  if (strcmp(class_name, "DerivedFrom") == 0) return this;
+  return ScheduleTrait::cast_to(class_name);
+}
+void DerivedFrom::write_short(::std::ostream& s) const
+{
+  assert(plan_set);
+  index_type i_src = plan_set->first(s_src);
+  if (i_src != no_such_index) {
+    s << "derived from plan #" << i_src;
+    if (s_src->plan_name()) {
+      s << " (" << s_src->plan_name() << ")";
+    }
+    s << " by additional constraints " << e_prec;
+  }
+  else {
+    s << "derived from plan@" << s_src << " (not in plan set)";
+  }
+}
+void DerivedFrom::write_detail(::std::ostream& s) const
+{
+  write_short(s);
+  s << std::endl;
+}
+void DerivedFrom::writeXML(::std::ostream& s) const
+{
+  index_type i_src = plan_set->first(s_src);
+  if (i_src != no_such_index) {
+    s << "<derived-from";
+    s << " plan=\"" << i_src << "\"";
+    if (s_src->plan_name()) {
+      s << " name=\"";
+      s_src->plan_name()->write(s, Name::NC_XML);
+      s << "\"";
+    }
+    s << ">" << ::std::endl;
+  }
+  else {
+    s << "<derived-from>" << ::std::endl;
+  }
+  for (index_type k = 0; k < e_prec.length(); k++) {
+    s << "<prec-link from=\"" << e_prec[k].first
+      << "\" to=\"" << e_prec[k].second << "\"/>" << ::std::endl;
+  }
+  s << "</derived-from>" << ::std::endl;
+}
+const PlanTrait* PlanPrecedenceRelation::cast_to(const char* class_name) const
+{
+  if (strcmp(class_name, "PlanPrecedenceRelation") == 0) return this;
+  return ScheduleTrait::cast_to(class_name);
+}
+void PlanPrecedenceRelation::write_short(::std::ostream& s) const
+{
+  s << "precedence relation = " << prec;
+}
+void PlanPrecedenceRelation::writeXML(::std::ostream& s) const
+{
+  s << "<plan-precedence-relation>" << ::std::endl;
+  graph p(prec);
+  p.transitive_closure();
+  for (index_type k = 0; k < p.size(); k++) {
+    s << "<step id=\"" << k << "\">" << ::std::endl;
+    for (index_type j = 0; j < p.size(); j++) if (p.adjacent(k, j)) {
+      s << "<link step=\"" << j << "\" type=\"prec\"/>" << ::std::endl;
+    }
+    s << "</step>" << ::std::endl;
+  }
+  s << "</plan-precedence-relation>" << ::std::endl;
+}
+const PlanTrait* PlanActionOccurs::cast_to(const char* class_name) const
+{
+  if (strcmp(class_name, "PlanActionOccurs") == 0) return this;
+  return ScheduleTrait::cast_to(class_name);
+}
+void PlanActionOccurs::write_short(::std::ostream& s) const
+{
+  if (n_of_times == 0) {
+    s << "does not contain action " << instance.actions[act].name;
+  }
+  else if (n_of_times == 1) {
+    s << "contains action " << instance.actions[act].name;
+  }
+  else {
+    s << "action " << instance.actions[act].name
+      << " occurs " << n_of_times << " times";
+  }
+  write_meta_short(s << " ");
+}
+void PlanActionOccurs::writeXML(::std::ostream& s) const
+{
+  s << "<plan-action-occurs action=\"" << act
+    << "\" name=\"";
+  instance.actions[act].name->write(s, Name::NC_XML);
+  s << "\" count=\"" << n_of_times << "\"";
+  write_meta_attributes(s);
+  if (n_of_times > 0) {
+    s << ">" << ::std::endl;
+    for (index_type k = 0; k < plan->plan_steps().length(); k++)
+      if (plan->plan_steps()[k].act == act) {
+ s << "<link step=\"" << k << "\"/>" << ::std::endl;
+      }
+    s << "</plan-action-occurs>" << ::std::endl;
+  }
+  else {
+    s << "/>" << ::std::endl;
+  }
+}
+const PlanTrait* PlanStepOrder::cast_to(const char* class_name) const
+{
+  if (strcmp(class_name, "PlanStepOrder") == 0) return this;
+  return ScheduleTrait::cast_to(class_name);
+}
+void PlanStepOrder::write_short(::std::ostream& s) const
+{
+  assert(plan);
+  assert(order.first < plan->n_steps());
+  assert(order.second < plan->n_steps());
+  assert(plan->step_actions()[order.first] < instance.n_actions());
+  assert(plan->step_actions()[order.second] < instance.n_actions());
+  s << instance.actions[plan->step_actions()[order.first]].name
+    << " preceeds "
+    << instance.actions[plan->step_actions()[order.second]].name;
+}
+void PlanStepOrder::writeXML(::std::ostream& s) const
+{
+  s << "<plan-step-order";
+  write_meta_attributes(s);
+  s << ">" << ::std::endl;
+  s << "<prec-link from=\"" << order.first
+    << "\" to=\"" << order.second << "\"/>" << ::std::endl;
+  s << "</plan-step-order>" << ::std::endl;
+}
+const PlanTrait* PlanFeatureValue::cast_to(const char* class_name) const
+{
+  if (strcmp(class_name, "PlanFeatureValue") == 0) return this;
+  return ScheduleTrait::cast_to(class_name);
+}
+void PlanFeatureValue::write_short(::std::ostream& s) const
+{
+  switch (ftype) {
+  case makespan:
+    s << "makespan = " << value;
+    break;
+  case cost:
+    s << "cost = " << value;
+    break;
+  case resource_peak_use:
+    s << "peak use of " << instance.resources[index].name << " = " << value;
+    break;
+  case resource_total_consumption:
+    s << "amount of " << instance.resources[index].name << " consumed = "
+      << value;
+    break;
+  case resource_tolerable_loss:
+    s << "resource " << instance.resources[index].name << " tolerable loss = "
+      << value;
+    break;
+  default:
+    ::std::cerr << "error: invalid plan feature type " << ftype << ::std::endl;
+    exit(255);
+  }
+  write_meta_short(s << " ");
+}
+void PlanFeatureValue::writeXML(::std::ostream& s) const
+{
+  s << "<plan-feature-value";
+  switch (ftype) {
+  case makespan:
+    s << " type=\"makespan\"";
+    break;
+  case cost:
+    s << " type=\"cost\"";
+    break;
+  case resource_peak_use:
+    s << " type=\"peak-use\" resource=\"" << index << "\" name=\"";
+    instance.resources[index].name->write(s, Name::NC_XML);
+    s << "\"";
+    break;
+  case resource_total_consumption:
+    s << " type=\"total-consumption\" resource=\"" << index << "\" name=\"";
+    instance.resources[index].name->write(s, Name::NC_XML);
+    s << "\"";
+    break;
+  case resource_tolerable_loss:
+    s << " type=\"tolerable-loss\" resource=\"" << index << "\" name=\"";
+    instance.resources[index].name->write(s, Name::NC_XML);
+    s << "\"";
+    break;
+  default:
+    ::std::cerr << "error: invalid plan feature type " << ftype << ::std::endl;
+    exit(255);
+  }
+  s << " value=\"" << value << "\"";
+  write_meta_attributes(s);
+  switch (ftype) {
+  case resource_peak_use:
+  case resource_total_consumption:
+  case resource_tolerable_loss:
+    s << ">" << ::std::endl
+      << "<link resource=\"" << index << "\"/>" << ::std::endl
+      << "</plan-feature-value>" << ::std::endl;
+    break;
+  default:
+    s << "/>" << ::std::endl;
+  }
+}
+void PlanName::write(::std::ostream& s, unsigned int c) const
+{
+  write_string_escaped(s, desc, c);
+  write_string_escaped(s, " #", c);
+  s << index;
+  if (src) {
+    write_string_escaped(s, " of ", c);
+    src->write(s, c);
+  }
+}
+}

--- a/pr/seq-opt-hspsf/forward.ccx
+++ b/pr/seq-opt-hspsf/forward.ccx
@@ -1,0 +1,7466 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+class AtomSet {
+ protected:
+  Instance& instance;
+  bool_vec set;
+  index_type size;
+  index_type count();
+ private:
+  hsps::rational split(index_set g, index_type p, index_type n_out, index_type limit,
+       StateFactory& f, State* sp, Search& s, hsps::rational bound);
+  hsps::rational split_random(index_set g, index_type p, index_type n_out,
+       index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+ public:
+  static index_type max_set_size_encountered;
+  AtomSet(Instance& i);
+  AtomSet(Instance& i, const index_set& g);
+  AtomSet(Instance& i, const bool_vec& g);
+  AtomSet(const AtomSet& s);
+  ~AtomSet();
+  index_type atom_set_size() { return size; };
+  void add(const index_set& s);
+  void add(const bool_vec& s);
+  void del(const index_set& s);
+  void del(const bool_vec& s);
+  bool is_init_all();
+  bool is_init_some();
+  bool is_goal_all();
+  bool is_goal_some();
+  index_vec& copy_to(index_vec& s);
+  bool_vec& copy_to(bool_vec& s);
+  hsps::rational split(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound);
+  hsps::rational split_random(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+  int compare(const AtomSet& s);
+  index_type hash();
+};
+class AtomSetState : public AtomSet, public State {
+ protected:
+  Heuristic& heuristic;
+  hsps::rational est;
+  hsps::rational eval();
+  hsps::rational eval(hsps::rational b_est);
+  hsps::rational eval_with_trace_level(int level);
+  void apply_path_max();
+ public:
+  AtomSetState(Instance& i, Heuristic& h);
+  AtomSetState(Instance& i, Heuristic& h, const index_set& g);
+  AtomSetState(Instance& i, Heuristic& h, const bool_vec& g);
+  AtomSetState(const AtomSetState& s);
+  virtual ~AtomSetState();
+  index_type atom_set_size() { return size; };
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual void write(std::ostream& s);
+  virtual void write_eval(std::ostream& s, char* p = 0, bool e = true);
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class SeqProgState : public AtomSetState, public StateFactory {
+ protected:
+  const ACF& cost;
+  index_type act;
+  BasicResourceState* res;
+  virtual bool applicable(Instance::Action& a);
+  virtual SeqProgState* apply(Instance::Action& a);
+  bool is_update(Instance::Action& a) {
+    return (a.del.empty() && (cost(a.index)).zero() && (res == 0));
+  };
+  void apply_update_actions();
+ public:
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c);
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c, const index_set& s);
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& s);
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c,
+        BasicResourceState* r);
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c, const index_set& s,
+        BasicResourceState* r);
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& s,
+        BasicResourceState* r);
+  SeqProgState(const SeqProgState& s);
+  virtual ~SeqProgState();
+  static bool separate_update_actions;
+  virtual bool is_final();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void set_predecessor(State* p);
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write_plan(std::ostream& s);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual void write(std::ostream& s);
+};
+class SeqCProgState : public SeqProgState {
+ public:
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c)
+    : SeqProgState(i, h, c) { };
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c, const index_set& s)
+    : SeqProgState(i, h, c, s) { };
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& s)
+    : SeqProgState(i, h, c, s) { };
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c, BasicResourceState* r)
+    : SeqProgState(i, h, c, r) { };
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c,
+        const index_set& s, BasicResourceState* r)
+    : SeqProgState(i, h, c, s, r) { };
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c,
+        const bool_vec& s, BasicResourceState* r)
+    : SeqProgState(i, h, c, s, r) { };
+  SeqCProgState(const SeqProgState& s)
+    : SeqProgState(s) { };
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual int compare(const State& s);
+  index_type hash();
+  virtual void write(std::ostream& s);
+};
+class RestrictedSeqProgState : public SeqProgState {
+ protected:
+  const bool_vec& p_atoms;
+  bool_vec& f_atoms;
+ public:
+  RestrictedSeqProgState(Instance& i, const bool_vec& pa, bool_vec& fa,
+    Heuristic& h, const ACF& c, const index_set& s)
+    : SeqProgState(i, h, c, s), p_atoms(pa), f_atoms(fa) { };
+  RestrictedSeqProgState(Instance& i, const bool_vec& pa, bool_vec& fa,
+    Heuristic& h, const ACF& c, const bool_vec& s)
+    : SeqProgState(i, h, c, s), p_atoms(pa), f_atoms(fa) { };
+  RestrictedSeqProgState(Instance& i, const bool_vec& pa, bool_vec& fa,
+    Heuristic& h, const ACF& c, const index_set& s,
+    BasicResourceState* r)
+    : SeqProgState(i, h, c, s, r), p_atoms(pa), f_atoms(fa) { };
+  RestrictedSeqProgState(Instance& i, const bool_vec& pa, bool_vec& fa,
+    Heuristic& h, const ACF& c, const bool_vec& s,
+    BasicResourceState* r)
+    : SeqProgState(i, h, c, s, r), p_atoms(pa), f_atoms(fa) { };
+  RestrictedSeqProgState(const RestrictedSeqProgState& s)
+    : SeqProgState(*this), p_atoms(s.p_atoms), f_atoms(s.f_atoms) { };
+  virtual ~RestrictedSeqProgState() { };
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+};
+class ExtendedSeqProgState : public SeqProgState {
+ protected:
+  virtual bool applicable(Instance::Action& a);
+  virtual SeqProgState* apply(Instance::Action& a);
+ public:
+  ExtendedSeqProgState(Instance& i, Heuristic& h, const ACF& c)
+    : SeqProgState(i, h, c) { };
+  ExtendedSeqProgState(Instance& i, Heuristic& h, const ACF& c,
+         const index_set& s)
+    : SeqProgState(i, h, c, s) { };
+  ExtendedSeqProgState(Instance& i, Heuristic& h, const ACF& c,
+   const bool_vec& s)
+    : SeqProgState(i, h, c, s) { };
+  ExtendedSeqProgState(const ExtendedSeqProgState& s)
+    : SeqProgState(s) { };
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+};
+class RelaxedSeqProgState : public SeqProgState {
+ protected:
+  index_set x_atoms;
+  bool_vec x_action;
+  void compute_x_actions();
+  void closure();
+  virtual bool applicable(Instance::Action& a);
+  virtual SeqProgState* apply(Instance::Action& a);
+ public:
+  RelaxedSeqProgState(Instance& i, const index_set& x, Heuristic& h,
+        const ACF& c, const index_set& s)
+    : SeqProgState(i, h, c, s), x_atoms(x)
+  {
+    compute_x_actions();
+    closure();
+  };
+  RelaxedSeqProgState(Instance& i, const index_set& x, Heuristic& h,
+        const ACF& c, const bool_vec& g)
+    : SeqProgState(i, h, c, g), x_atoms(x)
+  {
+    compute_x_actions();
+    closure();
+  };
+  RelaxedSeqProgState(const RelaxedSeqProgState& s);
+  virtual ~RelaxedSeqProgState() { };
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+};
+class FwdUnitHeuristic : public Heuristic {
+ public:
+  FwdUnitHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~FwdUnitHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+}
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class PDDL_Name;
+class PDDL_Base {
+ public:
+  static bool use_default_function_value;
+  static hsps::rational default_function_value;
+  static bool use_strict_borrow_definition;
+  static bool use_extended_borrow_definition;
+  static bool del_before_add_semantics;
+  static bool compact_resource_effects;
+  static bool compile_away_disjunctive_preconditions;
+  static bool check_precondition_consistency;
+  static bool compile_away_conditional_effects;
+  static bool compile_away_plan_constraints;
+  static bool compile_away_object_functions;
+  static bool compile_for_validator;
+  static bool create_all_atoms;
+  static bool create_all_actions;
+  static bool number_multiple_action_instances;
+  static bool exclude_all_dkel_items;
+  static string_set excluded_dkel_tags;
+  static string_set required_dkel_tags;
+  static bool strict_set_export;
+  static bool best_effort;
+  static bool write_PDDL31;
+  static bool write_warnings;
+  static bool write_info;
+  static bool write_trace;
+  static bool trace_print_context;
+  static bool name_instance_by_problem_file;
+  static const char* instance_name_prefix;
+  enum symbol_class {
+    sym_object,
+    sym_typename,
+    sym_predicate,
+    sym_object_function,
+    sym_function,
+    sym_action,
+    sym_variable,
+    sym_misc,
+    sym_preference,
+    sym_set,
+    sym_meta_variable
+  };
+  enum metric_class {
+    metric_none,
+    metric_makespan,
+    metric_minimize,
+    metric_maximize
+  };
+  enum mode_keyword {
+    md_none,
+    md_start,
+    md_end,
+    md_all,
+    md_init,
+    md_pos_goal,
+    md_neg_goal
+  };
+  enum partial_value { p_false, p_true, p_unknown };
+  enum expression_class {
+    exp_fun,
+    exp_list,
+    exp_const,
+    exp_add,
+    exp_sub,
+    exp_mul,
+    exp_div,
+    exp_time,
+    exp_preference
+  };
+  enum relation_type {
+    rel_equal,
+    rel_greater,
+    rel_greater_equal,
+    rel_less,
+    rel_less_equal
+  };
+  enum formula_class { fc_false,
+         fc_true,
+         fc_atom,
+         fc_equality,
+         fc_negation,
+         fc_conjunction,
+         fc_disjunction,
+         fc_equivalence,
+         fc_implication,
+         fc_universal,
+         fc_existential,
+         fc_list
+  };
+  struct Symbol;
+  struct TypeSymbol;
+  struct Atom;
+  struct FTerm;
+  struct FChangeAtom;
+  struct SetOf;
+  struct ListExpression;
+  struct ActionSymbol;
+  struct Reference;
+  struct IrrelevantItem;
+  typedef lvector<TypeSymbol*> type_vec;
+  typedef lvector<Atom*> atom_vec;
+  typedef lvector<FChangeAtom*> ch_atom_vec;
+  typedef lvector<SetOf*> atom_set_vec;
+  typedef lvector<Reference*> ref_vec;
+  typedef lvector<IrrelevantItem*> irrelevant_vec;
+  struct TypeSet : public type_vec {
+    TypeSet() : type_vec(0, 0) { };
+    TypeSet(const TypeSet& s) : type_vec(s) { };
+    TypeSet(TypeSymbol* t) : type_vec(t, 1) { };
+    index_type n_elements() const;
+    Symbol* get_element(index_type n);
+    bool is_object() const;
+    bool subtype_or_equal(const TypeSet& s) const;
+    bool subtype_or_equal(TypeSymbol* t) const;
+    void print(std::ostream& s) const;
+    void write_type(std::ostream& s) const;
+  };
+  struct Symbol {
+    symbol_class sym_class;
+    char* print_name;
+    TypeSet sym_types;
+    bool defined_in_problem;
+    bool visible;
+    Symbol(symbol_class c, char* n)
+      : sym_class(c), print_name(n), defined_in_problem(false), visible(true) { };
+    Symbol(char* n)
+      : sym_class(sym_object), print_name(n), defined_in_problem(false), visible(true) { };
+    void print(std::ostream& s) const;
+  };
+  typedef zero_init_pair<Symbol*> symbol_pair;
+  typedef lvector<Symbol*> symbol_vec;
+  typedef svector<Symbol*> symbol_set;
+  typedef lvector<symbol_pair> symbol_pair_vec;
+  static bool extend_substitution(Symbol* out, Symbol* in, symbol_pair_vec& u);
+  static bool print_substitution(std::ostream& s, const symbol_pair_vec& u);
+  static bool print_inequality(std::ostream& s, const symbol_pair_vec& neq);
+  static bool substitution_violates_inequality(const symbol_pair_vec& neq,
+            const symbol_pair_vec& u);
+  static index_type find_matching_atom(Atom* a, atom_vec& v);
+  static index_type find_matching_atom(Atom* a, mode_keyword m, atom_vec& v);
+  static index_type find_matching_fluent_atom
+    (FChangeAtom* a, mode_keyword m, ch_atom_vec& v);
+  struct TypeSymbol : public Symbol {
+    symbol_vec elements;
+    bool is_base_type;
+    TypeSymbol(char* n) : Symbol(sym_typename, n), elements(0, 0),
+  is_base_type(false) { };
+    void add_element(Symbol* e);
+    bool is_object() const { return (strcmp(print_name, "object") == 0); };
+    bool subtype_or_equal(TypeSymbol* t) const;
+    bool subtype_or_equal(const TypeSet& t) const;
+    void print(std::ostream& s) const;
+  };
+  struct VariableSymbol : public Symbol {
+    Symbol* value;
+    FTerm* binding;
+    VariableSymbol(char* n) : Symbol(sym_variable, n), value(0), binding(0) {};
+    bool equality_type_check(Symbol* s);
+    void print(std::ostream& s);
+  };
+  typedef lvector<VariableSymbol*> variable_vec;
+  struct ParamSymbol : public Symbol {
+    variable_vec param;
+    ParamSymbol(symbol_class c, char* n) : Symbol(c, n), param(0, 0) { };
+  };
+  struct PredicateSymbol : public ParamSymbol {
+    bool pos_pre;
+    bool neg_pre;
+    bool added;
+    bool deleted;
+    bool locked;
+    bool modded;
+    ptr_table init;
+    ptr_table pos_goal;
+    ptr_table neg_goal;
+    ptr_table pos_prop;
+    ptr_table neg_prop;
+    irrelevant_vec irr_ins;
+    PredicateSymbol(char* n) : ParamSymbol(sym_predicate, n),
+  pos_pre(false), neg_pre(false), added(false), deleted(false),
+  locked(false), modded(false), irr_ins(0, 0) { };
+    bool is_static() const { return !modded; };
+    bool is_equality() const { return (strcmp(print_name, "=") == 0); };
+    void instantiate(Instance& ins);
+    void initialise_missing(const symbol_vec& p,
+       atom_vec* created,
+       index_type i = 0);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+  };
+  struct ObjectFunctionSymbol : public ParamSymbol {
+    bool modded;
+    ptr_table init;
+    ObjectFunctionSymbol(char* n)
+      : ParamSymbol(sym_object_function, n), modded(false) { };
+    bool is_static() const { return !modded; };
+    void print(std::ostream& s);
+  };
+  struct FunctionSymbol : public ParamSymbol {
+    bool modified;
+    bool integral;
+    bool linear;
+    bool conditioned;
+    bool increased;
+    bool decreased;
+    bool assigned;
+    bool borrowed;
+    ptr_table init;
+    FunctionSymbol(char* n) : ParamSymbol(sym_function, n),
+  modified(false), integral(true), linear(true), conditioned(false),
+  increased(false), decreased(false), assigned(false), borrowed(false)
+    { };
+    bool is_static() const
+    { return !modified; };
+    bool is_reusable() const
+    { return borrowed && !increased && !decreased && !assigned; };
+    bool is_consumable() const
+    { return !borrowed && !increased && decreased && !assigned; };
+    interval eval_init_bounds(ptr_table* p, index_type i, ListExpression* r);
+    void print(std::ostream& s);
+  };
+  struct AtomBase {
+    symbol_vec param;
+    mode_keyword at;
+    hsps::rational at_time;
+    AtomBase() : param(0, 0), at(md_none), at_time(0) { };
+    AtomBase(mode_keyword t) : param(0, 0), at(t), at_time(0) { };
+    AtomBase(AtomBase* b);
+    bool equals(AtomBase& b);
+    void free_variables(variable_vec& v);
+    bool occurs(Symbol* s);
+    void fill_in_args(AtomBase* b);
+    void collect_bound_variables(variable_vec& v);
+    void insert(ptr_table& t);
+    static bool print_bindings;
+    void print(std::ostream& s) const;
+    void print_instance(std::ostream& s);
+  };
+  typedef lvector<AtomBase*> atom_base_vec;
+  struct Atom : AtomBase {
+    PredicateSymbol* pred;
+    Atom(PredicateSymbol* p) : pred(p) { };
+    Atom(PredicateSymbol* p, mode_keyword t) : AtomBase(t), pred(p) { };
+    Atom(PredicateSymbol* p, variable_vec& a, bool as_value)
+      : pred(p)
+    {
+      param.set_length(a.length());
+      for (index_type k = 0; k < a.length(); k++)
+ param[k] = (as_value ? a[k]->value : a[k]);
+    };
+    Atom(PredicateSymbol* p, Symbol* a0)
+      : pred(p)
+    {
+      param.append(a0);
+    };
+    Atom(Atom* a) : AtomBase(a), pred(a->pred) { };
+    bool equals(Atom& a);
+    bool is_static() const {
+      return ((at == md_init) ||
+       (at == md_pos_goal) ||
+       (at == md_neg_goal) ||
+       pred->is_static());
+    };
+    bool check();
+    Instance::Atom* find_prop(Instance& ins, bool neg, bool create);
+    void build(Instance& ins, bool neg, index_type p);
+    Atom* instantiate_partially();
+    partial_value partial_eval(ptr_table* r, index_type p);
+    partial_value partial_eval();
+    bool initial_value();
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    void print(std::ostream& s, bool neg) const;
+    void print(std::ostream& s) const { print(s, false); };
+  };
+  struct CAtom : public Atom {
+    symbol_pair_vec neq;
+    CAtom(Atom* a) : Atom(a), neq(symbol_pair(0, 0), 0) { };
+    CAtom(CAtom* s) : Atom(s), neq(s->neq) { };
+    CAtom(const Atom* a, symbol_pair_vec& u);
+    CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool instance_of(CAtom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(CAtom* a, symbol_pair_vec& u);
+    void print(std::ostream& s);
+  };
+  typedef lvector<CAtom*> catom_vec;
+  struct FTerm : AtomBase {
+    ObjectFunctionSymbol* fun;
+    FTerm(ObjectFunctionSymbol* f) : fun(f) { };
+    bool equals(FTerm& a);
+    void print(std::ostream& s) const;
+  };
+  struct OInitAtom : AtomBase {
+    ObjectFunctionSymbol* fun;
+    Symbol* val;
+    OInitAtom(ObjectFunctionSymbol* f) : fun(f), val(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<OInitAtom*> obj_init_atom_vec;
+  struct FInitAtom : AtomBase {
+    FunctionSymbol* fun;
+    hsps::rational val;
+    Instance::resource_ref res;
+    FInitAtom(FunctionSymbol* f) : fun(f), val(0) { };
+    FInitAtom(FChangeAtom* a);
+    bool is_static() const { return fun->is_static(); };
+    void print(std::ostream& s);
+  };
+  typedef lvector<FInitAtom*> fun_init_atom_vec;
+  struct Expression;
+  typedef lvector<Expression*> exp_vec;
+  struct Expression {
+    expression_class exp_class;
+    Expression(expression_class c) : exp_class(c) { };
+    static bool print_nary;
+    bool is_static();
+    bool is_constant();
+    bool is_integral();
+    hsps::rational eval_static();
+    bool eval_partial(hsps::rational& val);
+    interval eval_bounds();
+    hsps::rational eval_init();
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    hsps::rational eval_delta(Symbol* preference, hsps::rational p_value, hsps::rational d_value);
+    Expression* copy();
+    Expression* simplify();
+    void collect_constants(exp_vec& c);
+    void mark_functions_in_condition();
+    hsps::rational integrify();
+    void substitute_for_time(Expression* e);
+    Expression* substitute_for_preference(Symbol* n, Expression* e);
+    bool equals(Expression* e);
+    void print_sum(std::ostream& s, bool grnd);
+    void print_product(std::ostream& s, bool grnd);
+    void print(std::ostream& s, bool grnd);
+  };
+  struct ListExpression : public Expression {
+    Symbol* sym;
+    ListExpression* rest;
+    ListExpression(Symbol* s, ListExpression* r) :
+      Expression(exp_list), sym(s), rest(r) { };
+    bool match(AtomBase* atom);
+  };
+  struct FunctionExpression : public Expression {
+    FunctionSymbol* fun;
+    ListExpression* args;
+    FunctionExpression(FunctionSymbol* f, ListExpression* a) :
+      Expression(exp_fun), fun(f), args(a) { };
+    bool match(FChangeAtom* atom);
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    FChangeAtom* make_atom_base();
+  };
+  struct ConstantExpression : public Expression {
+    hsps::rational val;
+    ConstantExpression(hsps::rational v) :
+      Expression(exp_const), val(v) { };
+  };
+  struct TimeExpression : public Expression {
+    Expression* time_exp;
+    TimeExpression() :
+      Expression(exp_time), time_exp(0) { };
+    TimeExpression(Expression* e) :
+      Expression(exp_time), time_exp(e) { };
+  };
+  struct BinaryExpression : public Expression {
+    Expression* first;
+    Expression* second;
+    BinaryExpression(expression_class c, Expression* e1, Expression* e2) :
+      Expression(c), first(e1), second(e2) { };
+  };
+  struct PreferenceExpression : public Expression {
+    Symbol* name;
+    PreferenceExpression(Symbol* n) :
+      Expression(exp_preference), name(n) { };
+  };
+  struct Relation {
+    relation_type rel;
+    mode_keyword at;
+    Expression* first;
+    Expression* second;
+    Relation(relation_type r, Expression* e1, Expression* e2) :
+      rel(r), at(md_none), first(e1), second(e2) { };
+    Relation(relation_type r, mode_keyword m, Expression* e1, Expression* e2) :
+      rel(r), at(m), first(e1), second(e2) { };
+    Expression* match_gteq_constant(FChangeAtom* atom);
+    FunctionExpression* match_lteq_fun(FChangeAtom* atom);
+    bool is_static();
+    partial_value partial_eval();
+    void print(std::ostream& s, bool grnd);
+  };
+  typedef lvector<Relation*> relation_vec;
+  struct FChangeAtom : AtomBase {
+    FunctionSymbol* fun;
+    Expression* val;
+    FChangeAtom(FunctionSymbol* f) :
+      fun(f), val(0) { };
+    FChangeAtom(FunctionSymbol* f, mode_keyword t) :
+      AtomBase(t), fun(f), val(0) { };
+    FChangeAtom(FChangeAtom* a, hsps::rational v) :
+      AtomBase(a), fun(a->fun), val(new ConstantExpression(v)) { };
+    bool equals(FChangeAtom& a);
+    bool fluent_equals(FChangeAtom& a);
+    bool fluent_and_mode_equals(FChangeAtom& a);
+    FChangeAtom* find_fluent_equals(ch_atom_vec& vec);
+    Instance::Resource* find_resource(Instance& ins);
+    void print(std::ostream& s);
+  };
+  struct Formula {
+    formula_class fc;
+    Formula(formula_class c) : fc(c) { };
+    void rename_variables_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_variables_2(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_2(PDDL_Base::symbol_pair_vec& sub);
+    Formula* simplify();
+    void write_otter(std::ostream& s) const;
+    void print(std::ostream& s) const;
+    void untype(PDDL_Base* base);
+  };
+  typedef lvector<Formula*> formula_vec;
+  struct AFormula : public Formula, public Atom {
+    AFormula(Atom* a) :
+      Formula(fc_atom), Atom(a) { };
+    AFormula(PredicateSymbol* p) :
+      Formula(fc_atom), Atom(p) { };
+    AFormula(PredicateSymbol* p, variable_vec& a) :
+      Formula(fc_atom), Atom(p, a, false) { };
+    void print(std::ostream& s) const;
+    void write_otter(std::ostream& s) const;
+  };
+  struct EqFormula : public Formula {
+    Symbol* t1;
+    Symbol* t2;
+    EqFormula(Symbol* s1, Symbol* s2) :
+      Formula(fc_equality), t1(s1), t2(s2) { };
+    void write_otter(std::ostream& s) const;
+  };
+  struct NFormula : public Formula {
+    Formula* f;
+    NFormula(Formula* g) : Formula(fc_negation), f(g) { };
+  };
+  struct BFormula : public Formula {
+    Formula* f1;
+    Formula* f2;
+    BFormula(formula_class c, Formula* g1, Formula* g2) :
+      Formula(c), f1(g1), f2(g2) { };
+  };
+  struct CFormula : public Formula {
+    formula_vec parts;
+    CFormula(formula_class c) : Formula(c), parts(0, 0) { };
+    CFormula(formula_class c, Formula* f1, Formula* f2) :
+      Formula(c), parts(0, 0)
+    {
+      parts.append(f1);
+      parts.append(f2);
+    };
+    void add(Formula* f) { parts.append(f); };
+    void add(formula_vec& f) { parts.append(f); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct QFormula : public Formula {
+    variable_vec vars;
+    Formula* f;
+    QFormula(formula_class c) : Formula(c), vars(0, 0), f(0) { };
+    QFormula(formula_class c, Formula* g) : Formula(c), vars(0, 0), f(g) { };
+    QFormula(formula_class c, variable_vec& v, Formula* g) :
+      Formula(c), vars(0, 0), f(g)
+    {
+      for (index_type k = 0; k < v.length(); k++) vars.append(v[k]);
+    };
+    void add(PDDL_Base::VariableSymbol* v) { vars.append(v); };
+    void add(PDDL_Base::variable_vec& v) { vars.append(v); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct TypeConstraint {
+    VariableSymbol* var;
+    TypeSymbol* typ;
+    TypeConstraint(VariableSymbol* v, TypeSymbol* t) : var(v), typ(t) { };
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+  };
+  typedef lvector<TypeConstraint*> type_constraint_vec;
+  struct Context {
+    variable_vec param;
+    atom_vec pos_con;
+    atom_vec neg_con;
+    type_constraint_vec type_con;
+    Context() : param(0, 0), pos_con(0, 0), neg_con(0, 0), type_con(0, 0) { };
+    Context(const Context* c) : param(c->param), pos_con(c->pos_con),
+  neg_con(c->neg_con), type_con(c->type_con) { };
+    bool context_is_static() const;
+    bool occurs_in_context(Symbol* s);
+    void clear_arguments();
+    void set_mode(mode_keyword m);
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+    void print_assignment(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct DKEL_Item : public Context {
+    char* item_name;
+    Symbol* name;
+    string_set item_tags;
+    bool defined_in_problem;
+    bool included;
+    DKEL_Item(char* name) : item_name(name), name(0),
+  defined_in_problem(false), included(true) { };
+    DKEL_Item(const DKEL_Item* i) : Context(i), item_name(i->item_name),
+  name(i->name), item_tags(i->item_tags),
+  defined_in_problem(i->defined_in_problem), included(i->included) { };
+    bool item_is_included(string_set& ex_tags, string_set& req_tags);
+    void print_begin(std::ostream& s);
+    void print_end(std::ostream& s);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SetOf : public Context {
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    SetOf() : pos_atoms(0, 0), neg_atoms(0, 0) { };
+    SetOf(const SetOf* s)
+      : Context(s), pos_atoms(s->pos_atoms), neg_atoms(s->neg_atoms)
+    { };
+    SetOf(Atom* a)
+    { pos_atoms.append(a); };
+    SetOf(Atom* a, bool n)
+    { if (n) neg_atoms.append(a); else pos_atoms.append(a); };
+    bool is_static() const;
+    void set_mode(mode_keyword m);
+    partial_value partial_eval(bool as_disjunction = false);
+    partial_value partial_eval(index_type p, bool as_disjunction = false);
+    void instantiate_as_set(Instance& ins, index_set& s);
+    void instantiate_as_effect(Instance& ins, index_set& s_add,
+          index_set& s_del);
+    void instantiate_conditional(Instance& ins, rule_set& s_pos,
+     rule_set& s_neg);
+    SetOf* instantiate_partially();
+    void compile(atom_vec& pos_ins, atom_vec& neg_ins, index_type p);
+    void compile_non_static(atom_set_vec& ins, index_type p);
+    void print(std::ostream& s);
+    void print_as_disjunction(std::ostream& s);
+    void build_set(Instance& ins, index_set& s, index_type p);
+    void build_effect(Instance& ins, index_set& s_add, index_set& s_del,
+        index_type p);
+    void build_conditional(Instance& ins, rule_set& s_pos, rule_set& s_neg,
+      index_type p);
+  };
+  struct QCNumericEffect : public Context {
+    FChangeAtom* atom;
+    QCNumericEffect() : atom(0) { };
+    QCNumericEffect(FChangeAtom* a) : atom(a) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<QCNumericEffect*> qc_numeric_effect_vec;
+  enum set_constraint_keyword { sc_at_least, sc_at_most, sc_exactly };
+  struct SetConstraint : public DKEL_Item {
+    set_constraint_keyword sc_type;
+    index_type sc_count;
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    atom_set_vec atom_sets;
+    SetConstraint() : DKEL_Item(":invariant"), sc_type(sc_at_least),
+  sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0), atom_sets(0, 0) { };
+    SetConstraint(const DKEL_Item* item) : DKEL_Item(item),
+  sc_type(sc_at_least), sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0),
+  atom_sets(0, 0) { };
+    void build(Instance& ins, index_type p);
+    void instantiate(Instance& ins);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InvariantFormula : public DKEL_Item {
+    Formula* f;
+    InvariantFormula(Formula* g)
+      : DKEL_Item(":invariant"), f(g) { };
+    InvariantFormula(const DKEL_Item* item, Formula* g)
+      : DKEL_Item(item), f(g) { };
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct Reference : public AtomBase {
+    Symbol* name;
+    bool neg;
+    bool has_args;
+    index_set index;
+    Reference(Symbol* n) : name(n), neg(false), has_args(true) { };
+    Reference(Symbol* n, bool ng, bool ha)
+      : name(n), neg(ng), has_args(ha) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    void* find_action();
+    void find(const name_vec& names, index_set& ind);
+    Reference* instantiate_partially();
+    void print(std::ostream& s);
+  };
+  struct IrrelevantItem : public DKEL_Item {
+    Reference* entity;
+    IrrelevantItem() : DKEL_Item(":irrelevant"), entity(0) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    IrrelevantItem* instantiate_partially();
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SequentialTaskNet : public Context {
+    ref_vec tasks;
+    ActionSymbol* abs_act;
+    SequentialTaskNet() : tasks(0, 0), abs_act(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<SequentialTaskNet*> task_net_vec;
+  struct SetSymbol : public Symbol {
+    ptr_table set_table;
+    lvector<index_set*> sets;
+    name_vec names;
+    SetSymbol(char* n) : Symbol(sym_set, n), sets(0, 0), names(0, 0) { };
+  };
+  struct SetName : public AtomBase {
+    SetSymbol* sym;
+    SetName(SetSymbol* s) : sym(s) { };
+    index_set* find();
+    SetName* instantiate_partially();
+    void print(std::ostream& s);
+    void print_instance(std::ostream& s);
+  };
+  struct ActionSymbol : public ParamSymbol {
+    atom_vec pos_pre;
+    atom_vec neg_pre;
+    atom_set_vec set_pre;
+    atom_set_vec dis_pre;
+    relation_vec num_pre;
+    atom_vec adds;
+    atom_vec dels;
+    atom_set_vec set_eff;
+    atom_vec cons;
+    atom_set_vec cond_eff;
+    atom_vec locks;
+    atom_vec enables;
+    ch_atom_vec reqs;
+    ch_atom_vec incs;
+    ch_atom_vec decs;
+    ch_atom_vec fass;
+    qc_numeric_effect_vec qc_incs;
+    qc_numeric_effect_vec qc_decs;
+    qc_numeric_effect_vec qc_fass;
+    Expression* dmin;
+    Expression* dmax;
+    irrelevant_vec irr_ins;
+    ref_vec refs;
+    task_net_vec exps;
+    ptr_table instances;
+    SetName* part;
+    const char* assoc;
+    ActionSymbol(char* n) : ParamSymbol(sym_action, n), pos_pre(0, 0),
+  neg_pre(0, 0), set_pre(0, 0), dis_pre(0, 0), num_pre(0, 0),
+  adds(0, 0), dels(0, 0), set_eff(0, 0), cons(0, 0), cond_eff(0, 0),
+  locks(0, 0), enables(0, 0), reqs(0, 0), incs(0, 0), decs(0, 0),
+  fass(0, 0), qc_incs(0, 0), qc_decs(0, 0), qc_fass(0, 0), dmin(0),
+  dmax(0), irr_ins(0, 0), refs(0, 0), exps(0, 0), part(0), assoc(0) { };
+    void build(Instance& ins, index_type p, Expression* cost_exp);
+    Instance::Action& build_action(Instance& ins,
+       PDDL_Name* name,
+       index_type& count,
+       const index_set& pre,
+       const index_set& add,
+       const index_set& del,
+       const index_set& lck,
+       const index_cost_vec& r_use,
+       const index_cost_vec& r_cons,
+       hsps::rational dmin,
+       hsps::rational dmax,
+       hsps::rational dur,
+       hsps::rational cost);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          index_vec& s,
+          index_type p);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc);
+    void build_actions_with_dc_and_ce(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          const rule_set& pce,
+          const rule_set& nce,
+          const bool_vec& ece);
+    index_type param_index(VariableSymbol* p);
+    void get_param_inequalities(symbol_pair_vec& neq);
+    void set_arguments(const symbol_vec& args);
+    void set_arguments(const ptr_table::key_vec& args);
+    void clear_arguments();
+    void* find_instance();
+    bool is_abstract();
+    void post_process();
+    void instantiate(Instance& ins, Expression* cost_exp);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InputPlanStep {
+    Reference* act;
+    hsps::rational start_time;
+    InputPlanStep() : act(0), start_time(0) { };
+    InputPlanStep(Reference* a, hsps::rational t) : act(a), start_time(t) { };
+  };
+  struct InputPlan {
+    Symbol* name;
+    bool is_opt;
+    lvector<InputPlanStep*> steps;
+    InputPlan() : name(0), is_opt(false), steps(0, 0) { };
+    bool export_to_instance(Instance& ins, const index_vec& map, Plan& p);
+    void print(std::ostream& s);
+  };
+  struct HTableEntry {
+    atom_vec atoms;
+    bool_vec neg;
+    hsps::rational cost;
+    bool opt;
+    HTableEntry() : atoms(0, 0), neg(false, 0), cost(0), opt(false) { };
+  };
+  struct SimpleReferenceSet : public Context {
+    Reference* ref;
+    SimpleReferenceSet(Reference* r) : ref(r) { };
+    bool build(const name_vec& names, index_set& set, index_type p);
+    void print(std::ostream& s);
+  };
+  typedef lvector<SimpleReferenceSet*> refs_vec;
+  struct ReferenceSet : public Context {
+    refs_vec refs;
+    Symbol* name;
+    ReferenceSet() : refs(0, 0), name(0) { };
+    void add(SimpleReferenceSet* ref) { refs.append(ref); };
+    void build(const name_vec& names, index_set_vec& sets, index_type p);
+    void print(std::ostream& s);
+  };
+  struct CPG {
+    atom_vec atoms;
+    index_vec atom_first_arg;
+    bool_vec neg;
+    symbol_vec args;
+    type_vec arg_types;
+    CPG() : atoms(0, 0), neg(false, 0), args(0, 0), arg_types(0, 0) { };
+    CPG(CPG& g, index_vec& s);
+    void make_key(ptr_table::key_vec& key);
+    void make_typed_key(ptr_table::key_vec& key);
+    void make_parameters(variable_vec& params);
+    ListExpression* make_argument_list(index_type first);
+    void add_asserting_effects(ActionSymbol* act,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          bool strict);
+    void add_destroying_effects(ActionSymbol* act,
+    ParamSymbol* pf,
+    PredicateSymbol* p,
+    bool p_val,
+    PredicateSymbol* g,
+    FunctionSymbol* f,
+    Expression* f_val,
+    bool strict);
+    bool initial_value();
+    void add_asserting_effects(index_type c_atom,
+          ActionSymbol* act,
+          index_type c_eff,
+          bool_vec& sat,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          symbol_pair_vec& eq,
+          symbol_pair_vec& neq,
+          bool strict);
+    void add_propositional_effect(ActionSymbol* act,
+      PredicateSymbol* p, bool p_val,
+      index_type c_atom, Atom* a_eff,
+      bool strict);
+    void add_fluent_effect(ActionSymbol* act,
+      FunctionSymbol* f, Expression* f_val,
+      index_type c_atom, Atom* a_eff);
+    void add_effect_conditions(Context* e, ParamSymbol* pf, bool_vec& sat,
+          symbol_vec& subs, symbol_pair_vec& eq,
+          symbol_pair_vec& neq);
+  };
+  enum goal_class { goal_pos_atom, goal_neg_atom, goal_relation, goal_task,
+      goal_conjunction, goal_disjunction, goal_forall,
+      goal_exists, goal_always, goal_sometime,
+      goal_at_most_once, goal_within, goal_always_within,
+      goal_sometime_before, goal_sometime_after };
+  struct Goal {
+    goal_class g_class;
+    Goal(goal_class c) : g_class(c) { };
+    bool is_state();
+    bool is_propositional();
+    bool is_singular();
+    bool makeCPG(CPG& g);
+    bool makeCPG(CPG& g, index_vec& s);
+    void instantiate(Instance& ins, hsps::rational deadline);
+    void instantiate(Instance& ins, index_set& set, Symbol* p, index_type i);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Goal*> goal_vec;
+  struct AtomicGoal : public Goal {
+    Atom* atom;
+    AtomicGoal(Atom* a, bool neg)
+      : Goal(neg ? goal_neg_atom : goal_pos_atom), atom(a) { };
+    void print(std::ostream& s);
+  };
+  struct NumericGoal : public Goal {
+    Relation* rel;
+    NumericGoal(Relation* r) : Goal(goal_relation), rel(r) { };
+    void print(std::ostream& s);
+  };
+  struct TaskGoal : public Goal {
+    Reference* task;
+    TaskGoal(Reference* r) : Goal(goal_task), task(r) { };
+    void print(std::ostream& s);
+  };
+  struct ConjunctiveGoal : public Goal {
+    goal_vec goals;
+    ConjunctiveGoal() : Goal(goal_conjunction), goals(0, 0) { };
+    ConjunctiveGoal(goal_class gc) : Goal(gc), goals(0, 0) { };
+    void print(std::ostream& s);
+  };
+  struct DisjunctiveGoal : public ConjunctiveGoal {
+    DisjunctiveGoal() : ConjunctiveGoal(goal_disjunction) { };
+    void print(std::ostream& s);
+  };
+  struct QuantifiedGoal : public Goal, public Context {
+    Goal* goal;
+    QuantifiedGoal() : Goal(goal_forall), goal(0) { };
+    QuantifiedGoal(goal_class gc) : Goal(gc), goal(0) { };
+    void print(std::ostream& s);
+  };
+  struct SimpleSequenceGoal : public Goal {
+    Goal* constraint;
+    SimpleSequenceGoal(goal_class c, Goal* g) : Goal(c), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredSequenceGoal : public Goal {
+    Goal* trigger;
+    Goal* constraint;
+    TriggeredSequenceGoal(goal_class c, Goal* t, Goal* g)
+      : Goal(c), trigger(t), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct DeadlineGoal : public Goal {
+    Goal* goal;
+    hsps::rational at;
+    DeadlineGoal(hsps::rational t, Goal* g) : Goal(goal_within), goal(g), at(t) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredDeadlineGoal : public Goal {
+    Goal* trigger;
+    Goal* goal;
+    hsps::rational delay;
+    TriggeredDeadlineGoal(Goal* t, hsps::rational d, Goal* g)
+      : Goal(goal_always_within), trigger(t), delay(d), goal(g) { };
+    void print(std::ostream& s);
+  };
+  struct Preference {
+    Symbol* name;
+    Goal* goal;
+    Preference() : name(0), goal(0) { };
+    Preference(Symbol* n) : name(n), goal(0) { };
+    Preference(Symbol* n, Goal* g) : name(n), goal(g) { };
+    bool is_state() { return goal->is_state(); };
+    bool is_propositional() { return goal->is_propositional(); };
+    hsps::rational value(metric_class metric_type, Expression* m);
+    void instantiate(SoftInstance& ins,
+       metric_class metric_type,
+       Expression* m);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Preference*> preference_vec;
+  char* domain_name;
+  char* problem_name;
+  char* domain_file;
+  char* problem_file;
+  bool ready_to_instantiate;
+  char* problem_file_basename();
+  char* enum_problem_filename(const char* s, index_type i);
+  StringTable& tab;
+  type_vec dom_types;
+  type_vec dom_base_types;
+  TypeSymbol* dom_top_type;
+  symbol_vec dom_constants;
+  PredicateSymbol* dom_eq_pred;
+  PredicateSymbol* dom_assign_pred;
+  Symbol* dom_undefined_obj;
+  static PredicateSymbol* current_eq_predicate;
+  lvector<PredicateSymbol*> dom_predicates;
+  lvector<ObjectFunctionSymbol*> dom_object_functions;
+  lvector<FunctionSymbol*> dom_functions;
+  lvector<ActionSymbol*> dom_actions;
+  lvector<SetConstraint*> dom_sc_invariants;
+  lvector<InvariantFormula*> dom_f_invariants;
+  lvector<IrrelevantItem*> dom_irrelevant;
+  atom_vec dom_init;
+  obj_init_atom_vec dom_obj_init;
+  fun_init_atom_vec dom_fun_init;
+  goal_vec dom_goals;
+  preference_vec dom_preferences;
+  ref_vec goal_tasks;
+  metric_class metric_type;
+  Expression* metric;
+  hsps::rational serial_length;
+  hsps::rational parallel_length;
+  lvector<InputPlan*> input_plans;
+  lvector<HTableEntry*> h_table;
+  lvector<ReferenceSet*> input_sets;
+  lvector<SetSymbol*> partitions;
+  static ActionSymbol* src_action_symbol(ptr_pair* p);
+  TypeSymbol* find_type(const char* name);
+  PredicateSymbol* find_predicate(const char* name);
+  FunctionSymbol* find_function(const char* name);
+  bool find_initial_fact(const char* pname, const symbol_vec& arg);
+  hsps::rational find_function_value(const char* fname, const symbol_vec& arg);
+  index_type find_element_satisfying(const symbol_vec& elements,
+         const char* pname,
+         symbol_vec& arg,
+         index_type element_arg_p);
+  void find_elements_satisfying(const symbol_vec& elements,
+    const char* pname,
+    symbol_vec& arg,
+    index_type element_arg_p,
+    index_set& sats);
+  Atom* goal_to_atom(Goal* g);
+  bool goal_to_atom_vec(Goal* g, atom_vec& av);
+  PDDL_Base(StringTable& t);
+  ~PDDL_Base();
+  void set_variable_type(variable_vec& vec, TypeSymbol* t);
+  void set_variable_type(variable_vec& vec, const TypeSet& t);
+  void set_type_type(type_vec& vec, TypeSymbol* t);
+  void set_constant_type(symbol_vec& vec, TypeSymbol* t);
+  void clear_context(variable_vec& vec);
+  void clear_context(variable_vec& vec, index_type n_min, index_type n_max);
+  bool merge_type_vectors(type_vec& v0, type_vec& v1);
+  void make_parameters(type_vec& t, const char* prefix, variable_vec& v);
+  Atom* make_atom_from_prop(ptr_pair& src, bool& neg);
+  Symbol* gensym(symbol_class c, const char* p, const TypeSet& t);
+  Symbol* gensym(symbol_class c, const char* p, TypeSymbol* t);
+  Symbol* gensym_i(symbol_class c, const char* p, index_type i, TypeSymbol* t);
+  Symbol* gensym_s(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t);
+  Symbol* gensym_n(symbol_class c, const char* p, const Name* n, TypeSymbol* t);
+  void new_variable_substitution(Atom* a,
+     symbol_pair_vec& u,
+     symbol_pair_vec& new_u);
+  Atom* new_meta_atom(PredicateSymbol* p);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& u);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+  void extend_cc(CAtom* l, catom_vec& m, catom_vec& nm,
+   lvector< swapable_pair<catom_vec> >& x,
+   index_type d);
+  void find_cc();
+  void post_process();
+  void instantiate(Instance& ins);
+  void instantiate_soft(SoftInstance& ins);
+  void instantiate_atom_set(Instance& ins, atom_vec& a, index_set& s);
+  index_type n_plans() const { return input_plans.length(); };
+  bool export_plan(index_type i, Instance& ins, const index_vec& map, Plan& p);
+  bool export_plan(index_type i, Instance& ins, Plan& p);
+  void export_heuristic(Instance& ins,
+   const index_vec& map,
+   bool opt_maximize,
+   Heuristic& h);
+  void export_sets(const name_vec& names, index_set_vec& sets);
+  void export_action_partitions(name_vec& names, index_set_vec& sets);
+  void lift_DKEL_Items(const Instance& ins);
+  PredicateSymbol* find_type_predicate(Symbol* type_sym);
+  void untype();
+  void compile_preferences();
+  void compile_constraints_1();
+  void compile_constraints_2();
+  void select_preferences(const bool_vec& sel);
+  void metric_to_goal(hsps::rational bound);
+  void compile_set_conditions_and_effects();
+  void compile_object_functions();
+  Expression* replace_violations_1(Expression* exp,
+       CPG* cpg[],
+       FunctionSymbol* f_violated[]);
+  Goal* compile_constraint_1(Goal* g, index_type i, const Symbol* n,
+        symbol_vec& aut_states, index_type n_ra);
+  AtomicGoal* make_automaton_type_a(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_e(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_o(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sb(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sa(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  void make_automaton_transition(Symbol* s_from,
+     Symbol* s_to,
+     bool is_accept,
+     CPG* f, bool neg_f,
+     CPG* g, bool neg_g,
+     PredicateSymbol* p_state,
+     PredicateSymbol* p_accept,
+     PredicateSymbol* p_synch);
+  void add_precondition_formula(ActionSymbol* a, CPG* f, bool is_neg);
+  Goal* compile_constraint_2(Goal* g, const Symbol* n);
+  Goal* compile_always_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_sometime_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_at_most_once_constraint(SimpleSequenceGoal* g,
+     const Symbol* n);
+  Goal* compile_sometime_before_constraint(TriggeredSequenceGoal* g,
+        const Symbol* n);
+  void compile_set_conditions_and_effects(ActionSymbol* act);
+  void compile_set_conditions_and_effects(ActionSymbol* act,
+       variable_vec& i_param,
+       variable_vec& d_param,
+       index_type p);
+  Atom* make_binding_atom(VariableSymbol* v);
+  void compile_object_functions(ActionSymbol* act, Symbol* undefined_value);
+  void compile_object_functions_for_validator(ActionSymbol* act);
+  Goal* compile_object_functions(Goal* g);
+  void write_declarations(std::ostream& s);
+  void write_action(std::ostream& s, ActionSymbol* act);
+  void write_set_precondition(std::ostream& s, SetOf* set);
+  void write_disjunctive_set_precondition(std::ostream& s, SetOf* set);
+  void write_set_effect(std::ostream& s, SetOf* set);
+  void write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn);
+  void write_objects(std::ostream& s, bool defined_in_problem);
+  void write_init(std::ostream& s);
+  void write_goal(std::ostream& s);
+  void write_metric(std::ostream& s);
+  void write_dkel_items(std::ostream& s, bool defined_in_problem);
+  void write_domain_begin(std::ostream& s);
+  void write_problem_begin(std::ostream& s);
+  void write_end(std::ostream& s);
+  void write_dkel_domain(std::ostream& s, bool leave_open);
+  void write_dkel_problem(std::ostream& s, bool leave_open);
+  void write_plans(std::ostream& s);
+  void write_heuristic_table(std::ostream& s);
+  void write_sets(std::ostream& s);
+  void print(std::ostream& s);
+};
+class InstanceName : public Name {
+  char* domain_name;
+  char* problem_name;
+ public:
+  InstanceName(char* d, char* p) : domain_name(d), problem_name(p) { };
+  virtual ~InstanceName() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class PDDL_Name : public Name {
+ protected:
+  bool neg;
+  PDDL_Base::Symbol* sym;
+  PDDL_Base::symbol_vec arg;
+  bool vis;
+  bool_vec avis;
+ public:
+  static char catc;
+  static bool obscure_symbol_names;
+  PDDL_Name(PDDL_Base::Symbol* s)
+    : neg(false), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, bool n)
+    : neg(n), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::symbol_vec a, bool n)
+    : neg(n), sym(s), arg(a), vis(true), avis(true, a.length()) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n);
+  void add(PDDL_Base::Symbol* s);
+  void add(PDDL_Base::Symbol* s, bool v);
+  PDDL_Base::Symbol* symbol() { return sym; };
+  PDDL_Base::symbol_vec& args() { return arg; };
+  index_type argc() { return arg.length(); };
+  bool is_neg() { return neg; };
+  virtual ~PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class Numbered_PDDL_Name : public PDDL_Name {
+  index_type copy;
+ public:
+  Numbered_PDDL_Name(PDDL_Base::Symbol* sym, index_type c)
+    : PDDL_Name(sym), copy(c) { };
+  Numbered_PDDL_Name(PDDL_Name* n, index_type c);
+  virtual ~Numbered_PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+};
+}
+namespace hsps {
+bool SeqProgState::separate_update_actions = false;
+SeqProgState::SeqProgState
+(Instance& i, Heuristic& h, const ACF& c)
+  : AtomSetState(i, h), cost(c), act(no_such_index), res(0)
+{
+  if (separate_update_actions) {
+    apply_update_actions();
+  }
+}
+SeqProgState::SeqProgState
+(Instance& i, Heuristic& h, const ACF& c, const index_set& s)
+  : AtomSetState(i, h, s), cost(c), act(no_such_index), res(0)
+{
+  if (separate_update_actions) {
+    apply_update_actions();
+  }
+}
+SeqProgState::SeqProgState
+(Instance& i, Heuristic& h, const ACF& c, const bool_vec& s)
+  : AtomSetState(i, h, s), cost(c), act(no_such_index), res(0)
+{
+  if (separate_update_actions) {
+    apply_update_actions();
+  }
+}
+SeqProgState::SeqProgState
+(Instance& i, Heuristic& h, const ACF& c, BasicResourceState* r)
+  : AtomSetState(i, h), cost(c), act(no_such_index), res(r)
+{
+  if (separate_update_actions) {
+    apply_update_actions();
+  }
+}
+SeqProgState::SeqProgState
+(Instance& i, Heuristic& h, const ACF& c, const index_set& s,
+ BasicResourceState* r)
+  : AtomSetState(i, h, s), cost(c), act(no_such_index), res(r)
+{
+  if (separate_update_actions) {
+    apply_update_actions();
+  }
+}
+SeqProgState::SeqProgState
+(Instance& i, Heuristic& h, const ACF& c, const bool_vec& s,
+ BasicResourceState* r)
+  : AtomSetState(i, h, s), cost(c), act(no_such_index), res(r)
+{
+  if (separate_update_actions) {
+    apply_update_actions();
+  }
+}
+SeqProgState::SeqProgState(const SeqProgState& s)
+  : AtomSetState(s), cost(s.cost), act(s.act), res(0)
+{
+  if (s.res) res = s.res->copy();
+}
+SeqProgState::~SeqProgState()
+{
+  if (res) delete res;
+}
+bool SeqProgState::applicable(Instance::Action& a)
+{
+  bool app = true;
+  for (index_type i = 0; (i < a.pre.length()) && app; i++)
+    if (!set[a.pre[i]]) app = false;
+  if (res) {
+    if (app) {
+      if (!res->applicable(a)) app = false;
+    }
+  }
+  return app;
+}
+SeqProgState* SeqProgState::apply(Instance::Action& a)
+{
+  SeqProgState* s = (SeqProgState*)copy();
+  for (index_type k = 0; k < a.add.length(); k++) {
+    if (!s->set[a.add[k]]) s->size += 1;
+    s->set[a.add[k]] = true;
+  }
+  for (index_type k = 0; k < a.del.length(); k++) {
+    if (s->set[a.del[k]]) s->size -= 1;
+    s->set[a.del[k]] = false;
+  }
+  if (separate_update_actions) {
+    s->apply_update_actions();
+  }
+  s->State::set_predecessor(this);
+  s->act = a.index;
+  s->eval();
+  if (s->res) {
+    s->res->apply(a);
+  }
+  return s;
+}
+void SeqProgState::apply_update_actions()
+{
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type k = 0; k < instance.n_actions(); k++) {
+      Instance::Action& a = instance.actions[k];
+      if (is_update(a) && applicable(a)) {
+ for (index_type i = 0; i < instance.actions[k].add.length(); i++) {
+   if (!set[instance.actions[k].add[i]]) done = false;
+   set[instance.actions[k].add[i]] = true;
+ }
+      }
+    }
+  }
+  count();
+}
+void SeqProgState::set_predecessor(State* p)
+{
+  if (p == 0) {
+    act = no_such_index;
+    pre = 0;
+    return;
+  }
+  SeqProgState* s = (SeqProgState*)p;
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    Instance::Action& a = instance.actions[k];
+    if (a.sel && s->applicable(a)) {
+      SeqProgState* new_s = s->apply(a);
+      int d = compare(*new_s);
+      delete new_s;
+      if (d == 0) {
+ act = k;
+ pre = s;
+ return;
+      }
+    }
+  }
+  std::cerr << "error in SeqProgState::set_predecessor: state " << *this
+     << " can not be a successor of " << *s << std::endl;
+  exit(255);
+}
+bool SeqProgState::is_final()
+{
+  for (index_type k = 0; k < instance.goal_atoms.length(); k++)
+    if (!set[instance.goal_atoms[k]]) return false;
+  return true;
+}
+hsps::rational SeqProgState::delta_cost() {
+  if (act == no_such_index)
+    return 0;
+  else
+    return cost(act);
+}
+hsps::rational SeqProgState::expand(Search& s, hsps::rational bound) {
+  hsps::rational c_min = POS_INF;
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    Instance::Action& a = instance.actions[k];
+    if (a.sel && (!separate_update_actions || !is_update(a))) {
+      if (applicable(a)) {
+ SeqProgState* new_s = apply(a);
+ if ((new_s->est).finite() && (cost(a.index) + new_s->est <= bound)) {
+   hsps::rational c_new =
+     cost(a.index) + s.new_state(*new_s, bound - cost(a.index));
+   if (s.solved()) {
+     if (size > max_set_size_encountered)
+       max_set_size_encountered = size;
+   }
+   if (s.done()) {
+     delete new_s;
+     return c_new;
+   }
+   else {
+     c_min = hsps::rational::min(c_min,c_new);
+   }
+ }
+ else {
+   c_min = hsps::rational::min(c_min,cost(a.index) + new_s->est);
+ }
+ delete new_s;
+      }
+    }
+  }
+  return c_min;
+}
+void SeqProgState::store(hsps::rational cost, bool opt) {
+  if (res) {
+    if (!res->is_root()) return;
+  }
+  heuristic.store(set, cost, opt);
+}
+void SeqProgState::insert(Plan& p) {
+  if (act != no_such_index) {
+    p.insert(act);
+    for (index_type k = 0; k < instance.n_atoms(); k++)
+      if (set[k] && !instance.actions[act].add.contains(k))
+ p.protect(k);
+    p.advance(instance.actions[act].dur);
+  }
+}
+void SeqProgState::insert_path(Plan& p)
+{
+  if (predecessor()) {
+    predecessor()->insert_path(p);
+  }
+  insert(p);
+}
+void SeqProgState::write_plan(std::ostream& s)
+{
+  if (act != no_such_index) {
+    s << instance.actions[act].name;
+  }
+}
+State* SeqProgState::copy() {
+  return new SeqProgState(*this);
+}
+State* SeqProgState::new_state(const index_set& s, State* p) {
+  SeqProgState* new_s =
+    (res ? new SeqProgState(instance, heuristic, cost, s, res->new_state())
+         : new SeqProgState(instance, heuristic, cost, s));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* SeqProgState::new_state(const bool_vec& s, State* p) {
+  SeqProgState* new_s =
+    (res ? new SeqProgState(instance, heuristic, cost, s, res->new_state())
+         : new SeqProgState(instance, heuristic, cost, s));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+void SeqProgState::write(std::ostream& s) {
+  instance.write_atom_set(s, set);
+  if (res) {
+    s << " (";
+    res->write(s);
+    s << ")";
+  }
+}
+hsps::rational SeqCProgState::expand(Search& s, hsps::rational bound) {
+  hsps::rational c_min = POS_INF;
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    Instance::Action& a = instance.actions[k];
+    if (a.sel && (!separate_update_actions || !is_update(a))) {
+      bool app = applicable(a);
+      if (app) {
+ if ((act != no_such_index) && (act < a.index) &&
+     instance.commutative(act, a.index)) app = false;
+      }
+      if (app) {
+ SeqCProgState* new_s = (SeqCProgState*)apply(a);
+ if ((new_s->est).finite() && (cost(a.index) + new_s->est <= bound)) {
+   hsps::rational c_new =
+     cost(a.index) + s.new_state(*new_s, bound - cost(a.index));
+   if (s.solved()) {
+     if (size > max_set_size_encountered)
+       max_set_size_encountered = size;
+   }
+   if (s.done()) {
+     delete new_s;
+     return c_new;
+   }
+   else {
+     c_min = hsps::rational::min(c_min,c_new);
+   }
+ }
+ else {
+   c_min = hsps::rational::min(c_min,cost(a.index) + new_s->est);
+ }
+ delete new_s;
+      }
+    }
+  }
+  return c_min;
+}
+State* SeqCProgState::copy() {
+  return new SeqCProgState(*this);
+}
+State* SeqCProgState::new_state(const index_set& s, State* p) {
+  SeqCProgState* new_s =
+    (res ? new SeqCProgState(instance, heuristic, cost, s, res)
+         : new SeqCProgState(instance, heuristic, cost, s));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* SeqCProgState::new_state(const bool_vec& s, State* p) {
+  SeqCProgState* new_s =
+    (res ? new SeqCProgState(instance, heuristic, cost, s, res)
+         : new SeqCProgState(instance, heuristic, cost, s));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+int SeqCProgState::compare(const State& s) {
+  if (act < ((SeqCProgState&)s).act) return -1;
+  else if (act > ((SeqCProgState&)s).act) return 1;
+  else return AtomSetState::compare(s);
+}
+index_type SeqCProgState::hash()
+{
+  return (AtomSetState::hash() + act);
+}
+void SeqCProgState::write(std::ostream& s) {
+  if (act != no_such_index)
+    s << "(" << instance.actions[act].name << ") ";
+  else
+    s << "() ";
+  instance.write_atom_set(s, set);
+  if (res) {
+    s << " (";
+    res->write(s);
+    s << ")";
+  }
+}
+hsps::rational RestrictedSeqProgState::expand(Search& s, hsps::rational bound)
+{
+  hsps::rational c_min = POS_INF;
+  for (index_type k = 0; k < instance.n_actions(); k++) if (instance.actions[k].sel) {
+    Instance::Action& a = instance.actions[k];
+    if (applicable(a)) {
+      RestrictedSeqProgState* new_s = (RestrictedSeqProgState*)apply(a);
+      if ((new_s->est).finite() && (cost(a.index) + new_s->est <= bound)) {
+ bool allowed = true;
+ for (index_type i = 0; i < a.del.length(); i++)
+   if (p_atoms[a.del[i]]) {
+     allowed = false;
+     f_atoms[a.del[i]] = true;
+   }
+ if (allowed) {
+   hsps::rational c_new =
+     cost(a.index) + s.new_state(*new_s, bound - cost(a.index));
+   if (s.done()) {
+     delete new_s;
+     return c_new;
+   }
+   else {
+     c_min = hsps::rational::min(c_min,c_new);
+   }
+ }
+      }
+      else {
+ c_min = hsps::rational::min(c_min,cost(a.index) + new_s->est);
+      }
+      delete new_s;
+    }
+  }
+  return c_min;
+}
+State* RestrictedSeqProgState::new_state(const index_set& s, State* p)
+{
+  RestrictedSeqProgState* new_s =
+    (res ? new RestrictedSeqProgState(instance, p_atoms, f_atoms,
+          heuristic, cost, s, res)
+         : new RestrictedSeqProgState(instance, p_atoms, f_atoms,
+          heuristic, cost, s));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* RestrictedSeqProgState::new_state(const bool_vec& s, State* p)
+{
+  RestrictedSeqProgState* new_s =
+    (res ? new RestrictedSeqProgState(instance, p_atoms, f_atoms,
+          heuristic, cost, s, res)
+         : new RestrictedSeqProgState(instance, p_atoms, f_atoms,
+          heuristic, cost, s));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* RestrictedSeqProgState::copy()
+{
+  return new RestrictedSeqProgState(*this);
+}
+bool ExtendedSeqProgState::applicable(Instance::Action& a)
+{
+  if (!SeqProgState::applicable(a)) return false;
+  if (PDDL_Base::compile_away_disjunctive_preconditions) return true;
+  ptr_pair* p = (ptr_pair*)a.src;
+  PDDL_Base::ActionSymbol* act = (PDDL_Base::ActionSymbol*)p->first;
+  return true;
+}
+SeqProgState* ExtendedSeqProgState::apply(Instance::Action& a)
+{
+  ExtendedSeqProgState* s = (ExtendedSeqProgState*)copy();
+  for (index_type k = 0; k < a.add.length(); k++) {
+    s->set[a.add[k]] = true;
+  }
+  for (index_type k = 0; k < a.del.length(); k++) {
+    s->set[a.del[k]] = false;
+  }
+  if (!PDDL_Base::compile_away_conditional_effects) {
+    ptr_pair* p = (ptr_pair*)a.src;
+    PDDL_Base::ActionSymbol* act = (PDDL_Base::ActionSymbol*)p->first;
+    if (act->cond_eff.length() > 0) {
+      ptr_table* ins = (ptr_table*)p->second;
+      ptr_table::key_vec* args = ins->key_sequence();
+      for (index_type k = 0; k < act->param.length(); k++)
+ act->param[k]->value = (PDDL_Base::Symbol*)((*args)[k + 1]);
+      delete args;
+      for (index_type k = 0; k < act->cond_eff.length(); k++) {
+ rule_set ne;
+ rule_set pe;
+ act->cond_eff[k]->instantiate_conditional(instance, pe, ne);
+ for (index_type i = 0; i < ne.length(); i++) {
+   bool app = true;
+   for (index_type j = 0; (j < ne[i].antecedent.length()) && app; j++)
+     if (!set[ne[i].antecedent[j]]) app = false;
+   if (app) {
+     s->set[ne[i].consequent] = false;
+   }
+ }
+ for (index_type i = 0; i < pe.length(); i++) {
+   bool app = true;
+   for (index_type j = 0; (j < pe[i].antecedent.length()) && app; j++)
+     if (!set[pe[i].antecedent[j]]) app = false;
+   if (app) {
+     s->set[pe[i].consequent] = true;
+   }
+ }
+      }
+    }
+  }
+  s->count();
+  s->State::set_predecessor(this);
+  s->act = a.index;
+  s->eval();
+  return s;
+}
+State* ExtendedSeqProgState::new_state(const index_set& s, State* p)
+{
+  ExtendedSeqProgState* new_s =
+    new ExtendedSeqProgState(instance, heuristic, cost, s);
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* ExtendedSeqProgState::new_state(const bool_vec& s, State* p)
+{
+  ExtendedSeqProgState* new_s =
+    new ExtendedSeqProgState(instance, heuristic, cost, s);
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* ExtendedSeqProgState::copy()
+{
+  return new ExtendedSeqProgState(*this);
+}
+RelaxedSeqProgState::RelaxedSeqProgState(const RelaxedSeqProgState& s)
+  : SeqProgState(s), x_atoms(s.x_atoms), x_action(s.x_action)
+{
+}
+void RelaxedSeqProgState::RelaxedSeqProgState::compute_x_actions()
+{
+  x_action.assign_value(false, instance.n_actions());
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    if (instance.actions[k].del.first_common_element(x_atoms) != no_such_index)
+      x_action[k] = true;
+  }
+}
+void RelaxedSeqProgState::closure()
+{
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type k = 0; k < instance.n_actions(); k++) if (!x_action[k])
+      if (SeqProgState::applicable(instance.actions[k]))
+ for (index_type i = 0; i < instance.actions[k].add.length(); i++) {
+   if (!set[instance.actions[k].add[i]]) done = false;
+   set[instance.actions[k].add[i]] = true;
+ }
+  }
+  count();
+}
+bool RelaxedSeqProgState::applicable(Instance::Action& a)
+{
+  if (!x_action[a.index]) return false;
+  return SeqProgState::applicable(a);
+}
+SeqProgState* RelaxedSeqProgState::apply(Instance::Action& a)
+{
+  RelaxedSeqProgState* s = new RelaxedSeqProgState(*this);
+  for (index_type k = 0; k < a.add.length(); k++)
+    s->set[a.add[k]] = true;
+  for (index_type k = 0; k < a.del.length(); k++)
+    s->set[a.del[k]] = false;
+  s->closure();
+  s->State::set_predecessor(this);
+  s->act = a.index;
+  s->eval();
+  return s;
+}
+State* RelaxedSeqProgState::new_state(const index_set& s, State* p)
+{
+  RelaxedSeqProgState* new_s =
+    new RelaxedSeqProgState(instance, x_atoms, heuristic, cost, s);
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* RelaxedSeqProgState::new_state(const bool_vec& s, State* p)
+{
+  RelaxedSeqProgState* new_s =
+    new RelaxedSeqProgState(instance, x_atoms, heuristic, cost, s);
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* RelaxedSeqProgState::copy()
+{
+  return new RelaxedSeqProgState(*this);
+}
+hsps::rational FwdUnitHeuristic::eval(const index_set& s)
+{
+  if (s.contains(instance.goal_atoms))
+    return 0;
+  else
+    return 1;
+}
+hsps::rational FwdUnitHeuristic::eval(const bool_vec& s)
+{
+  if (s.contains(instance.goal_atoms))
+    return 0;
+  else
+    return 1;
+}
+}

--- a/pr/seq-opt-hspsf/grammar.ccx
+++ b/pr/seq-opt-hspsf/grammar.ccx
@@ -1,0 +1,10508 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class PDDL_Name;
+class PDDL_Base {
+ public:
+  static bool use_default_function_value;
+  static hsps::rational default_function_value;
+  static bool use_strict_borrow_definition;
+  static bool use_extended_borrow_definition;
+  static bool del_before_add_semantics;
+  static bool compact_resource_effects;
+  static bool compile_away_disjunctive_preconditions;
+  static bool check_precondition_consistency;
+  static bool compile_away_conditional_effects;
+  static bool compile_away_plan_constraints;
+  static bool compile_away_object_functions;
+  static bool compile_for_validator;
+  static bool create_all_atoms;
+  static bool create_all_actions;
+  static bool number_multiple_action_instances;
+  static bool exclude_all_dkel_items;
+  static string_set excluded_dkel_tags;
+  static string_set required_dkel_tags;
+  static bool strict_set_export;
+  static bool best_effort;
+  static bool write_PDDL31;
+  static bool write_warnings;
+  static bool write_info;
+  static bool write_trace;
+  static bool trace_print_context;
+  static bool name_instance_by_problem_file;
+  static const char* instance_name_prefix;
+  enum symbol_class {
+    sym_object,
+    sym_typename,
+    sym_predicate,
+    sym_object_function,
+    sym_function,
+    sym_action,
+    sym_variable,
+    sym_misc,
+    sym_preference,
+    sym_set,
+    sym_meta_variable
+  };
+  enum metric_class {
+    metric_none,
+    metric_makespan,
+    metric_minimize,
+    metric_maximize
+  };
+  enum mode_keyword {
+    md_none,
+    md_start,
+    md_end,
+    md_all,
+    md_init,
+    md_pos_goal,
+    md_neg_goal
+  };
+  enum partial_value { p_false, p_true, p_unknown };
+  enum expression_class {
+    exp_fun,
+    exp_list,
+    exp_const,
+    exp_add,
+    exp_sub,
+    exp_mul,
+    exp_div,
+    exp_time,
+    exp_preference
+  };
+  enum relation_type {
+    rel_equal,
+    rel_greater,
+    rel_greater_equal,
+    rel_less,
+    rel_less_equal
+  };
+  enum formula_class { fc_false,
+         fc_true,
+         fc_atom,
+         fc_equality,
+         fc_negation,
+         fc_conjunction,
+         fc_disjunction,
+         fc_equivalence,
+         fc_implication,
+         fc_universal,
+         fc_existential,
+         fc_list
+  };
+  struct Symbol;
+  struct TypeSymbol;
+  struct Atom;
+  struct FTerm;
+  struct FChangeAtom;
+  struct SetOf;
+  struct ListExpression;
+  struct ActionSymbol;
+  struct Reference;
+  struct IrrelevantItem;
+  typedef lvector<TypeSymbol*> type_vec;
+  typedef lvector<Atom*> atom_vec;
+  typedef lvector<FChangeAtom*> ch_atom_vec;
+  typedef lvector<SetOf*> atom_set_vec;
+  typedef lvector<Reference*> ref_vec;
+  typedef lvector<IrrelevantItem*> irrelevant_vec;
+  struct TypeSet : public type_vec {
+    TypeSet() : type_vec(0, 0) { };
+    TypeSet(const TypeSet& s) : type_vec(s) { };
+    TypeSet(TypeSymbol* t) : type_vec(t, 1) { };
+    index_type n_elements() const;
+    Symbol* get_element(index_type n);
+    bool is_object() const;
+    bool subtype_or_equal(const TypeSet& s) const;
+    bool subtype_or_equal(TypeSymbol* t) const;
+    void print(std::ostream& s) const;
+    void write_type(std::ostream& s) const;
+  };
+  struct Symbol {
+    symbol_class sym_class;
+    char* print_name;
+    TypeSet sym_types;
+    bool defined_in_problem;
+    bool visible;
+    Symbol(symbol_class c, char* n)
+      : sym_class(c), print_name(n), defined_in_problem(false), visible(true) { };
+    Symbol(char* n)
+      : sym_class(sym_object), print_name(n), defined_in_problem(false), visible(true) { };
+    void print(std::ostream& s) const;
+  };
+  typedef zero_init_pair<Symbol*> symbol_pair;
+  typedef lvector<Symbol*> symbol_vec;
+  typedef svector<Symbol*> symbol_set;
+  typedef lvector<symbol_pair> symbol_pair_vec;
+  static bool extend_substitution(Symbol* out, Symbol* in, symbol_pair_vec& u);
+  static bool print_substitution(std::ostream& s, const symbol_pair_vec& u);
+  static bool print_inequality(std::ostream& s, const symbol_pair_vec& neq);
+  static bool substitution_violates_inequality(const symbol_pair_vec& neq,
+            const symbol_pair_vec& u);
+  static index_type find_matching_atom(Atom* a, atom_vec& v);
+  static index_type find_matching_atom(Atom* a, mode_keyword m, atom_vec& v);
+  static index_type find_matching_fluent_atom
+    (FChangeAtom* a, mode_keyword m, ch_atom_vec& v);
+  struct TypeSymbol : public Symbol {
+    symbol_vec elements;
+    bool is_base_type;
+    TypeSymbol(char* n) : Symbol(sym_typename, n), elements(0, 0),
+  is_base_type(false) { };
+    void add_element(Symbol* e);
+    bool is_object() const { return (strcmp(print_name, "object") == 0); };
+    bool subtype_or_equal(TypeSymbol* t) const;
+    bool subtype_or_equal(const TypeSet& t) const;
+    void print(std::ostream& s) const;
+  };
+  struct VariableSymbol : public Symbol {
+    Symbol* value;
+    FTerm* binding;
+    VariableSymbol(char* n) : Symbol(sym_variable, n), value(0), binding(0) {};
+    bool equality_type_check(Symbol* s);
+    void print(std::ostream& s);
+  };
+  typedef lvector<VariableSymbol*> variable_vec;
+  struct ParamSymbol : public Symbol {
+    variable_vec param;
+    ParamSymbol(symbol_class c, char* n) : Symbol(c, n), param(0, 0) { };
+  };
+  struct PredicateSymbol : public ParamSymbol {
+    bool pos_pre;
+    bool neg_pre;
+    bool added;
+    bool deleted;
+    bool locked;
+    bool modded;
+    ptr_table init;
+    ptr_table pos_goal;
+    ptr_table neg_goal;
+    ptr_table pos_prop;
+    ptr_table neg_prop;
+    irrelevant_vec irr_ins;
+    PredicateSymbol(char* n) : ParamSymbol(sym_predicate, n),
+  pos_pre(false), neg_pre(false), added(false), deleted(false),
+  locked(false), modded(false), irr_ins(0, 0) { };
+    bool is_static() const { return !modded; };
+    bool is_equality() const { return (strcmp(print_name, "=") == 0); };
+    void instantiate(Instance& ins);
+    void initialise_missing(const symbol_vec& p,
+       atom_vec* created,
+       index_type i = 0);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+  };
+  struct ObjectFunctionSymbol : public ParamSymbol {
+    bool modded;
+    ptr_table init;
+    ObjectFunctionSymbol(char* n)
+      : ParamSymbol(sym_object_function, n), modded(false) { };
+    bool is_static() const { return !modded; };
+    void print(std::ostream& s);
+  };
+  struct FunctionSymbol : public ParamSymbol {
+    bool modified;
+    bool integral;
+    bool linear;
+    bool conditioned;
+    bool increased;
+    bool decreased;
+    bool assigned;
+    bool borrowed;
+    ptr_table init;
+    FunctionSymbol(char* n) : ParamSymbol(sym_function, n),
+  modified(false), integral(true), linear(true), conditioned(false),
+  increased(false), decreased(false), assigned(false), borrowed(false)
+    { };
+    bool is_static() const
+    { return !modified; };
+    bool is_reusable() const
+    { return borrowed && !increased && !decreased && !assigned; };
+    bool is_consumable() const
+    { return !borrowed && !increased && decreased && !assigned; };
+    interval eval_init_bounds(ptr_table* p, index_type i, ListExpression* r);
+    void print(std::ostream& s);
+  };
+  struct AtomBase {
+    symbol_vec param;
+    mode_keyword at;
+    hsps::rational at_time;
+    AtomBase() : param(0, 0), at(md_none), at_time(0) { };
+    AtomBase(mode_keyword t) : param(0, 0), at(t), at_time(0) { };
+    AtomBase(AtomBase* b);
+    bool equals(AtomBase& b);
+    void free_variables(variable_vec& v);
+    bool occurs(Symbol* s);
+    void fill_in_args(AtomBase* b);
+    void collect_bound_variables(variable_vec& v);
+    void insert(ptr_table& t);
+    static bool print_bindings;
+    void print(std::ostream& s) const;
+    void print_instance(std::ostream& s);
+  };
+  typedef lvector<AtomBase*> atom_base_vec;
+  struct Atom : AtomBase {
+    PredicateSymbol* pred;
+    Atom(PredicateSymbol* p) : pred(p) { };
+    Atom(PredicateSymbol* p, mode_keyword t) : AtomBase(t), pred(p) { };
+    Atom(PredicateSymbol* p, variable_vec& a, bool as_value)
+      : pred(p)
+    {
+      param.set_length(a.length());
+      for (index_type k = 0; k < a.length(); k++)
+ param[k] = (as_value ? a[k]->value : a[k]);
+    };
+    Atom(PredicateSymbol* p, Symbol* a0)
+      : pred(p)
+    {
+      param.append(a0);
+    };
+    Atom(Atom* a) : AtomBase(a), pred(a->pred) { };
+    bool equals(Atom& a);
+    bool is_static() const {
+      return ((at == md_init) ||
+       (at == md_pos_goal) ||
+       (at == md_neg_goal) ||
+       pred->is_static());
+    };
+    bool check();
+    Instance::Atom* find_prop(Instance& ins, bool neg, bool create);
+    void build(Instance& ins, bool neg, index_type p);
+    Atom* instantiate_partially();
+    partial_value partial_eval(ptr_table* r, index_type p);
+    partial_value partial_eval();
+    bool initial_value();
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    void print(std::ostream& s, bool neg) const;
+    void print(std::ostream& s) const { print(s, false); };
+  };
+  struct CAtom : public Atom {
+    symbol_pair_vec neq;
+    CAtom(Atom* a) : Atom(a), neq(symbol_pair(0, 0), 0) { };
+    CAtom(CAtom* s) : Atom(s), neq(s->neq) { };
+    CAtom(const Atom* a, symbol_pair_vec& u);
+    CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool instance_of(CAtom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(CAtom* a, symbol_pair_vec& u);
+    void print(std::ostream& s);
+  };
+  typedef lvector<CAtom*> catom_vec;
+  struct FTerm : AtomBase {
+    ObjectFunctionSymbol* fun;
+    FTerm(ObjectFunctionSymbol* f) : fun(f) { };
+    bool equals(FTerm& a);
+    void print(std::ostream& s) const;
+  };
+  struct OInitAtom : AtomBase {
+    ObjectFunctionSymbol* fun;
+    Symbol* val;
+    OInitAtom(ObjectFunctionSymbol* f) : fun(f), val(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<OInitAtom*> obj_init_atom_vec;
+  struct FInitAtom : AtomBase {
+    FunctionSymbol* fun;
+    hsps::rational val;
+    Instance::resource_ref res;
+    FInitAtom(FunctionSymbol* f) : fun(f), val(0) { };
+    FInitAtom(FChangeAtom* a);
+    bool is_static() const { return fun->is_static(); };
+    void print(std::ostream& s);
+  };
+  typedef lvector<FInitAtom*> fun_init_atom_vec;
+  struct Expression;
+  typedef lvector<Expression*> exp_vec;
+  struct Expression {
+    expression_class exp_class;
+    Expression(expression_class c) : exp_class(c) { };
+    static bool print_nary;
+    bool is_static();
+    bool is_constant();
+    bool is_integral();
+    hsps::rational eval_static();
+    bool eval_partial(hsps::rational& val);
+    interval eval_bounds();
+    hsps::rational eval_init();
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    hsps::rational eval_delta(Symbol* preference, hsps::rational p_value, hsps::rational d_value);
+    Expression* copy();
+    Expression* simplify();
+    void collect_constants(exp_vec& c);
+    void mark_functions_in_condition();
+    hsps::rational integrify();
+    void substitute_for_time(Expression* e);
+    Expression* substitute_for_preference(Symbol* n, Expression* e);
+    bool equals(Expression* e);
+    void print_sum(std::ostream& s, bool grnd);
+    void print_product(std::ostream& s, bool grnd);
+    void print(std::ostream& s, bool grnd);
+  };
+  struct ListExpression : public Expression {
+    Symbol* sym;
+    ListExpression* rest;
+    ListExpression(Symbol* s, ListExpression* r) :
+      Expression(exp_list), sym(s), rest(r) { };
+    bool match(AtomBase* atom);
+  };
+  struct FunctionExpression : public Expression {
+    FunctionSymbol* fun;
+    ListExpression* args;
+    FunctionExpression(FunctionSymbol* f, ListExpression* a) :
+      Expression(exp_fun), fun(f), args(a) { };
+    bool match(FChangeAtom* atom);
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    FChangeAtom* make_atom_base();
+  };
+  struct ConstantExpression : public Expression {
+    hsps::rational val;
+    ConstantExpression(hsps::rational v) :
+      Expression(exp_const), val(v) { };
+  };
+  struct TimeExpression : public Expression {
+    Expression* time_exp;
+    TimeExpression() :
+      Expression(exp_time), time_exp(0) { };
+    TimeExpression(Expression* e) :
+      Expression(exp_time), time_exp(e) { };
+  };
+  struct BinaryExpression : public Expression {
+    Expression* first;
+    Expression* second;
+    BinaryExpression(expression_class c, Expression* e1, Expression* e2) :
+      Expression(c), first(e1), second(e2) { };
+  };
+  struct PreferenceExpression : public Expression {
+    Symbol* name;
+    PreferenceExpression(Symbol* n) :
+      Expression(exp_preference), name(n) { };
+  };
+  struct Relation {
+    relation_type rel;
+    mode_keyword at;
+    Expression* first;
+    Expression* second;
+    Relation(relation_type r, Expression* e1, Expression* e2) :
+      rel(r), at(md_none), first(e1), second(e2) { };
+    Relation(relation_type r, mode_keyword m, Expression* e1, Expression* e2) :
+      rel(r), at(m), first(e1), second(e2) { };
+    Expression* match_gteq_constant(FChangeAtom* atom);
+    FunctionExpression* match_lteq_fun(FChangeAtom* atom);
+    bool is_static();
+    partial_value partial_eval();
+    void print(std::ostream& s, bool grnd);
+  };
+  typedef lvector<Relation*> relation_vec;
+  struct FChangeAtom : AtomBase {
+    FunctionSymbol* fun;
+    Expression* val;
+    FChangeAtom(FunctionSymbol* f) :
+      fun(f), val(0) { };
+    FChangeAtom(FunctionSymbol* f, mode_keyword t) :
+      AtomBase(t), fun(f), val(0) { };
+    FChangeAtom(FChangeAtom* a, hsps::rational v) :
+      AtomBase(a), fun(a->fun), val(new ConstantExpression(v)) { };
+    bool equals(FChangeAtom& a);
+    bool fluent_equals(FChangeAtom& a);
+    bool fluent_and_mode_equals(FChangeAtom& a);
+    FChangeAtom* find_fluent_equals(ch_atom_vec& vec);
+    Instance::Resource* find_resource(Instance& ins);
+    void print(std::ostream& s);
+  };
+  struct Formula {
+    formula_class fc;
+    Formula(formula_class c) : fc(c) { };
+    void rename_variables_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_variables_2(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_2(PDDL_Base::symbol_pair_vec& sub);
+    Formula* simplify();
+    void write_otter(std::ostream& s) const;
+    void print(std::ostream& s) const;
+    void untype(PDDL_Base* base);
+  };
+  typedef lvector<Formula*> formula_vec;
+  struct AFormula : public Formula, public Atom {
+    AFormula(Atom* a) :
+      Formula(fc_atom), Atom(a) { };
+    AFormula(PredicateSymbol* p) :
+      Formula(fc_atom), Atom(p) { };
+    AFormula(PredicateSymbol* p, variable_vec& a) :
+      Formula(fc_atom), Atom(p, a, false) { };
+    void print(std::ostream& s) const;
+    void write_otter(std::ostream& s) const;
+  };
+  struct EqFormula : public Formula {
+    Symbol* t1;
+    Symbol* t2;
+    EqFormula(Symbol* s1, Symbol* s2) :
+      Formula(fc_equality), t1(s1), t2(s2) { };
+    void write_otter(std::ostream& s) const;
+  };
+  struct NFormula : public Formula {
+    Formula* f;
+    NFormula(Formula* g) : Formula(fc_negation), f(g) { };
+  };
+  struct BFormula : public Formula {
+    Formula* f1;
+    Formula* f2;
+    BFormula(formula_class c, Formula* g1, Formula* g2) :
+      Formula(c), f1(g1), f2(g2) { };
+  };
+  struct CFormula : public Formula {
+    formula_vec parts;
+    CFormula(formula_class c) : Formula(c), parts(0, 0) { };
+    CFormula(formula_class c, Formula* f1, Formula* f2) :
+      Formula(c), parts(0, 0)
+    {
+      parts.append(f1);
+      parts.append(f2);
+    };
+    void add(Formula* f) { parts.append(f); };
+    void add(formula_vec& f) { parts.append(f); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct QFormula : public Formula {
+    variable_vec vars;
+    Formula* f;
+    QFormula(formula_class c) : Formula(c), vars(0, 0), f(0) { };
+    QFormula(formula_class c, Formula* g) : Formula(c), vars(0, 0), f(g) { };
+    QFormula(formula_class c, variable_vec& v, Formula* g) :
+      Formula(c), vars(0, 0), f(g)
+    {
+      for (index_type k = 0; k < v.length(); k++) vars.append(v[k]);
+    };
+    void add(PDDL_Base::VariableSymbol* v) { vars.append(v); };
+    void add(PDDL_Base::variable_vec& v) { vars.append(v); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct TypeConstraint {
+    VariableSymbol* var;
+    TypeSymbol* typ;
+    TypeConstraint(VariableSymbol* v, TypeSymbol* t) : var(v), typ(t) { };
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+  };
+  typedef lvector<TypeConstraint*> type_constraint_vec;
+  struct Context {
+    variable_vec param;
+    atom_vec pos_con;
+    atom_vec neg_con;
+    type_constraint_vec type_con;
+    Context() : param(0, 0), pos_con(0, 0), neg_con(0, 0), type_con(0, 0) { };
+    Context(const Context* c) : param(c->param), pos_con(c->pos_con),
+  neg_con(c->neg_con), type_con(c->type_con) { };
+    bool context_is_static() const;
+    bool occurs_in_context(Symbol* s);
+    void clear_arguments();
+    void set_mode(mode_keyword m);
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+    void print_assignment(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct DKEL_Item : public Context {
+    char* item_name;
+    Symbol* name;
+    string_set item_tags;
+    bool defined_in_problem;
+    bool included;
+    DKEL_Item(char* name) : item_name(name), name(0),
+  defined_in_problem(false), included(true) { };
+    DKEL_Item(const DKEL_Item* i) : Context(i), item_name(i->item_name),
+  name(i->name), item_tags(i->item_tags),
+  defined_in_problem(i->defined_in_problem), included(i->included) { };
+    bool item_is_included(string_set& ex_tags, string_set& req_tags);
+    void print_begin(std::ostream& s);
+    void print_end(std::ostream& s);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SetOf : public Context {
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    SetOf() : pos_atoms(0, 0), neg_atoms(0, 0) { };
+    SetOf(const SetOf* s)
+      : Context(s), pos_atoms(s->pos_atoms), neg_atoms(s->neg_atoms)
+    { };
+    SetOf(Atom* a)
+    { pos_atoms.append(a); };
+    SetOf(Atom* a, bool n)
+    { if (n) neg_atoms.append(a); else pos_atoms.append(a); };
+    bool is_static() const;
+    void set_mode(mode_keyword m);
+    partial_value partial_eval(bool as_disjunction = false);
+    partial_value partial_eval(index_type p, bool as_disjunction = false);
+    void instantiate_as_set(Instance& ins, index_set& s);
+    void instantiate_as_effect(Instance& ins, index_set& s_add,
+          index_set& s_del);
+    void instantiate_conditional(Instance& ins, rule_set& s_pos,
+     rule_set& s_neg);
+    SetOf* instantiate_partially();
+    void compile(atom_vec& pos_ins, atom_vec& neg_ins, index_type p);
+    void compile_non_static(atom_set_vec& ins, index_type p);
+    void print(std::ostream& s);
+    void print_as_disjunction(std::ostream& s);
+    void build_set(Instance& ins, index_set& s, index_type p);
+    void build_effect(Instance& ins, index_set& s_add, index_set& s_del,
+        index_type p);
+    void build_conditional(Instance& ins, rule_set& s_pos, rule_set& s_neg,
+      index_type p);
+  };
+  struct QCNumericEffect : public Context {
+    FChangeAtom* atom;
+    QCNumericEffect() : atom(0) { };
+    QCNumericEffect(FChangeAtom* a) : atom(a) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<QCNumericEffect*> qc_numeric_effect_vec;
+  enum set_constraint_keyword { sc_at_least, sc_at_most, sc_exactly };
+  struct SetConstraint : public DKEL_Item {
+    set_constraint_keyword sc_type;
+    index_type sc_count;
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    atom_set_vec atom_sets;
+    SetConstraint() : DKEL_Item(":invariant"), sc_type(sc_at_least),
+  sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0), atom_sets(0, 0) { };
+    SetConstraint(const DKEL_Item* item) : DKEL_Item(item),
+  sc_type(sc_at_least), sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0),
+  atom_sets(0, 0) { };
+    void build(Instance& ins, index_type p);
+    void instantiate(Instance& ins);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InvariantFormula : public DKEL_Item {
+    Formula* f;
+    InvariantFormula(Formula* g)
+      : DKEL_Item(":invariant"), f(g) { };
+    InvariantFormula(const DKEL_Item* item, Formula* g)
+      : DKEL_Item(item), f(g) { };
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct Reference : public AtomBase {
+    Symbol* name;
+    bool neg;
+    bool has_args;
+    index_set index;
+    Reference(Symbol* n) : name(n), neg(false), has_args(true) { };
+    Reference(Symbol* n, bool ng, bool ha)
+      : name(n), neg(ng), has_args(ha) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    void* find_action();
+    void find(const name_vec& names, index_set& ind);
+    Reference* instantiate_partially();
+    void print(std::ostream& s);
+  };
+  struct IrrelevantItem : public DKEL_Item {
+    Reference* entity;
+    IrrelevantItem() : DKEL_Item(":irrelevant"), entity(0) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    IrrelevantItem* instantiate_partially();
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SequentialTaskNet : public Context {
+    ref_vec tasks;
+    ActionSymbol* abs_act;
+    SequentialTaskNet() : tasks(0, 0), abs_act(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<SequentialTaskNet*> task_net_vec;
+  struct SetSymbol : public Symbol {
+    ptr_table set_table;
+    lvector<index_set*> sets;
+    name_vec names;
+    SetSymbol(char* n) : Symbol(sym_set, n), sets(0, 0), names(0, 0) { };
+  };
+  struct SetName : public AtomBase {
+    SetSymbol* sym;
+    SetName(SetSymbol* s) : sym(s) { };
+    index_set* find();
+    SetName* instantiate_partially();
+    void print(std::ostream& s);
+    void print_instance(std::ostream& s);
+  };
+  struct ActionSymbol : public ParamSymbol {
+    atom_vec pos_pre;
+    atom_vec neg_pre;
+    atom_set_vec set_pre;
+    atom_set_vec dis_pre;
+    relation_vec num_pre;
+    atom_vec adds;
+    atom_vec dels;
+    atom_set_vec set_eff;
+    atom_vec cons;
+    atom_set_vec cond_eff;
+    atom_vec locks;
+    atom_vec enables;
+    ch_atom_vec reqs;
+    ch_atom_vec incs;
+    ch_atom_vec decs;
+    ch_atom_vec fass;
+    qc_numeric_effect_vec qc_incs;
+    qc_numeric_effect_vec qc_decs;
+    qc_numeric_effect_vec qc_fass;
+    Expression* dmin;
+    Expression* dmax;
+    irrelevant_vec irr_ins;
+    ref_vec refs;
+    task_net_vec exps;
+    ptr_table instances;
+    SetName* part;
+    const char* assoc;
+    ActionSymbol(char* n) : ParamSymbol(sym_action, n), pos_pre(0, 0),
+  neg_pre(0, 0), set_pre(0, 0), dis_pre(0, 0), num_pre(0, 0),
+  adds(0, 0), dels(0, 0), set_eff(0, 0), cons(0, 0), cond_eff(0, 0),
+  locks(0, 0), enables(0, 0), reqs(0, 0), incs(0, 0), decs(0, 0),
+  fass(0, 0), qc_incs(0, 0), qc_decs(0, 0), qc_fass(0, 0), dmin(0),
+  dmax(0), irr_ins(0, 0), refs(0, 0), exps(0, 0), part(0), assoc(0) { };
+    void build(Instance& ins, index_type p, Expression* cost_exp);
+    Instance::Action& build_action(Instance& ins,
+       PDDL_Name* name,
+       index_type& count,
+       const index_set& pre,
+       const index_set& add,
+       const index_set& del,
+       const index_set& lck,
+       const index_cost_vec& r_use,
+       const index_cost_vec& r_cons,
+       hsps::rational dmin,
+       hsps::rational dmax,
+       hsps::rational dur,
+       hsps::rational cost);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          index_vec& s,
+          index_type p);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc);
+    void build_actions_with_dc_and_ce(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          const rule_set& pce,
+          const rule_set& nce,
+          const bool_vec& ece);
+    index_type param_index(VariableSymbol* p);
+    void get_param_inequalities(symbol_pair_vec& neq);
+    void set_arguments(const symbol_vec& args);
+    void set_arguments(const ptr_table::key_vec& args);
+    void clear_arguments();
+    void* find_instance();
+    bool is_abstract();
+    void post_process();
+    void instantiate(Instance& ins, Expression* cost_exp);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InputPlanStep {
+    Reference* act;
+    hsps::rational start_time;
+    InputPlanStep() : act(0), start_time(0) { };
+    InputPlanStep(Reference* a, hsps::rational t) : act(a), start_time(t) { };
+  };
+  struct InputPlan {
+    Symbol* name;
+    bool is_opt;
+    lvector<InputPlanStep*> steps;
+    InputPlan() : name(0), is_opt(false), steps(0, 0) { };
+    bool export_to_instance(Instance& ins, const index_vec& map, Plan& p);
+    void print(std::ostream& s);
+  };
+  struct HTableEntry {
+    atom_vec atoms;
+    bool_vec neg;
+    hsps::rational cost;
+    bool opt;
+    HTableEntry() : atoms(0, 0), neg(false, 0), cost(0), opt(false) { };
+  };
+  struct SimpleReferenceSet : public Context {
+    Reference* ref;
+    SimpleReferenceSet(Reference* r) : ref(r) { };
+    bool build(const name_vec& names, index_set& set, index_type p);
+    void print(std::ostream& s);
+  };
+  typedef lvector<SimpleReferenceSet*> refs_vec;
+  struct ReferenceSet : public Context {
+    refs_vec refs;
+    Symbol* name;
+    ReferenceSet() : refs(0, 0), name(0) { };
+    void add(SimpleReferenceSet* ref) { refs.append(ref); };
+    void build(const name_vec& names, index_set_vec& sets, index_type p);
+    void print(std::ostream& s);
+  };
+  struct CPG {
+    atom_vec atoms;
+    index_vec atom_first_arg;
+    bool_vec neg;
+    symbol_vec args;
+    type_vec arg_types;
+    CPG() : atoms(0, 0), neg(false, 0), args(0, 0), arg_types(0, 0) { };
+    CPG(CPG& g, index_vec& s);
+    void make_key(ptr_table::key_vec& key);
+    void make_typed_key(ptr_table::key_vec& key);
+    void make_parameters(variable_vec& params);
+    ListExpression* make_argument_list(index_type first);
+    void add_asserting_effects(ActionSymbol* act,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          bool strict);
+    void add_destroying_effects(ActionSymbol* act,
+    ParamSymbol* pf,
+    PredicateSymbol* p,
+    bool p_val,
+    PredicateSymbol* g,
+    FunctionSymbol* f,
+    Expression* f_val,
+    bool strict);
+    bool initial_value();
+    void add_asserting_effects(index_type c_atom,
+          ActionSymbol* act,
+          index_type c_eff,
+          bool_vec& sat,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          symbol_pair_vec& eq,
+          symbol_pair_vec& neq,
+          bool strict);
+    void add_propositional_effect(ActionSymbol* act,
+      PredicateSymbol* p, bool p_val,
+      index_type c_atom, Atom* a_eff,
+      bool strict);
+    void add_fluent_effect(ActionSymbol* act,
+      FunctionSymbol* f, Expression* f_val,
+      index_type c_atom, Atom* a_eff);
+    void add_effect_conditions(Context* e, ParamSymbol* pf, bool_vec& sat,
+          symbol_vec& subs, symbol_pair_vec& eq,
+          symbol_pair_vec& neq);
+  };
+  enum goal_class { goal_pos_atom, goal_neg_atom, goal_relation, goal_task,
+      goal_conjunction, goal_disjunction, goal_forall,
+      goal_exists, goal_always, goal_sometime,
+      goal_at_most_once, goal_within, goal_always_within,
+      goal_sometime_before, goal_sometime_after };
+  struct Goal {
+    goal_class g_class;
+    Goal(goal_class c) : g_class(c) { };
+    bool is_state();
+    bool is_propositional();
+    bool is_singular();
+    bool makeCPG(CPG& g);
+    bool makeCPG(CPG& g, index_vec& s);
+    void instantiate(Instance& ins, hsps::rational deadline);
+    void instantiate(Instance& ins, index_set& set, Symbol* p, index_type i);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Goal*> goal_vec;
+  struct AtomicGoal : public Goal {
+    Atom* atom;
+    AtomicGoal(Atom* a, bool neg)
+      : Goal(neg ? goal_neg_atom : goal_pos_atom), atom(a) { };
+    void print(std::ostream& s);
+  };
+  struct NumericGoal : public Goal {
+    Relation* rel;
+    NumericGoal(Relation* r) : Goal(goal_relation), rel(r) { };
+    void print(std::ostream& s);
+  };
+  struct TaskGoal : public Goal {
+    Reference* task;
+    TaskGoal(Reference* r) : Goal(goal_task), task(r) { };
+    void print(std::ostream& s);
+  };
+  struct ConjunctiveGoal : public Goal {
+    goal_vec goals;
+    ConjunctiveGoal() : Goal(goal_conjunction), goals(0, 0) { };
+    ConjunctiveGoal(goal_class gc) : Goal(gc), goals(0, 0) { };
+    void print(std::ostream& s);
+  };
+  struct DisjunctiveGoal : public ConjunctiveGoal {
+    DisjunctiveGoal() : ConjunctiveGoal(goal_disjunction) { };
+    void print(std::ostream& s);
+  };
+  struct QuantifiedGoal : public Goal, public Context {
+    Goal* goal;
+    QuantifiedGoal() : Goal(goal_forall), goal(0) { };
+    QuantifiedGoal(goal_class gc) : Goal(gc), goal(0) { };
+    void print(std::ostream& s);
+  };
+  struct SimpleSequenceGoal : public Goal {
+    Goal* constraint;
+    SimpleSequenceGoal(goal_class c, Goal* g) : Goal(c), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredSequenceGoal : public Goal {
+    Goal* trigger;
+    Goal* constraint;
+    TriggeredSequenceGoal(goal_class c, Goal* t, Goal* g)
+      : Goal(c), trigger(t), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct DeadlineGoal : public Goal {
+    Goal* goal;
+    hsps::rational at;
+    DeadlineGoal(hsps::rational t, Goal* g) : Goal(goal_within), goal(g), at(t) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredDeadlineGoal : public Goal {
+    Goal* trigger;
+    Goal* goal;
+    hsps::rational delay;
+    TriggeredDeadlineGoal(Goal* t, hsps::rational d, Goal* g)
+      : Goal(goal_always_within), trigger(t), delay(d), goal(g) { };
+    void print(std::ostream& s);
+  };
+  struct Preference {
+    Symbol* name;
+    Goal* goal;
+    Preference() : name(0), goal(0) { };
+    Preference(Symbol* n) : name(n), goal(0) { };
+    Preference(Symbol* n, Goal* g) : name(n), goal(g) { };
+    bool is_state() { return goal->is_state(); };
+    bool is_propositional() { return goal->is_propositional(); };
+    hsps::rational value(metric_class metric_type, Expression* m);
+    void instantiate(SoftInstance& ins,
+       metric_class metric_type,
+       Expression* m);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Preference*> preference_vec;
+  char* domain_name;
+  char* problem_name;
+  char* domain_file;
+  char* problem_file;
+  bool ready_to_instantiate;
+  char* problem_file_basename();
+  char* enum_problem_filename(const char* s, index_type i);
+  StringTable& tab;
+  type_vec dom_types;
+  type_vec dom_base_types;
+  TypeSymbol* dom_top_type;
+  symbol_vec dom_constants;
+  PredicateSymbol* dom_eq_pred;
+  PredicateSymbol* dom_assign_pred;
+  Symbol* dom_undefined_obj;
+  static PredicateSymbol* current_eq_predicate;
+  lvector<PredicateSymbol*> dom_predicates;
+  lvector<ObjectFunctionSymbol*> dom_object_functions;
+  lvector<FunctionSymbol*> dom_functions;
+  lvector<ActionSymbol*> dom_actions;
+  lvector<SetConstraint*> dom_sc_invariants;
+  lvector<InvariantFormula*> dom_f_invariants;
+  lvector<IrrelevantItem*> dom_irrelevant;
+  atom_vec dom_init;
+  obj_init_atom_vec dom_obj_init;
+  fun_init_atom_vec dom_fun_init;
+  goal_vec dom_goals;
+  preference_vec dom_preferences;
+  ref_vec goal_tasks;
+  metric_class metric_type;
+  Expression* metric;
+  hsps::rational serial_length;
+  hsps::rational parallel_length;
+  lvector<InputPlan*> input_plans;
+  lvector<HTableEntry*> h_table;
+  lvector<ReferenceSet*> input_sets;
+  lvector<SetSymbol*> partitions;
+  static ActionSymbol* src_action_symbol(ptr_pair* p);
+  TypeSymbol* find_type(const char* name);
+  PredicateSymbol* find_predicate(const char* name);
+  FunctionSymbol* find_function(const char* name);
+  bool find_initial_fact(const char* pname, const symbol_vec& arg);
+  hsps::rational find_function_value(const char* fname, const symbol_vec& arg);
+  index_type find_element_satisfying(const symbol_vec& elements,
+         const char* pname,
+         symbol_vec& arg,
+         index_type element_arg_p);
+  void find_elements_satisfying(const symbol_vec& elements,
+    const char* pname,
+    symbol_vec& arg,
+    index_type element_arg_p,
+    index_set& sats);
+  Atom* goal_to_atom(Goal* g);
+  bool goal_to_atom_vec(Goal* g, atom_vec& av);
+  PDDL_Base(StringTable& t);
+  ~PDDL_Base();
+  void set_variable_type(variable_vec& vec, TypeSymbol* t);
+  void set_variable_type(variable_vec& vec, const TypeSet& t);
+  void set_type_type(type_vec& vec, TypeSymbol* t);
+  void set_constant_type(symbol_vec& vec, TypeSymbol* t);
+  void clear_context(variable_vec& vec);
+  void clear_context(variable_vec& vec, index_type n_min, index_type n_max);
+  bool merge_type_vectors(type_vec& v0, type_vec& v1);
+  void make_parameters(type_vec& t, const char* prefix, variable_vec& v);
+  Atom* make_atom_from_prop(ptr_pair& src, bool& neg);
+  Symbol* gensym(symbol_class c, const char* p, const TypeSet& t);
+  Symbol* gensym(symbol_class c, const char* p, TypeSymbol* t);
+  Symbol* gensym_i(symbol_class c, const char* p, index_type i, TypeSymbol* t);
+  Symbol* gensym_s(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t);
+  Symbol* gensym_n(symbol_class c, const char* p, const Name* n, TypeSymbol* t);
+  void new_variable_substitution(Atom* a,
+     symbol_pair_vec& u,
+     symbol_pair_vec& new_u);
+  Atom* new_meta_atom(PredicateSymbol* p);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& u);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+  void extend_cc(CAtom* l, catom_vec& m, catom_vec& nm,
+   lvector< swapable_pair<catom_vec> >& x,
+   index_type d);
+  void find_cc();
+  void post_process();
+  void instantiate(Instance& ins);
+  void instantiate_soft(SoftInstance& ins);
+  void instantiate_atom_set(Instance& ins, atom_vec& a, index_set& s);
+  index_type n_plans() const { return input_plans.length(); };
+  bool export_plan(index_type i, Instance& ins, const index_vec& map, Plan& p);
+  bool export_plan(index_type i, Instance& ins, Plan& p);
+  void export_heuristic(Instance& ins,
+   const index_vec& map,
+   bool opt_maximize,
+   Heuristic& h);
+  void export_sets(const name_vec& names, index_set_vec& sets);
+  void export_action_partitions(name_vec& names, index_set_vec& sets);
+  void lift_DKEL_Items(const Instance& ins);
+  PredicateSymbol* find_type_predicate(Symbol* type_sym);
+  void untype();
+  void compile_preferences();
+  void compile_constraints_1();
+  void compile_constraints_2();
+  void select_preferences(const bool_vec& sel);
+  void metric_to_goal(hsps::rational bound);
+  void compile_set_conditions_and_effects();
+  void compile_object_functions();
+  Expression* replace_violations_1(Expression* exp,
+       CPG* cpg[],
+       FunctionSymbol* f_violated[]);
+  Goal* compile_constraint_1(Goal* g, index_type i, const Symbol* n,
+        symbol_vec& aut_states, index_type n_ra);
+  AtomicGoal* make_automaton_type_a(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_e(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_o(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sb(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sa(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  void make_automaton_transition(Symbol* s_from,
+     Symbol* s_to,
+     bool is_accept,
+     CPG* f, bool neg_f,
+     CPG* g, bool neg_g,
+     PredicateSymbol* p_state,
+     PredicateSymbol* p_accept,
+     PredicateSymbol* p_synch);
+  void add_precondition_formula(ActionSymbol* a, CPG* f, bool is_neg);
+  Goal* compile_constraint_2(Goal* g, const Symbol* n);
+  Goal* compile_always_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_sometime_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_at_most_once_constraint(SimpleSequenceGoal* g,
+     const Symbol* n);
+  Goal* compile_sometime_before_constraint(TriggeredSequenceGoal* g,
+        const Symbol* n);
+  void compile_set_conditions_and_effects(ActionSymbol* act);
+  void compile_set_conditions_and_effects(ActionSymbol* act,
+       variable_vec& i_param,
+       variable_vec& d_param,
+       index_type p);
+  Atom* make_binding_atom(VariableSymbol* v);
+  void compile_object_functions(ActionSymbol* act, Symbol* undefined_value);
+  void compile_object_functions_for_validator(ActionSymbol* act);
+  Goal* compile_object_functions(Goal* g);
+  void write_declarations(std::ostream& s);
+  void write_action(std::ostream& s, ActionSymbol* act);
+  void write_set_precondition(std::ostream& s, SetOf* set);
+  void write_disjunctive_set_precondition(std::ostream& s, SetOf* set);
+  void write_set_effect(std::ostream& s, SetOf* set);
+  void write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn);
+  void write_objects(std::ostream& s, bool defined_in_problem);
+  void write_init(std::ostream& s);
+  void write_goal(std::ostream& s);
+  void write_metric(std::ostream& s);
+  void write_dkel_items(std::ostream& s, bool defined_in_problem);
+  void write_domain_begin(std::ostream& s);
+  void write_problem_begin(std::ostream& s);
+  void write_end(std::ostream& s);
+  void write_dkel_domain(std::ostream& s, bool leave_open);
+  void write_dkel_problem(std::ostream& s, bool leave_open);
+  void write_plans(std::ostream& s);
+  void write_heuristic_table(std::ostream& s);
+  void write_sets(std::ostream& s);
+  void print(std::ostream& s);
+};
+class InstanceName : public Name {
+  char* domain_name;
+  char* problem_name;
+ public:
+  InstanceName(char* d, char* p) : domain_name(d), problem_name(p) { };
+  virtual ~InstanceName() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class PDDL_Name : public Name {
+ protected:
+  bool neg;
+  PDDL_Base::Symbol* sym;
+  PDDL_Base::symbol_vec arg;
+  bool vis;
+  bool_vec avis;
+ public:
+  static char catc;
+  static bool obscure_symbol_names;
+  PDDL_Name(PDDL_Base::Symbol* s)
+    : neg(false), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, bool n)
+    : neg(n), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::symbol_vec a, bool n)
+    : neg(n), sym(s), arg(a), vis(true), avis(true, a.length()) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n);
+  void add(PDDL_Base::Symbol* s);
+  void add(PDDL_Base::Symbol* s, bool v);
+  PDDL_Base::Symbol* symbol() { return sym; };
+  PDDL_Base::symbol_vec& args() { return arg; };
+  index_type argc() { return arg.length(); };
+  bool is_neg() { return neg; };
+  virtual ~PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class Numbered_PDDL_Name : public PDDL_Name {
+  index_type copy;
+ public:
+  Numbered_PDDL_Name(PDDL_Base::Symbol* sym, index_type c)
+    : PDDL_Name(sym), copy(c) { };
+  Numbered_PDDL_Name(PDDL_Name* n, index_type c);
+  virtual ~Numbered_PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+};
+}
+#include <sstream>
+typedef union {
+  hsps::StringTable::Cell* sym;
+  hsps::PDDL_Base::Expression* exp;
+  hsps::PDDL_Base::ListExpression* lst;
+  hsps::PDDL_Base::Relation* rel;
+  hsps::PDDL_Base::Goal* goal;
+  hsps::PDDL_Base::Formula* ff;
+  hsps::PDDL_Base::mode_keyword tkw;
+  hsps::PDDL_Base::relation_type rkw;
+  hsps::PDDL_Base::set_constraint_keyword sckw;
+  hsps::rational::XR rval;
+  int ival;
+  char* sval;
+} yy_PDDL_Parser_stype;
+class PDDL_Parser : public hsps::PDDL_Base
+{
+public:
+enum YY_PDDL_Parser_ENUM_TOKEN { YY_PDDL_Parser_NULL_TOKEN=0
+ ,TK_OPEN=258
+ ,TK_CLOSE=259
+ ,TK_OPEN_SQ=260
+ ,TK_CLOSE_SQ=261
+ ,TK_GREATER=262
+ ,TK_GREATEQ=263
+ ,TK_LESS=264
+ ,TK_LESSEQ=265
+ ,TK_COLON=266
+ ,TK_HASHT=267
+ ,TK_EQ=268
+ ,TK_HYPHEN=269
+ ,TK_PLUS=270
+ ,TK_MUL=271
+ ,TK_DIV=272
+ ,TK_UMINUS=273
+ ,TK_NEW_SYMBOL=274
+ ,TK_OBJ_SYMBOL=275
+ ,TK_TYPE_SYMBOL=276
+ ,TK_PRED_SYMBOL=277
+ ,TK_OBJFUN_SYMBOL=278
+ ,TK_FUN_SYMBOL=279
+ ,TK_VAR_SYMBOL=280
+ ,TK_ACTION_SYMBOL=281
+ ,TK_MISC_SYMBOL=282
+ ,TK_KEYWORD=283
+ ,TK_NEW_VAR_SYMBOL=284
+ ,TK_PREFERENCE_SYMBOL=285
+ ,TK_SET_SYMBOL=286
+ ,TK_FLOAT=287
+ ,TK_INT=288
+ ,TK_STRING=289
+ ,KW_REQS=290
+ ,KW_CONSTANTS=291
+ ,KW_PREDS=292
+ ,KW_FUNS=293
+ ,KW_TYPES=294
+ ,KW_DEFINE=295
+ ,KW_DOMAIN=296
+ ,KW_ACTION=297
+ ,KW_PROCESS=298
+ ,KW_EVENT=299
+ ,KW_ARGS=300
+ ,KW_PRE=301
+ ,KW_COND=302
+ ,KW_AT_START=303
+ ,KW_AT_END=304
+ ,KW_OVER_ALL=305
+ ,KW_EFFECT=306
+ ,KW_INVARIANT=307
+ ,KW_DURATION=308
+ ,KW_AND=309
+ ,KW_OR=310
+ ,KW_EXISTS=311
+ ,KW_FORALL=312
+ ,KW_IMPLY=313
+ ,KW_NOT=314
+ ,KW_WHEN=315
+ ,KW_EITHER=316
+ ,KW_PROBLEM=317
+ ,KW_FORDOMAIN=318
+ ,KW_OBJECTS=319
+ ,KW_INIT=320
+ ,KW_GOAL=321
+ ,KW_LENGTH=322
+ ,KW_SERIAL=323
+ ,KW_PARALLEL=324
+ ,KW_METRIC=325
+ ,KW_MINIMIZE=326
+ ,KW_MAXIMIZE=327
+ ,KW_DURATION_VAR=328
+ ,KW_TOTAL_TIME=329
+ ,KW_INCREASE=330
+ ,KW_DECREASE=331
+ ,KW_SCALE_UP=332
+ ,KW_SCALE_DOWN=333
+ ,KW_ASSIGN=334
+ ,KW_TAG=335
+ ,KW_NAME=336
+ ,KW_VARS=337
+ ,KW_SET_CONSTRAINT=338
+ ,KW_SETOF=339
+ ,KW_AT_LEAST_N=340
+ ,KW_AT_MOST_N=341
+ ,KW_EXACTLY_N=342
+ ,KW_CONTEXT=343
+ ,KW_FORMULA=344
+ ,KW_IRRELEVANT=345
+ ,KW_PLAN=346
+ ,KW_HEURISTIC=347
+ ,KW_OPT=348
+ ,KW_INF=349
+ ,KW_FACT=350
+ ,KW_SET=351
+ ,KW_EXPANSION=352
+ ,KW_TASKS=353
+ ,KW_PREFERENCE=354
+ ,KW_VIOLATED=355
+ ,KW_WITHIN=356
+ ,KW_ASSOC=357
+ ,KW_CONSTRAINTS=358
+ ,KW_ALWAYS=359
+ ,KW_SOMETIME=360
+ ,KW_AT_MOST_ONCE=361
+ ,KW_SOMETIME_BEFORE=362
+ ,KW_SOMETIME_AFTER=363
+ ,KW_ALWAYS_WITHIN=364
+ ,KW_IFF=365
+ ,KW_FALSE=366
+ ,KW_TRUE=367
+ ,KW_NUMBER=368
+ ,KW_UNDEFINED=369
+     };
+public:
+ int yyparse (void);
+ virtual void log_error(char *msg) = 0;
+ virtual int next_token() = 0;
+ yy_PDDL_Parser_stype yylval;
+ int yynerrs;
+ int yychar;
+ int yydebug;
+public:
+ PDDL_Parser(hsps::StringTable& t);
+public:
+ public: virtual std::ostream& at_position(std::ostream& s) = 0; virtual char* current_file() = 0; bool error_flag; private: hsps::PDDL_Base::variable_vec current_param; hsps::index_vec stored_n_param; hsps::PDDL_Base::TypeSet current_type_set; hsps::index_type last_n_functions; hsps::PDDL_Base::AtomBase* current_atom; hsps::PDDL_Base::atom_base_vec current_atom_stack; hsps::PDDL_Base::Context* current_context; hsps::lvector<Context*> stored_context; hsps::PDDL_Base::DKEL_Item* current_item; hsps::lvector<ConjunctiveGoal*> current_goal; hsps::PDDL_Base::Symbol* current_preference_name; hsps::PDDL_Base::HTableEntry* current_entry; char* current_plan_file; hsps::index_type n_plans_in_current_file;
+};
+PDDL_Parser::PDDL_Parser(hsps::StringTable& t) : hsps::PDDL_Base(t), error_flag(false), current_param(0, 0), stored_n_param(0, 0), current_atom(0), current_atom_stack(0, 0), current_context(0), stored_context(0, 0), current_item(0), current_goal(0, 0), current_preference_name(0), current_entry(0), current_plan_file(0), n_plans_in_current_file(0)
+{
+yydebug=0;
+;
+};
+static const char yytranslate[] = { 0,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 2, 1, 2, 3, 4, 5,
+     6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+    26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+    36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+    46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+    56, 57, 58, 59, 60, 61, 62, 63, 64, 65,
+    66, 67, 68, 69, 70, 71, 72, 73, 74, 75,
+    76, 77, 78, 79, 80, 81, 82, 83, 84, 85,
+    86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
+    96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
+   106, 107, 108, 109, 110, 111, 112, 113, 114
+};
+static const short yyprhs[] = { 0,
+     0, 3, 6, 9, 12, 15, 16, 22, 25, 28,
+    31, 34, 37, 40, 43, 46, 47, 52, 54, 56,
+    58, 60, 62, 64, 66, 68, 70, 72, 74, 79,
+    82, 85, 88, 89, 94, 97, 99, 100, 106, 111,
+   112, 121, 124, 125, 128, 131, 133, 135, 138, 140,
+   141, 147, 148, 154, 155, 161, 162, 171, 173, 174,
+   177, 179, 180, 186, 187, 193, 198, 203, 206, 207,
+   210, 213, 214, 219, 224, 229, 232, 233, 236, 238,
+   241, 243, 245, 247, 249, 250, 257, 258, 265, 269,
+   273, 277, 281, 285, 288, 292, 293, 294, 300, 301,
+   307, 309, 311, 316, 319, 322, 324, 326, 328, 330,
+   332, 334, 336, 338, 340, 342, 343, 349, 355, 356,
+   365, 374, 375, 384, 393, 394, 406, 418, 421, 422,
+   425, 426, 428, 430, 431, 437, 439, 441, 447, 456,
+   458, 460, 462, 464, 466, 471, 477, 483, 489, 495,
+   499, 501, 503, 507, 512, 514, 516, 519, 521, 524,
+   529, 531, 534, 537, 538, 539, 540, 552, 553, 554,
+   564, 565, 572, 573, 574, 589, 590, 591, 604, 605,
+   615, 621, 623, 628, 630, 633, 635, 640, 642, 643,
+   649, 650, 659, 665, 674, 675, 681, 682, 683, 684,
+   694, 703, 708, 710, 713, 715, 716, 722, 728, 729,
+   738, 747, 749, 754, 757, 759, 760, 761, 771, 772,
+   779, 780, 781, 794, 795, 804, 806, 808, 814, 816,
+   821, 823, 825, 830, 833, 835, 837, 839, 840, 846,
+   847, 857, 858, 867, 869, 871, 872, 881, 882, 894,
+   895, 905, 906, 916, 917, 927, 928, 941, 942, 955,
+   956, 969, 971, 976, 978, 981, 983, 985, 987, 993,
+   995, 1001, 1003, 1005, 1011, 1013, 1015, 1016, 1027, 1030,
+  1031, 1032, 1038, 1044, 1049, 1055, 1058, 1061, 1064, 1067,
+  1070, 1073, 1076, 1079, 1082, 1083, 1088, 1091, 1094, 1097,
+  1098, 1099, 1105, 1106, 1116, 1117, 1127, 1133, 1138, 1146,
+  1151, 1159, 1161, 1167, 1170, 1171, 1173, 1174, 1180, 1181,
+  1187, 1190, 1191, 1192, 1198, 1199, 1208, 1214, 1216, 1221,
+  1226, 1231, 1237, 1243, 1249, 1256, 1262, 1264, 1266, 1268,
+  1274, 1280, 1282, 1286, 1288, 1290, 1291, 1297, 1298, 1307,
+  1311, 1313, 1315, 1316, 1322, 1328, 1333, 1338, 1343, 1349,
+  1355, 1356, 1365, 1366, 1375, 1378, 1380, 1381, 1387, 1389,
+  1391, 1392, 1400, 1401, 1409, 1410, 1416, 1417, 1426, 1430,
+  1433, 1436, 1439, 1442, 1443, 1446, 1449, 1452, 1453, 1459,
+  1462, 1468, 1473, 1475, 1476, 1480, 1487, 1491, 1498, 1502,
+  1509, 1510, 1513, 1519, 1520, 1523, 1529, 1532, 1538, 1539,
+  1542, 1544, 1546, 1548, 1550, 1552, 1554, 1555, 1561, 1562,
+  1571, 1572, 1581, 1587, 1588, 1597, 1598, 1610, 1611, 1623,
+  1624, 1636, 1645, 1646, 1655, 1656, 1668, 1669, 1681, 1682,
+  1697, 1702, 1707, 1709, 1711, 1713, 1716, 1719, 1720, 1721,
+  1727, 1728, 1737, 1738, 1739, 1740, 1756, 1757, 1763, 1766,
+  1769, 1772, 1773, 1776, 1777, 1785, 1787, 1789, 1792, 1794,
+  1795, 1804, 1808, 1809, 1812, 1814, 1815, 1821, 1826, 1829,
+  1830, 1831, 1837, 1840, 1842, 1845, 1847, 1849, 1851, 1852,
+  1858, 1859, 1868, 1869, 1878, 1881, 1884, 1885, 1888, 1891,
+  1892, 1893, 1899, 1901, 1902, 1910, 1911, 1917, 1918
+};
+static const short yyrhs[] = { 115,
+   116, 0, 115, 249, 0, 115, 333, 0, 115, 339,
+     0, 115, 347, 0, 0, 3, 40, 118, 117, 4,
+     0, 121, 117, 0, 140, 117, 0, 144, 117, 0,
+   123, 117, 0, 131, 117, 0, 147, 117, 0, 358,
+   117, 0, 260, 117, 0, 0, 3, 41, 119, 4,
+     0, 19, 0, 20, 0, 21, 0, 22, 0, 24,
+     0, 25, 0, 26, 0, 27, 0, 30, 0, 19,
+     0, 26, 0, 3, 35, 122, 4, 0, 122, 39,
+     0, 122, 103, 0, 122, 28, 0, 0, 3, 37,
+   124, 4, 0, 125, 124, 0, 125, 0, 0, 3,
+    19, 126, 127, 4, 0, 127, 129, 14, 21, 0,
+     0, 127, 129, 14, 3, 61, 128, 130, 4, 0,
+   127, 129, 0, 0, 129, 29, 0, 129, 25, 0,
+    29, 0, 25, 0, 130, 21, 0, 21, 0, 0,
+     3, 38, 132, 133, 4, 0, 0, 137, 14, 113,
+   134, 133, 0, 0, 137, 14, 21, 135, 133, 0,
+     0, 137, 14, 3, 61, 130, 4, 136, 133, 0,
+   137, 0, 0, 138, 137, 0, 138, 0, 0, 3,
+    19, 139, 127, 4, 0, 0, 3, 39, 141, 142,
+     4, 0, 142, 143, 14, 21, 0, 142, 143, 14,
+    19, 0, 142, 143, 0, 0, 143, 21, 0, 143,
+    19, 0, 0, 3, 36, 145, 4, 0, 3, 64,
+   145, 4, 0, 145, 146, 14, 21, 0, 145, 146,
+     0, 0, 146, 19, 0, 19, 0, 146, 20, 0,
+    20, 0, 148, 0, 275, 0, 284, 0, 0, 3,
+    42, 120, 149, 150, 4, 0, 0, 150, 45, 3,
+   151, 127, 4, 0, 150, 96, 152, 0, 150, 51,
+   207, 0, 150, 46, 155, 0, 150, 47, 155, 0,
+   150, 53, 236, 0, 150, 244, 0, 150, 102, 34,
+     0, 0, 0, 3, 19, 153, 166, 4, 0, 0,
+     3, 31, 154, 166, 4, 0, 156, 0, 158, 0,
+     3, 54, 157, 4, 0, 3, 4, 0, 157, 158,
+     0, 158, 0, 160, 0, 163, 0, 179, 0, 197,
+     0, 199, 0, 172, 0, 48, 0, 49, 0, 50,
+     0, 0, 3, 22, 161, 167, 4, 0, 3, 13,
+   171, 171, 4, 0, 0, 3, 159, 3, 22, 162,
+   167, 4, 4, 0, 3, 159, 3, 13, 171, 171,
+     4, 4, 0, 0, 3, 59, 3, 22, 164, 167,
+     4, 4, 0, 3, 59, 3, 13, 171, 171, 4,
+     4, 0, 0, 3, 159, 3, 59, 3, 22, 165,
+   167, 4, 4, 4, 0, 3, 159, 3, 59, 3,
+    13, 171, 171, 4, 4, 4, 0, 166, 168, 0,
+     0, 167, 171, 0, 0, 25, 0, 20, 0, 0,
+     3, 23, 170, 167, 4, 0, 168, 0, 169, 0,
+     3, 173, 174, 174, 4, 0, 3, 159, 3, 173,
+   174, 174, 4, 4, 0, 7, 0, 8, 0, 9,
+     0, 10, 0, 13, 0, 3, 14, 174, 4, 0,
+     3, 15, 174, 175, 4, 0, 3, 14, 174, 174,
+     4, 0, 3, 16, 174, 176, 4, 0, 3, 17,
+   174, 174, 4, 0, 174, 17, 174, 0, 33, 0,
+    32, 0, 3, 74, 4, 0, 3, 100, 30, 4,
+     0, 177, 0, 174, 0, 174, 175, 0, 174, 0,
+   174, 176, 0, 3, 24, 178, 4, 0, 24, 0,
+    25, 178, 0, 20, 178, 0, 0, 0, 0, 3,
+    84, 180, 301, 304, 3, 22, 181, 167, 4, 4,
+     0, 0, 0, 3, 57, 3, 182, 127, 4, 183,
+   190, 4, 0, 0, 3, 58, 184, 193, 191, 4,
+     0, 0, 0, 3, 159, 3, 84, 185, 301, 304,
+     3, 22, 186, 167, 4, 4, 4, 0, 0, 0,
+     3, 159, 3, 57, 3, 187, 127, 4, 188, 190,
+     4, 4, 0, 0, 3, 159, 3, 58, 189, 193,
+   191, 4, 4, 0, 3, 58, 193, 191, 4, 0,
+   191, 0, 3, 54, 192, 4, 0, 194, 0, 194,
+   192, 0, 194, 0, 3, 54, 306, 4, 0, 307,
+     0, 0, 3, 22, 195, 167, 4, 0, 0, 3,
+    59, 3, 22, 196, 167, 4, 4, 0, 3, 13,
+   171, 171, 4, 0, 3, 59, 3, 13, 171, 171,
+     4, 4, 0, 0, 3, 55, 198, 203, 4, 0,
+     0, 0, 0, 3, 56, 3, 200, 127, 4, 201,
+   202, 4, 0, 3, 54, 306, 3, 55, 203, 4,
+     4, 0, 3, 55, 203, 4, 0, 204, 0, 204,
+   203, 0, 204, 0, 0, 3, 22, 205, 167, 4,
+     0, 3, 13, 171, 171, 4, 0, 0, 3, 59,
+     3, 22, 206, 167, 4, 4, 0, 3, 59, 3,
+    13, 171, 171, 4, 4, 0, 209, 0, 3, 54,
+   208, 4, 0, 209, 208, 0, 209, 0, 0, 0,
+     3, 57, 3, 210, 127, 4, 211, 216, 4, 0,
+     0, 3, 60, 212, 218, 217, 4, 0, 0, 0,
+     3, 159, 3, 57, 3, 213, 127, 4, 214, 216,
+     4, 4, 0, 0, 3, 159, 3, 60, 215, 218,
+   217, 4, 0, 220, 0, 229, 0, 3, 60, 218,
+   217, 4, 0, 217, 0, 3, 54, 219, 4, 0,
+   220, 0, 307, 0, 3, 54, 306, 4, 0, 220,
+   219, 0, 220, 0, 221, 0, 226, 0, 0, 3,
+    22, 222, 167, 4, 0, 0, 3, 79, 3, 23,
+   223, 167, 4, 225, 4, 0, 0, 3, 159, 3,
+    22, 224, 167, 4, 4, 0, 171, 0, 114, 0,
+     0, 3, 59, 3, 22, 227, 167, 4, 4, 0,
+     0, 3, 159, 3, 59, 3, 22, 228, 167, 4,
+     4, 4, 0, 0, 3, 75, 3, 24, 230, 167,
+     4, 174, 4, 0, 0, 3, 76, 3, 24, 231,
+   167, 4, 174, 4, 0, 0, 3, 79, 3, 24,
+   232, 167, 4, 174, 4, 0, 0, 3, 159, 3,
+    75, 3, 24, 233, 167, 4, 174, 4, 4, 0,
+     0, 3, 159, 3, 76, 3, 24, 234, 167, 4,
+   174, 4, 4, 0, 0, 3, 159, 3, 79, 3,
+    24, 235, 167, 4, 174, 4, 4, 0, 238, 0,
+     3, 54, 237, 4, 0, 238, 0, 238, 237, 0,
+   239, 0, 240, 0, 242, 0, 3, 13, 73, 174,
+     4, 0, 174, 0, 3, 241, 73, 174, 4, 0,
+     9, 0, 10, 0, 3, 243, 73, 174, 4, 0,
+     7, 0, 8, 0, 0, 3, 97, 245, 302, 303,
+    98, 3, 246, 4, 4, 0, 247, 246, 0, 0,
+     0, 3, 26, 248, 167, 4, 0, 3, 40, 250,
+   251, 4, 0, 3, 62, 119, 4, 0, 251, 3,
+    63, 119, 4, 0, 251, 121, 0, 251, 144, 0,
+   251, 252, 0, 251, 260, 0, 251, 270, 0, 251,
+   273, 0, 251, 291, 0, 251, 284, 0, 251, 358,
+     0, 0, 3, 65, 253, 4, 0, 253, 258, 0,
+   253, 256, 0, 253, 254, 0, 0, 0, 3, 22,
+   255, 167, 4, 0, 0, 3, 13, 3, 23, 257,
+   167, 4, 20, 4, 0, 0, 3, 13, 3, 24,
+   259, 167, 4, 274, 4, 0, 3, 13, 24, 274,
+     4, 0, 3, 66, 261, 4, 0, 3, 66, 3,
+    54, 262, 4, 4, 0, 3, 103, 261, 4, 0,
+     3, 103, 3, 54, 262, 4, 4, 0, 267, 0,
+     3, 99, 19, 263, 4, 0, 261, 262, 0, 0,
+   267, 0, 0, 3, 54, 264, 266, 4, 0, 0,
+     3, 55, 265, 266, 4, 0, 267, 266, 0, 0,
+     0, 3, 22, 268, 167, 4, 0, 0, 3, 59,
+     3, 22, 269, 167, 4, 4, 0, 3, 13, 171,
+   171, 4, 0, 172, 0, 3, 104, 263, 4, 0,
+     3, 105, 263, 4, 0, 3, 106, 263, 4, 0,
+     3, 107, 263, 263, 4, 0, 3, 108, 263, 263,
+     4, 0, 3, 101, 274, 263, 4, 0, 3, 109,
+   274, 263, 263, 4, 0, 3, 70, 271, 272, 4,
+     0, 71, 0, 72, 0, 174, 0, 3, 67, 68,
+    33, 4, 0, 3, 67, 69, 33, 4, 0, 33,
+     0, 33, 17, 33, 0, 32, 0, 94, 0, 0,
+     3, 52, 276, 295, 277, 0, 0, 83, 278, 3,
+   324, 33, 325, 4, 4, 0, 89, 279, 4, 0,
+   111, 0, 112, 0, 0, 3, 22, 280, 166, 4,
+     0, 3, 13, 168, 168, 4, 0, 3, 59, 279,
+     4, 0, 3, 54, 283, 4, 0, 3, 55, 283,
+     4, 0, 3, 58, 279, 279, 4, 0, 3, 110,
+   279, 279, 4, 0, 0, 3, 57, 3, 281, 127,
+     4, 279, 4, 0, 0, 3, 56, 3, 282, 127,
+     4, 279, 4, 0, 283, 279, 0, 279, 0, 0,
+     3, 90, 285, 295, 286, 0, 287, 0, 289, 0,
+     0, 42, 3, 26, 288, 167, 4, 4, 0, 0,
+    95, 3, 22, 290, 167, 4, 4, 0, 0, 3,
+    52, 292, 295, 293, 0, 0, 83, 294, 3, 324,
+    33, 325, 4, 4, 0, 89, 279, 4, 0, 295,
+   296, 0, 295, 297, 0, 295, 298, 0, 295, 300,
+     0, 0, 80, 119, 0, 81, 19, 0, 81, 27,
+     0, 0, 82, 3, 299, 127, 4, 0, 88, 307,
+     0, 88, 3, 54, 306, 4, 0, 82, 3, 127,
+     4, 0, 301, 0, 0, 88, 307, 305, 0, 88,
+     3, 54, 306, 4, 305, 0, 46, 307, 304, 0,
+    46, 3, 54, 306, 4, 304, 0, 47, 307, 304,
+     0, 47, 3, 54, 306, 4, 304, 0, 0, 88,
+   307, 0, 88, 3, 54, 306, 4, 0, 0, 46,
+   307, 0, 46, 3, 54, 306, 4, 0, 47, 307,
+     0, 47, 3, 54, 306, 4, 0, 0, 306, 307,
+     0, 307, 0, 308, 0, 312, 0, 317, 0, 320,
+     0, 323, 0, 0, 3, 22, 309, 167, 4, 0,
+     0, 3, 159, 3, 22, 310, 167, 4, 4, 0,
+     0, 3, 65, 3, 22, 311, 167, 4, 4, 0,
+     3, 13, 171, 171, 4, 0, 0, 3, 59, 3,
+    22, 313, 167, 4, 4, 0, 0, 3, 159, 3,
+    59, 3, 22, 314, 167, 4, 4, 4, 0, 0,
+     3, 65, 3, 59, 3, 22, 315, 167, 4, 4,
+     4, 0, 0, 3, 59, 3, 65, 3, 22, 316,
+   167, 4, 4, 4, 0, 3, 59, 3, 13, 171,
+   171, 4, 4, 0, 0, 3, 66, 3, 22, 318,
+   167, 4, 4, 0, 0, 3, 66, 3, 59, 3,
+    22, 319, 167, 4, 4, 4, 0, 0, 3, 59,
+     3, 66, 3, 22, 321, 167, 4, 4, 4, 0,
+     0, 3, 59, 3, 66, 3, 59, 3, 22, 322,
+   167, 4, 4, 4, 4, 0, 3, 21, 25, 4,
+     0, 3, 21, 169, 4, 0, 85, 0, 86, 0,
+    87, 0, 325, 326, 0, 325, 329, 0, 0, 0,
+     3, 22, 327, 167, 4, 0, 0, 3, 59, 3,
+    22, 328, 167, 4, 4, 0, 0, 0, 0, 3,
+    84, 82, 3, 330, 127, 4, 331, 304, 3, 22,
+   332, 167, 4, 4, 0, 0, 3, 91, 334, 335,
+     4, 0, 336, 335, 0, 93, 335, 0, 337, 335,
+     0, 0, 81, 119, 0, 0, 274, 11, 3, 26,
+   338, 167, 4, 0, 340, 0, 344, 0, 341, 340,
+     0, 341, 0, 0, 274, 11, 3, 26, 342, 167,
+     4, 343, 0, 5, 274, 6, 0, 0, 345, 344,
+     0, 345, 0, 0, 3, 26, 346, 167, 4, 0,
+     3, 92, 348, 4, 0, 348, 349, 0, 0, 0,
+     3, 350, 352, 4, 351, 0, 93, 274, 0, 274,
+     0, 352, 353, 0, 353, 0, 354, 0, 356, 0,
+     0, 3, 22, 355, 167, 4, 0, 0, 3, 59,
+     3, 22, 357, 167, 4, 4, 0, 0, 3, 96,
+   359, 360, 302, 304, 361, 4, 0, 81, 19, 0,
+    81, 27, 0, 0, 361, 364, 0, 361, 362, 0,
+     0, 0, 3, 119, 363, 167, 4, 0, 119, 0,
+     0, 3, 84, 365, 301, 304, 366, 4, 0, 0,
+     3, 119, 367, 167, 4, 0, 0, 3, 59, 3,
+   119, 368, 167, 4, 4, 0
+};
+static const short yyrline[] = { 0,
+   103, 105, 106, 107, 108, 109, 112, 116, 118, 119,
+   120, 121, 122, 123, 124, 125, 128, 136, 138, 139,
+   140, 141, 142, 143, 144, 145, 148, 150, 155, 159,
+   161, 162, 163, 168, 172, 174, 177, 182, 192, 197,
+   201, 205, 209, 212, 225, 232, 244, 253, 258, 265,
+   270, 273, 279, 279, 309, 309, 339, 339, 343, 346,
+   348, 351, 356, 368, 373, 376, 384, 397, 404, 407,
+   413, 419, 424, 426, 429, 434, 438, 441, 450, 458,
+   465, 476, 478, 479, 484, 489, 498, 503, 507, 508,
+   509, 510, 511, 512, 513, 518, 521, 530, 534, 539,
+   545, 547, 548, 551, 555, 557, 560, 562, 563, 564,
+   565, 566, 572, 577, 581, 587, 592, 598, 606, 610,
+   616, 627, 632, 638, 646, 650, 656, 667, 674, 677,
+   684, 687, 695, 701, 707, 727, 732, 737, 744, 753,
+   758, 762, 766, 770, 776, 781, 785, 789, 793, 797,
+   801, 805, 809, 813, 817, 823, 828, 834, 839, 845,
+   850, 856, 861, 865, 871, 877, 881, 896, 901, 910,
+   920, 924, 929, 934, 938, 954, 959, 968, 980, 984,
+   992, 994, 997, 999, 1002, 1004, 1007, 1009, 1012, 1017,
+  1024, 1028, 1035, 1044, 1081, 1086, 1094, 1095, 1100, 1109,
+  1121, 1123, 1124, 1127, 1129, 1132, 1137, 1143, 1151, 1155,
+  1161, 1171, 1173, 1176, 1178, 1181, 1187, 1195, 1206, 1210,
+  1215, 1220, 1228, 1241, 1245, 1252, 1253, 1256, 1258, 1261,
+  1263, 1266, 1268, 1271, 1273, 1276, 1278, 1281, 1287, 1297,
+  1301, 1325, 1330, 1342, 1347, 1353, 1359, 1369, 1374, 1386,
+  1391, 1398, 1402, 1409, 1413, 1420, 1424, 1431, 1435, 1442,
+  1446, 1455, 1457, 1460, 1462, 1465, 1467, 1468, 1471, 1477,
+  1484, 1491, 1493, 1496, 1503, 1505, 1508, 1518, 1541, 1543,
+  1546, 1551, 1564, 1568, 1576, 1578, 1579, 1580, 1581, 1582,
+  1583, 1584, 1585, 1586, 1587, 1590, 1594, 1596, 1597, 1598,
+  1601, 1606, 1619, 1624, 1636, 1641, 1654, 1670, 1672, 1673,
+  1674, 1677, 1682, 1690, 1692, 1695, 1700, 1704, 1710, 1714,
+  1722, 1730, 1733, 1738, 1745, 1749, 1756, 1764, 1768, 1772,
+  1776, 1780, 1784, 1788, 1792, 1828, 1832, 1842, 1853, 1868,
+  1873, 1886, 1888, 1889, 1890, 1895, 1901, 1904, 1909, 1916,
+  1924, 1929, 1933, 1937, 1942, 1946, 1950, 1955, 1960, 1964,
+  1968, 1972, 1987, 1991, 2008, 2013, 2019, 2026, 2029, 2031,
+  2034, 2039, 2051, 2056, 2068, 2075, 2078, 2083, 2090, 2098,
+  2100, 2101, 2102, 2103, 2106, 2113, 2120, 2127, 2132, 2138,
+  2140, 2143, 2153, 2155, 2158, 2160, 2161, 2162, 2163, 2164,
+  2165, 2168, 2170, 2171, 2174, 2176, 2177, 2178, 2179, 2182,
+  2184, 2187, 2189, 2190, 2191, 2192, 2195, 2200, 2207, 2211,
+  2217, 2221, 2227, 2237, 2242, 2249, 2253, 2259, 2263, 2269,
+  2273, 2279, 2289, 2294, 2300, 2304, 2312, 2317, 2323, 2327,
+  2335, 2342, 2349, 2354, 2358, 2364, 2366, 2367, 2369, 2374,
+  2379, 2383, 2390, 2396, 2404, 2408, 2424, 2433, 2446, 2448,
+  2453, 2454, 2457, 2465, 2470, 2482, 2488, 2495, 2497, 2500,
+  2505, 2534, 2536, 2539, 2541, 2544, 2549, 2579, 2583, 2585,
+  2588, 2593, 2600, 2606, 2612, 2614, 2617, 2619, 2622, 2628,
+  2637, 2643, 2652, 2661, 2668, 2674, 2678, 2681, 2683, 2684,
+  2687, 2697, 2704, 2719, 2726, 2740, 2750, 2758, 2767
+};
+static const char * const yytname[] = { "$","error","$illegal.","TK_OPEN",
+"TK_CLOSE","TK_OPEN_SQ","TK_CLOSE_SQ","TK_GREATER","TK_GREATEQ","TK_LESS","TK_LESSEQ",
+"TK_COLON","TK_HASHT","TK_EQ","TK_HYPHEN","TK_PLUS","TK_MUL","TK_DIV","TK_UMINUS",
+"TK_NEW_SYMBOL","TK_OBJ_SYMBOL","TK_TYPE_SYMBOL","TK_PRED_SYMBOL","TK_OBJFUN_SYMBOL",
+"TK_FUN_SYMBOL","TK_VAR_SYMBOL","TK_ACTION_SYMBOL","TK_MISC_SYMBOL","TK_KEYWORD",
+"TK_NEW_VAR_SYMBOL","TK_PREFERENCE_SYMBOL","TK_SET_SYMBOL","TK_FLOAT","TK_INT",
+"TK_STRING","KW_REQS","KW_CONSTANTS","KW_PREDS","KW_FUNS","KW_TYPES","KW_DEFINE",
+"KW_DOMAIN","KW_ACTION","KW_PROCESS","KW_EVENT","KW_ARGS","KW_PRE","KW_COND",
+"KW_AT_START","KW_AT_END","KW_OVER_ALL","KW_EFFECT","KW_INVARIANT","KW_DURATION",
+"KW_AND","KW_OR","KW_EXISTS","KW_FORALL","KW_IMPLY","KW_NOT","KW_WHEN","KW_EITHER",
+"KW_PROBLEM","KW_FORDOMAIN","KW_OBJECTS","KW_INIT","KW_GOAL","KW_LENGTH","KW_SERIAL",
+"KW_PARALLEL","KW_METRIC","KW_MINIMIZE","KW_MAXIMIZE","KW_DURATION_VAR","KW_TOTAL_TIME",
+"KW_INCREASE","KW_DECREASE","KW_SCALE_UP","KW_SCALE_DOWN","KW_ASSIGN","KW_TAG",
+"KW_NAME","KW_VARS","KW_SET_CONSTRAINT","KW_SETOF","KW_AT_LEAST_N","KW_AT_MOST_N",
+"KW_EXACTLY_N","KW_CONTEXT","KW_FORMULA","KW_IRRELEVANT","KW_PLAN","KW_HEURISTIC",
+"KW_OPT","KW_INF","KW_FACT","KW_SET","KW_EXPANSION","KW_TASKS","KW_PREFERENCE",
+"KW_VIOLATED","KW_WITHIN","KW_ASSOC","KW_CONSTRAINTS","KW_ALWAYS","KW_SOMETIME",
+"KW_AT_MOST_ONCE","KW_SOMETIME_BEFORE","KW_SOMETIME_AFTER","KW_ALWAYS_WITHIN",
+"KW_IFF","KW_FALSE","KW_TRUE","KW_NUMBER","KW_UNDEFINED","pddl_declarations",
+"pddl_domain","domain_elements","domain_name","any_symbol","action_symbol","domain_requires",
+"require_list","domain_predicates","predicate_list","predicate_decl","@1","typed_param_list",
+"@2","typed_param_sym_list","non_empty_type_name_list","domain_functions","@3",
+"function_list","@4","@5","@6","function_decl_list","function_decl","@7","domain_types",
+"@8","typed_type_list","primitive_type_list","domain_constants","typed_constant_list",
+"ne_constant_sym_list","domain_structure","action_declaration","@9","action_elements",
+"@10","action_set_name","@11","@12","action_condition","empty_action_condition",
+"action_condition_list","single_action_condition","timing_keyword","positive_atom_condition",
+"@13","@14","negative_atom_condition","@15","@16","flat_atom_argument_list",
+"atom_argument_list","flat_atom_argument","functional_atom_argument","@17","atom_argument",
+"numeric_condition","relation_keyword","d_expression","d_sum","d_product","d_function",
+"d_argument_list","set_condition","@18","@19","@20","@21","@22","@23","@24",
+"@25","@26","@27","universal_condition_body","one_or_more_condition_atoms","quantified_condition_atom_list",
+"one_or_more_context_atoms","quantified_condition_atom","@28","@29","disjunctive_condition",
+"@30","disjunctive_set_condition","@31","@32","existential_condition_body","disjunction_list",
+"disjunction_atom","@33","@34","action_effect","action_effect_list","single_action_effect",
+"@35","@36","@37","@38","@39","@40","quantified_effect_body","one_or_more_atomic_effects",
+"effect_conditions","atomic_effect_list","atomic_effect","positive_atom_effect",
+"@41","@42","@43","object_assignment_value","negative_atom_effect","@44","@45",
+"numeric_effect","@46","@47","@48","@49","@50","@51","action_duration","action_duration_list",
+"action_duration_exp","action_exact_duration","action_min_duration","less_or_lesseq",
+"action_max_duration","greater_or_greatereq","action_expansion","@52","task_list",
+"task","@53","pddl_problem","problem_name","problem_elements","initial_state",
+"init_elements","init_atom","@54","init_object_function","@55","init_function",
+"@56","goal_spec","single_goal_spec","goal_spec_list","new_goal","@57","@58",
+"new_goal_list","new_single_goal","@59","@60","metric_spec","metric_keyword",
+"metric_expression","length_spec","numeric_value","domain_invariant","@61","domain_invariant_body",
+"@62","fol_formula","@63","@64","@65","fol_formula_list","irrelevant_item","@66",
+"irrelevant_item_content","irrelevant_action","@67","irrelevant_atom","@68",
+"problem_invariant","@69","problem_invariant_body","@70","dkel_element_list",
+"dkel_tag_spec","dkel_name_spec","dkel_vars_spec","@71","dkel_context_spec",
+"req_vars_spec","opt_vars_spec","opt_context_and_precondition_spec","opt_context_spec",
+"opt_precondition_spec","context_list","context_atom","positive_context_atom",
+"@72","@73","@74","negative_context_atom","@75","@76","@77","@78","positive_context_goal_atom",
+"@79","@80","negative_context_goal_atom","@81","@82","type_constraint_atom",
+"set_constraint_type","invariant_set","invariant_atom","@83","@84","invariant_set_of_atoms",
+"@85","@86","@87","pddl_plan","@88","plan_elements","plan_name","plan_step",
+"@89","ipc_plan","ipc_plan_step_list","ipc_plan_step","@90","opt_step_duration",
+"ipc_plan_step_seq","simple_plan_step","@91","heuristic_table","table_entry_list",
+"table_entry","@92","entry_value","ne_entry_atom_list","entry_atom","pos_entry_atom",
+"@93","neg_entry_atom","@94","reference_set","@95","opt_set_name","reference_list",
+"reference","@96","simple_reference_set","@97","simple_reference_set_body","@98",
+"@99",""
+};
+static const short yyr1[] = { 0,
+   115, 115, 115, 115, 115, 115, 116, 117, 117, 117,
+   117, 117, 117, 117, 117, 117, 118, 119, 119, 119,
+   119, 119, 119, 119, 119, 119, 120, 120, 121, 122,
+   122, 122, 122, 123, 124, 124, 126, 125, 127, 128,
+   127, 127, 127, 129, 129, 129, 129, 130, 130, 132,
+   131, 134, 133, 135, 133, 136, 133, 133, 133, 137,
+   137, 139, 138, 141, 140, 142, 142, 142, 142, 143,
+   143, 143, 144, 144, 145, 145, 145, 146, 146, 146,
+   146, 147, 147, 147, 149, 148, 151, 150, 150, 150,
+   150, 150, 150, 150, 150, 150, 153, 152, 154, 152,
+   155, 155, 155, 156, 157, 157, 158, 158, 158, 158,
+   158, 158, 159, 159, 159, 161, 160, 160, 162, 160,
+   160, 164, 163, 163, 165, 163, 163, 166, 166, 167,
+   167, 168, 168, 170, 169, 171, 171, 172, 172, 173,
+   173, 173, 173, 173, 174, 174, 174, 174, 174, 174,
+   174, 174, 174, 174, 174, 175, 175, 176, 176, 177,
+   177, 178, 178, 178, 180, 181, 179, 182, 183, 179,
+   184, 179, 185, 186, 179, 187, 188, 179, 189, 179,
+   190, 190, 191, 191, 192, 192, 193, 193, 195, 194,
+   196, 194, 194, 194, 198, 197, 199, 200, 201, 199,
+   202, 202, 202, 203, 203, 205, 204, 204, 206, 204,
+   204, 207, 207, 208, 208, 210, 211, 209, 212, 209,
+   213, 214, 209, 215, 209, 209, 209, 216, 216, 217,
+   217, 218, 218, 219, 219, 220, 220, 222, 221, 223,
+   221, 224, 221, 225, 225, 227, 226, 228, 226, 230,
+   229, 231, 229, 232, 229, 233, 229, 234, 229, 235,
+   229, 236, 236, 237, 237, 238, 238, 238, 239, 239,
+   240, 241, 241, 242, 243, 243, 245, 244, 246, 246,
+   248, 247, 249, 250, 251, 251, 251, 251, 251, 251,
+   251, 251, 251, 251, 251, 252, 253, 253, 253, 253,
+   255, 254, 257, 256, 259, 258, 258, 260, 260, 260,
+   260, 261, 261, 262, 262, 263, 264, 263, 265, 263,
+   266, 266, 268, 267, 269, 267, 267, 267, 267, 267,
+   267, 267, 267, 267, 267, 270, 271, 271, 272, 273,
+   273, 274, 274, 274, 274, 276, 275, 278, 277, 277,
+   279, 279, 280, 279, 279, 279, 279, 279, 279, 279,
+   281, 279, 282, 279, 283, 283, 285, 284, 286, 286,
+   288, 287, 290, 289, 292, 291, 294, 293, 293, 295,
+   295, 295, 295, 295, 296, 297, 297, 299, 298, 300,
+   300, 301, 302, 302, 303, 303, 303, 303, 303, 303,
+   303, 304, 304, 304, 305, 305, 305, 305, 305, 306,
+   306, 307, 307, 307, 307, 307, 309, 308, 310, 308,
+   311, 308, 308, 313, 312, 314, 312, 315, 312, 316,
+   312, 312, 318, 317, 319, 317, 321, 320, 322, 320,
+   323, 323, 324, 324, 324, 325, 325, 325, 327, 326,
+   328, 326, 330, 331, 332, 329, 334, 333, 335, 335,
+   335, 335, 336, 338, 337, 339, 339, 340, 340, 342,
+   341, 343, 343, 344, 344, 346, 345, 347, 348, 348,
+   350, 349, 351, 351, 352, 352, 353, 353, 355, 354,
+   357, 356, 359, 358, 360, 360, 360, 361, 361, 361,
+   363, 362, 362, 365, 364, 367, 366, 368, 366
+};
+static const short yyr2[] = { 0,
+     2, 2, 2, 2, 2, 0, 5, 2, 2, 2,
+     2, 2, 2, 2, 2, 0, 4, 1, 1, 1,
+     1, 1, 1, 1, 1, 1, 1, 1, 4, 2,
+     2, 2, 0, 4, 2, 1, 0, 5, 4, 0,
+     8, 2, 0, 2, 2, 1, 1, 2, 1, 0,
+     5, 0, 5, 0, 5, 0, 8, 1, 0, 2,
+     1, 0, 5, 0, 5, 4, 4, 2, 0, 2,
+     2, 0, 4, 4, 4, 2, 0, 2, 1, 2,
+     1, 1, 1, 1, 0, 6, 0, 6, 3, 3,
+     3, 3, 3, 2, 3, 0, 0, 5, 0, 5,
+     1, 1, 4, 2, 2, 1, 1, 1, 1, 1,
+     1, 1, 1, 1, 1, 0, 5, 5, 0, 8,
+     8, 0, 8, 8, 0, 11, 11, 2, 0, 2,
+     0, 1, 1, 0, 5, 1, 1, 5, 8, 1,
+     1, 1, 1, 1, 4, 5, 5, 5, 5, 3,
+     1, 1, 3, 4, 1, 1, 2, 1, 2, 4,
+     1, 2, 2, 0, 0, 0, 11, 0, 0, 9,
+     0, 6, 0, 0, 14, 0, 0, 12, 0, 9,
+     5, 1, 4, 1, 2, 1, 4, 1, 0, 5,
+     0, 8, 5, 8, 0, 5, 0, 0, 0, 9,
+     8, 4, 1, 2, 1, 0, 5, 5, 0, 8,
+     8, 1, 4, 2, 1, 0, 0, 9, 0, 6,
+     0, 0, 12, 0, 8, 1, 1, 5, 1, 4,
+     1, 1, 4, 2, 1, 1, 1, 0, 5, 0,
+     9, 0, 8, 1, 1, 0, 8, 0, 11, 0,
+     9, 0, 9, 0, 9, 0, 12, 0, 12, 0,
+    12, 1, 4, 1, 2, 1, 1, 1, 5, 1,
+     5, 1, 1, 5, 1, 1, 0, 10, 2, 0,
+     0, 5, 5, 4, 5, 2, 2, 2, 2, 2,
+     2, 2, 2, 2, 0, 4, 2, 2, 2, 0,
+     0, 5, 0, 9, 0, 9, 5, 4, 7, 4,
+     7, 1, 5, 2, 0, 1, 0, 5, 0, 5,
+     2, 0, 0, 5, 0, 8, 5, 1, 4, 4,
+     4, 5, 5, 5, 6, 5, 1, 1, 1, 5,
+     5, 1, 3, 1, 1, 0, 5, 0, 8, 3,
+     1, 1, 0, 5, 5, 4, 4, 4, 5, 5,
+     0, 8, 0, 8, 2, 1, 0, 5, 1, 1,
+     0, 7, 0, 7, 0, 5, 0, 8, 3, 2,
+     2, 2, 2, 0, 2, 2, 2, 0, 5, 2,
+     5, 4, 1, 0, 3, 6, 3, 6, 3, 6,
+     0, 2, 5, 0, 2, 5, 2, 5, 0, 2,
+     1, 1, 1, 1, 1, 1, 0, 5, 0, 8,
+     0, 8, 5, 0, 8, 0, 11, 0, 11, 0,
+    11, 8, 0, 8, 0, 11, 0, 11, 0, 14,
+     4, 4, 1, 1, 1, 2, 2, 0, 0, 5,
+     0, 8, 0, 0, 0, 15, 0, 5, 2, 2,
+     2, 0, 2, 0, 7, 1, 1, 2, 1, 0,
+     8, 3, 0, 2, 1, 0, 5, 4, 2, 0,
+     0, 5, 2, 1, 2, 1, 1, 1, 0, 5,
+     0, 8, 0, 8, 2, 2, 0, 2, 2, 0,
+     0, 5, 1, 0, 7, 0, 5, 0, 8
+};
+static const short yydefact[] = { 6,
+     0, 0, 344, 342, 345, 1, 2, 0, 3, 4,
+   466, 469, 467, 475, 5, 476, 0, 457, 480, 0,
+     0, 468, 0, 474, 131, 0, 16, 295, 462, 0,
+   343, 0, 0, 0, 0, 0, 0, 16, 16, 16,
+    16, 16, 16, 82, 16, 83, 84, 16, 0, 0,
+   462, 0, 0, 462, 462, 481, 478, 479, 470, 0,
+   477, 133, 132, 136, 137, 130, 18, 19, 20, 21,
+    22, 23, 24, 25, 26, 0, 0, 33, 77, 0,
+    50, 64, 0, 346, 77, 0, 367, 493, 0, 7,
+     8, 11, 12, 9, 10, 13, 15, 14, 0, 283,
+   286, 287, 288, 289, 290, 291, 293, 292, 294, 463,
+   460, 0, 458, 459, 461, 0, 131, 134, 17, 284,
+     0, 0, 0, 0, 36, 59, 69, 27, 28, 85,
+   384, 0, 0, 328, 0, 312, 384, 497, 0, 0,
+   375, 0, 300, 0, 0, 0, 0, 0, 486, 487,
+   488, 0, 131, 29, 32, 30, 31, 73, 79, 81,
+    76, 37, 34, 35, 0, 0, 58, 61, 72, 96,
+     0, 74, 140, 141, 142, 143, 144, 323, 113, 114,
+   115, 315, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 308, 0, 0, 394, 315, 310, 384,
+     0, 0, 0, 0, 337, 338, 0, 464, 489, 0,
+     0, 485, 473, 0, 0, 78, 80, 43, 62, 51,
+     0, 60, 65, 68, 0, 0, 0, 0, 348, 0,
+     0, 347, 380, 381, 382, 383, 0, 131, 0, 315,
+     0, 0, 0, 0, 0, 0, 316, 0, 0, 0,
+     0, 0, 0, 0, 161, 152, 151, 0, 155, 0,
+     0, 368, 369, 370, 495, 496, 0, 393, 404, 0,
+     0, 285, 0, 296, 299, 298, 297, 0, 0, 339,
+     0, 131, 131, 0, 0, 484, 482, 0, 471, 135,
+    75, 0, 43, 0, 54, 52, 0, 71, 70, 0,
+    86, 0, 197, 197, 0, 0, 0, 0, 94, 385,
+   386, 387, 388, 0, 0, 390, 412, 413, 414, 415,
+   416, 0, 351, 352, 0, 0, 0, 314, 0, 325,
+     0, 0, 317, 319, 329, 330, 331, 0, 0, 0,
+   144, 0, 0, 0, 0, 0, 164, 0, 0, 0,
+     0, 0, 0, 43, 0, 500, 0, 377, 0, 376,
+     0, 301, 340, 341, 336, 0, 0, 491, 483, 0,
+    38, 47, 46, 42, 0, 0, 59, 59, 67, 66,
+   277, 87, 0, 91, 101, 102, 107, 108, 112, 109,
+   110, 111, 92, 0, 90, 212, 226, 236, 237, 227,
+     0, 270, 93, 262, 266, 267, 268, 0, 89, 95,
+    43, 0, 0, 0, 417, 0, 0, 0, 0, 0,
+     0, 353, 0, 0, 0, 0, 0, 0, 0, 350,
+   327, 324, 309, 131, 313, 334, 322, 322, 332, 333,
+     0, 0, 0, 0, 0, 0, 164, 164, 0, 153,
+     0, 150, 138, 371, 373, 0, 0, 402, 0, 311,
+     0, 0, 0, 0, 131, 465, 490, 131, 472, 0,
+    45, 44, 63, 49, 0, 55, 53, 394, 43, 104,
+   144, 116, 197, 195, 0, 0, 171, 0, 165, 0,
+   238, 0, 0, 0, 219, 0, 0, 0, 0, 275,
+   276, 272, 273, 0, 0, 0, 0, 97, 99, 0,
+   443, 444, 445, 0, 0, 0, 0, 131, 0, 0,
+   411, 0, 0, 0, 0, 0, 129, 366, 0, 0,
+   363, 361, 0, 0, 0, 0, 0, 0, 322, 0,
+   335, 0, 145, 0, 156, 0, 158, 0, 0, 163,
+   162, 160, 154, 131, 131, 392, 0, 0, 494, 503,
+   499, 498, 0, 379, 303, 305, 0, 0, 0, 0,
+    39, 56, 48, 401, 0, 0, 131, 0, 0, 106,
+     0, 198, 168, 0, 0, 0, 0, 131, 0, 0,
+   215, 216, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 264, 0, 0, 129, 129, 389, 448, 0, 441,
+   442, 0, 391, 410, 0, 424, 0, 0, 421, 0,
+   433, 0, 419, 0, 0, 0, 357, 365, 358, 43,
+    43, 0, 356, 0, 0, 318, 321, 320, 0, 147,
+   157, 146, 159, 148, 149, 0, 0, 0, 504, 501,
+     0, 131, 131, 307, 302, 0, 40, 59, 0, 0,
+     0, 0, 88, 0, 0, 103, 105, 0, 0, 205,
+    43, 43, 0, 0, 188, 0, 122, 404, 144, 119,
+     0, 179, 0, 173, 0, 213, 214, 43, 246, 0,
+     0, 232, 250, 252, 240, 254, 242, 0, 0, 224,
+     0, 0, 0, 0, 263, 265, 0, 0, 0, 0,
+     0, 423, 418, 0, 131, 0, 0, 131, 0, 131,
+     0, 131, 0, 355, 354, 128, 0, 0, 359, 360,
+   326, 139, 0, 0, 403, 0, 131, 448, 0, 0,
+   492, 0, 57, 0, 404, 0, 404, 0, 409, 0,
+   118, 117, 0, 206, 0, 196, 204, 0, 0, 0,
+     0, 0, 184, 0, 131, 0, 0, 131, 176, 0,
+     0, 0, 239, 0, 131, 0, 0, 0, 231, 131,
+   131, 131, 131, 131, 221, 0, 0, 0, 0, 0,
+   269, 271, 274, 98, 100, 0, 0, 446, 447, 0,
+     0, 430, 437, 0, 0, 428, 0, 435, 0, 426,
+     0, 0, 372, 374, 404, 0, 0, 0, 0, 0,
+     0, 397, 0, 399, 0, 0, 0, 395, 280, 0,
+   131, 0, 199, 169, 0, 0, 189, 0, 0, 172,
+     0, 0, 0, 0, 0, 43, 0, 0, 125, 404,
+   217, 0, 0, 0, 0, 0, 220, 0, 0, 0,
+     0, 0, 43, 248, 0, 256, 258, 260, 449, 0,
+     0, 349, 0, 0, 131, 131, 0, 0, 131, 0,
+   131, 0, 131, 0, 0, 0, 502, 0, 0, 0,
+    41, 0, 0, 0, 0, 405, 0, 407, 0, 0,
+   280, 0, 0, 0, 209, 0, 0, 187, 0, 131,
+     0, 0, 186, 0, 0, 0, 166, 0, 0, 0,
+     0, 0, 131, 0, 0, 0, 233, 0, 0, 235,
+     0, 0, 0, 0, 0, 0, 0, 0, 131, 0,
+   131, 131, 131, 131, 0, 0, 432, 425, 0, 0,
+   439, 422, 0, 434, 0, 420, 0, 364, 362, 0,
+     0, 378, 304, 306, 404, 404, 409, 0, 0, 281,
+     0, 279, 208, 207, 0, 131, 0, 0, 203, 0,
+     0, 182, 0, 0, 183, 185, 0, 191, 124, 123,
+   131, 121, 120, 177, 0, 0, 0, 0, 0, 0,
+   229, 247, 230, 234, 0, 0, 245, 244, 0, 0,
+   243, 222, 0, 225, 0, 0, 0, 0, 451, 453,
+     0, 0, 131, 0, 0, 0, 0, 506, 505, 398,
+   400, 396, 0, 0, 131, 278, 0, 0, 0, 0,
+   200, 0, 170, 193, 190, 0, 131, 0, 0, 180,
+     0, 0, 174, 0, 218, 251, 253, 241, 255, 0,
+     0, 0, 0, 0, 450, 131, 43, 0, 0, 0,
+     0, 0, 0, 0, 131, 406, 408, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 131,
+     0, 0, 0, 0, 0, 0, 0, 0, 431, 438,
+     0, 429, 436, 427, 508, 0, 282, 211, 210, 0,
+   202, 0, 0, 0, 167, 0, 127, 126, 0, 0,
+     0, 249, 0, 0, 0, 0, 454, 0, 131, 507,
+     0, 181, 194, 192, 178, 0, 228, 223, 257, 259,
+   261, 452, 404, 0, 0, 0, 0, 0, 440, 0,
+     0, 175, 0, 509, 201, 455, 131, 0, 0, 456,
+     0, 0
+};
+static const short yydefgoto[] = { 1,
+     6, 37, 27, 76, 130, 38, 121, 39, 124, 125,
+   218, 292, 742, 374, 475, 40, 126, 166, 378, 377,
+   658, 167, 168, 293, 41, 127, 169, 224, 42, 122,
+   161, 43, 44, 170, 225, 479, 409, 605, 606, 384,
+   385, 579, 386, 420, 387, 577, 768, 388, 765, 923,
+   626, 33, 64, 65, 153, 66, 134, 193, 402, 546,
+   548, 259, 449, 390, 586, 991, 672, 907, 584, 772,
+  1090, 846, 1049, 770, 981, 982, 912, 674, 763, 910,
+  1047, 391, 581, 392, 671, 906, 978, 669, 670, 831,
+   976, 395, 590, 591, 688, 925, 594, 863, 1060, 787,
+  1000, 1001, 691, 929, 779, 398, 588, 782, 784, 1009,
+   399, 775, 939, 400, 780, 781, 783, 941, 942, 943,
+   403, 601, 602, 405, 406, 506, 407, 507, 309, 478,
+   900, 901, 1035, 7, 28, 49, 103, 202, 275, 465,
+   276, 652, 277, 653, 45, 240, 241, 246, 437, 438,
+   538, 247, 238, 434, 105, 207, 281, 106, 52, 46,
+   131, 232, 314, 528, 527, 631, 630, 529, 47, 137,
+   262, 263, 554, 264, 555, 108, 200, 360, 461, 171,
+   233, 234, 235, 411, 236, 268, 269, 662, 356, 828,
+   520, 521, 317, 518, 722, 718, 318, 715, 883, 879,
+   875, 319, 720, 881, 320, 876, 1023, 321, 514, 711,
+   798, 944, 1066, 799, 1067, 1143, 1157, 9, 29, 53,
+    54, 55, 282, 10, 11, 12, 117, 289, 13, 14,
+    25, 15, 30, 58, 116, 287, 148, 149, 150, 283,
+   151, 468, 48, 138, 197, 459, 561, 737, 562, 736,
+   961, 1075, 1129
+};
+static const short yypact[] = {-32768,
+    42, 20,-32768, 144,-32768,-32768,-32768, 160,-32768,-32768,
+-32768, 29,-32768, 238,-32768,-32768, 264,-32768,-32768, 153,
+   284,-32768, 263,-32768,-32768, 155, 340,-32768, 52, 241,
+-32768, 300, 506, 1311, 1311, 276, 367, 340, 340, 340,
+   340, 340, 340,-32768, 340,-32768,-32768, 340, 469, 1311,
+    52, 370, 381, 52, 52,-32768,-32768,-32768,-32768, 382,
+-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,
+-32768,-32768,-32768,-32768,-32768, 421, 423,-32768,-32768, 432,
+-32768,-32768, 318,-32768,-32768, 439,-32768,-32768, 442,-32768,
+-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768, 634,-32768,
+-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,
+-32768, 484,-32768,-32768,-32768, 517,-32768,-32768,-32768,-32768,
+    59, 348, 437, 520, 432, 529,-32768,-32768,-32768,-32768,
+-32768, 475, 226,-32768, 542,-32768,-32768, 457, 534, 545,
+-32768, 1311,-32768, 505, 585, 527, 49, 656,-32768,-32768,
+-32768, 611,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,
+   709,-32768,-32768,-32768, 539, 588, 599, 529, 619,-32768,
+   536,-32768,-32768,-32768,-32768,-32768, 194,-32768,-32768,-32768,
+-32768, 623, 629, 615, 29, 646, 646, 646, 646, 646,
+    29, 649, 64,-32768, 307, 228, 600, 623,-32768,-32768,
+   664, 681, 654, 657,-32768,-32768, 64,-32768,-32768, 689,
+   115,-32768, 698, 658, 691,-32768,-32768,-32768,-32768,-32768,
+    27,-32768,-32768, 302, 122, 1311, 246, 722,-32768, 728,
+    44,-32768,-32768,-32768,-32768,-32768, 194,-32768, 384, 623,
+   732, 721, 646, 646, 667, 749,-32768, 751, 753, 646,
+   646, 646, 637, 164,-32768,-32768,-32768, 407,-32768, 764,
+   774,-32768,-32768,-32768,-32768,-32768, 782,-32768, 706, 800,
+   727,-32768, 60,-32768,-32768,-32768,-32768, 817, 827, 806,
+   830,-32768,-32768, 821, 29,-32768,-32768, 29,-32768,-32768,
+-32768, 277,-32768, 778,-32768,-32768, 242,-32768,-32768, 761,
+-32768, 852, 874, 874, 879, 167, 901, 881,-32768,-32768,
+-32768,-32768,-32768, 910, 819,-32768,-32768,-32768,-32768,-32768,
+-32768, 172,-32768,-32768, 916, 922, 668,-32768, 932,-32768,
+   946, 949,-32768,-32768,-32768,-32768,-32768, 957, 958, 646,
+-32768, 64, 64, 64, 64, 64, 357, 960, 936, 64,
+    72, 939, 947,-32768, 972,-32768, 974,-32768, 44,-32768,
+    67,-32768,-32768,-32768,-32768, 707, 736,-32768,-32768, 976,
+-32768,-32768,-32768, 453, 325, 969, 529, 529,-32768,-32768,
+-32768,-32768, 853,-32768,-32768,-32768,-32768,-32768,-32768,-32768,
+-32768,-32768,-32768, 738,-32768,-32768,-32768,-32768,-32768,-32768,
+   491, 806,-32768,-32768,-32768,-32768,-32768, 145,-32768,-32768,
+-32768, 648, 194, 47,-32768, 988, 992, 993, 996, 1013,
+   450,-32768, 44, 44, 1014, 1016, 44, 44, 44,-32768,
+-32768,-32768,-32768,-32768,-32768,-32768, 1017, 1017,-32768,-32768,
+   975, 407, 366, 407, 407, 407, 357, 357, 1019,-32768,
+  1022,-32768,-32768,-32768,-32768, 332, 935,-32768, 1150,-32768,
+  1025, 1028, 696, 29,-32768,-32768,-32768,-32768,-32768, 96,
+-32768,-32768,-32768,-32768, 37,-32768,-32768, 600,-32768,-32768,
+   194,-32768, 1030,-32768, 1031, 1032,-32768, 1041,-32768, 1042,
+-32768, 1046, 1049, 1050,-32768, 1056, 1057, 1061, 1069,-32768,
+-32768,-32768,-32768, 998, 397, 1003, 1007,-32768,-32768, 335,
+-32768,-32768,-32768, 1052, 194, 1082, 1087,-32768, 1090, 742,
+-32768, 150, 68, 85, 161, 450,-32768,-32768, 30, 48,
+-32768,-32768, 44, 1095, 44, 776, 741, 1096, 1017, 1097,
+-32768, 273,-32768, 303, 407, 1100, 407, 1101, 361,-32768,
+-32768,-32768,-32768,-32768,-32768,-32768, 988, 427,-32768,-32768,
+-32768,-32768, 648,-32768,-32768,-32768, 1102, 808, 861, 1047,
+-32768,-32768,-32768, 18, 355, 194,-32768, 883, 766,-32768,
+  1072,-32768,-32768, 1106, 271, 600, 46,-32768, 895, 1111,
+  1046,-32768, 1088, 1120, 1107, 1108, 758, 183, 64, 553,
+  1131, 397, 64, 64,-32768,-32768,-32768,-32768, 1139,-32768,
+-32768, 894,-32768,-32768, 194,-32768, 1141, 1144,-32768, 1145,
+-32768, 1148,-32768, 1149, 1157, 493,-32768,-32768,-32768,-32768,
+-32768, 1169,-32768, 1182, 1183,-32768,-32768,-32768, 1185,-32768,
+-32768,-32768,-32768,-32768,-32768, 896, 943, 780,-32768,-32768,
+  1109,-32768,-32768,-32768,-32768, 1190,-32768, 529, 1193, 1196,
+  1199, 1110,-32768, 1209, 973,-32768,-32768, 244, 1211, 1072,
+-32768,-32768, 938, 1217,-32768, 194,-32768, 706, 194,-32768,
+  1231,-32768, 1248,-32768, 1002,-32768,-32768,-32768,-32768, 959,
+  1269,-32768,-32768,-32768,-32768,-32768,-32768, 1286, 1307,-32768,
+  1315, 1316, 1321, 405,-32768,-32768, 419, 424, 577, 586,
+   799,-32768,-32768, 194,-32768, 1305, 190,-32768, 1317,-32768,
+  1318,-32768, 1326,-32768,-32768,-32768, 440, 455,-32768,-32768,
+-32768,-32768, 1346, 1347,-32768, 600,-32768,-32768, 1011, 1043,
+-32768, 969,-32768, 989, 706, 1008, 706, 1029, 773, 1322,
+-32768,-32768, 194,-32768, 1350,-32768,-32768, 492, 508, 988,
+    56, 1351,-32768, 194,-32768, 1353, 194,-32768,-32768, 1106,
+   395, 600,-32768, 523,-32768, 988, 659, 1354,-32768,-32768,
+-32768,-32768,-32768,-32768,-32768, 1332, 1120, 1333, 1335, 1336,
+-32768,-32768,-32768,-32768,-32768, 55, 1357,-32768,-32768, 1358,
+  1062,-32768,-32768, 1360, 1121,-32768, 1125,-32768, 1163,-32768,
+    44, 44,-32768,-32768, 706, 1175, 834, 1344, 29, 185,
+   988,-32768, 988,-32768, 988, 1362, 1363,-32768, 1364, 194,
+-32768, 501,-32768,-32768, 848, 194,-32768, 1365, 1366,-32768,
+  1367, 1178, 1348, 1368, 1181,-32768, 1217, 194,-32768, 706,
+-32768, 1187, 850, 1370, 1371, 1372,-32768, 1189, 1201, 1207,
+  1213, 1215,-32768,-32768, 1269,-32768,-32768,-32768,-32768, 1373,
+  1296,-32768, 1375, 1376,-32768,-32768, 1355, 1377,-32768, 1378,
+-32768, 1379,-32768, 1380, 1381, 1383,-32768, 1384, 1385, 1386,
+-32768, 876, 884, 891, 1048,-32768, 1068,-32768, 1361, 1387,
+  1364, 1388, 1219, 194,-32768, 1390, 1391,-32768, 194,-32768,
+   279, 1392, 1365, 572, 1393, 1394,-32768, 1395, 1396, 546,
+  1397, 194,-32768, 1399, 1400, 1401,-32768, 297, 1402, 1370,
+  1389, 210, 64, 64, 24, 64, 1403, 551,-32768, 1404,
+-32768,-32768,-32768,-32768, 1382, 1406,-32768,-32768, 1221, 1225,
+-32768,-32768, 1227,-32768, 1233,-32768, 1239,-32768,-32768, 1138,
+  1407,-32768,-32768,-32768, 706, 706, 773, 988, 988,-32768,
+  1409,-32768,-32768,-32768, 194,-32768, 224, 1410,-32768, 70,
+  1411,-32768, 1412, 1245,-32768,-32768, 194,-32768,-32768,-32768,
+-32768,-32768,-32768,-32768, 1413, 1414, 1251, 1398, 480, 1415,
+-32768,-32768,-32768,-32768, 464, 499,-32768,-32768, 1417, 547,
+-32768,-32768, 1253,-32768, 1257, 1259, 1263, 1265,-32768,-32768,
+  1418, 1419,-32768, 1420, 1421, 1422, 1424,-32768,-32768,-32768,
+-32768,-32768, 919, 921,-32768,-32768, 1425, 1271, 988, 1072,
+-32768, 1106,-32768,-32768,-32768, 194,-32768, 1277, 1391,-32768,
+  1426, 1427,-32768, 1120,-32768,-32768,-32768,-32768,-32768, 1400,
+  1428, 64, 64, 64,-32768,-32768,-32768, 1429, 1430, 1283,
+  1431, 1432, 1433, 1311,-32768,-32768,-32768, 1289, 1434, 1435,
+  1437, 1438, 1217, 1439, 1291, 1440, 1441, 1442, 1443,-32768,
+  1269, 1444, 1445, 595, 604, 605, 1295, 575,-32768,-32768,
+  1446,-32768,-32768,-32768,-32768, 1297,-32768,-32768,-32768, 1071,
+-32768, 1447, 1448, 1449,-32768, 1450,-32768,-32768, 1301, 1451,
+  1452,-32768, 1453, 1454, 1455, 1456,-32768, 1457,-32768,-32768,
+  1072,-32768,-32768,-32768,-32768, 1458,-32768,-32768,-32768,-32768,
+-32768,-32768, 706, 1459, 1303, 1460, 1461, 1463,-32768, 1464,
+  1465,-32768, 1462,-32768,-32768,-32768,-32768, 1309, 1466,-32768,
+  1467,-32768
+};
+static const short yypgoto[] = {-32768,
+-32768, 1304,-32768, -33,-32768, 1423,-32768,-32768, 1270,-32768,
+-32768, -268,-32768,-32768, 686,-32768,-32768, -349,-32768,-32768,
+-32768, 1242,-32768,-32768,-32768,-32768,-32768,-32768, 1436, 1356,
+-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768, 1167,
+-32768,-32768, -448, -123,-32768,-32768,-32768,-32768,-32768,-32768,
+   323, -117, -413, 1059,-32768, -157, -285, -246, -192, 929,
+   928,-32768, 487,-32768,-32768,-32768,-32768,-32768,-32768,-32768,
+-32768,-32768,-32768,-32768, 428, -665, 563, -756, -795,-32768,
+-32768,-32768,-32768,-32768,-32768,-32768,-32768, -667, 573,-32768,
+-32768,-32768, 887, 1176,-32768,-32768,-32768,-32768,-32768,-32768,
+   420, -678, -766, 552, -300,-32768,-32768,-32768,-32768,-32768,
+-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,
+-32768, 885, 1177,-32768,-32768,-32768,-32768,-32768,-32768,-32768,
+   587,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,
+-32768,-32768,-32768,-32768, 1468, 136, -103, -150,-32768,-32768,
+  -407, -63,-32768,-32768,-32768,-32768,-32768,-32768, 10,-32768,
+-32768,-32768,-32768, -225,-32768,-32768,-32768, 1065, 1469,-32768,
+-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768, -80,
+-32768,-32768,-32768,-32768,-32768, -562, 1012,-32768, -666, 519,
+  -553, -198,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,
+-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768, 930, 754,
+-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768,-32768, 651,
+-32768,-32768,-32768,-32768, 1479,-32768,-32768,-32768, 1480,-32768,
+-32768,-32768,-32768,-32768,-32768,-32768,-32768, 1349,-32768,-32768,
+-32768,-32768, 1470,-32768,-32768,-32768,-32768,-32768,-32768,-32768,
+-32768,-32768,-32768
+};
+static const short yytable[] = { 152,
+   258, 77, 757, 648, 397, 325, 342, 526, 762, 192,
+     8, 766, 778, 847, 280, 192, 110, 389, 389, 237,
+   865, 8, 136, 678, 375, 136, 60, 476, 477, 294,
+   540, 316, 322, 627, 580, 214, 248, 249, 250, 251,
+   572, 1161, 913, 62, 2, 16, 322, 295, 63, 60,
+   322, 629, 173, 174, 175, 176, 195, 573, 679, 17,
+     3, 4, 154, 659, 660, 351, 254, 680, 836, 463,
+   209, 516, 361, 3, 4, 453, 869, 837, 822, 326,
+   824, 362, 836, 3, 4, 456, 155, 255, 350, 619,
+   464, 837, 331, 332, 270, 256, 257, 156, 570, 338,
+   339, 340, 681, 682, 683, 661, 621, 210, 201, 838,
+    18, 19, 625, 870, 839, 192, 571, 913, 136, 271,
+   327, 192, 5, 838, 300, 301, 620, 1042, 839, 684,
+   667, 637, 50, 462, 136, 5, 328, 1007, 871, 296,
+   323, 324, 510, 622, 51, 5, 3, 4, 886, 442,
+   443, 444, 445, 446, 323, 324, 458, 452, 323, 324,
+    20, 157, 615, 508, 366, 367, 302, 303, 304, 401,
+    21, 616, 305, 815, 306, 509, 136, 343, 344, 345,
+   346, 921, 623, 924, 421, 31, 940, 347, 891, 441,
+   255, 397, 310, 422, 244, 34, 60, 389, 256, 257,
+   252, 533, 534, 535, 697, 573, 835, 285, 5, 850,
+   575, 803, 726, 62, 617, 618, 35, 307, 63, 624,
+   286, 135, 853, 308, 140, 423, 424, 425, 426, 427,
+   428, 697, 173, 174, 175, 176, 753, 348, 177, 698,
+    23, 699, 700, 56, 57, 754, 265, 178, 804, 542,
+   544, 545, 547, 549, 266, 515, 753, 701, 702, 490,
+   379, 703, 380, 349, 311, 754, 26, 892, 699, 893,
+   499, 894, 312, 179, 180, 181, 639, 1039, 1040, 182,
+   371, 429, 755, 676, 183, 1083, 32, 1091, 16, 350,
+   397, 836, 677, 389, 369, 726, 726, 370, 1030, 1031,
+   837, 372, 755, 628, 628, 373, 640, 632, 743, 634,
+    78, 79, 80, 81, 82, 297, 536, 83, 491, 350,
+   298, 614, 299, 576, 184, 59, 185, 84, 473, 186,
+   187, 188, 189, 190, 191, 556, 128, 839, 607, 85,
+   342, 86, 36, 129, 179, 180, 181, 568, 260, 372,
+   569, 158, 545, 373, 547, 494, 372, 609, 663, 372,
+   373, 727, 728, 373, 645, 87, 159, 160, 254, 543,
+    90, 88, 1082, 539, 539, 855, 447, 350, 89, 372,
+   112, 448, 350, 373, 113, 675, 226, 227, 228, 255,
+   173, 174, 175, 176, 230, 692, 177, 256, 257, 600,
+   612, 261, 758, 759, 118, 178, 704, 848, 791, 254,
+   707, 708, 1120, 192, 1033, 1034, 849, 1112, 664, 774,
+   255, 350, 792, 350, 119, 560, 120, 793, 256, 257,
+   255, 179, 180, 181, 123, 350, 646, 647, 256, 257,
+   350, 133, 183, 811, 139, 67, 68, 69, 70, 614,
+    71, 72, 73, 74, 490, 162, 75, 714, 812, 665,
+   745, 747, 749, 1146, 372, 499, 470, 1056, 373, 62,
+   685, 99, 100, 567, 63, 539, 1148, 471, 172, 372,
+   350, 472, 184, 373, 185, 1081, 146, 186, 187, 188,
+   189, 190, 191, 159, 160, 833, 725, 500, 501, 502,
+   503, 491, 1057, 504, 343, 344, 345, 346, 60, 61,
+   649, 834, 62, 904, 347, 350, 372, 63, 764, 147,
+   373, 767, 905, 163, 650, 62, 851, 179, 180, 181,
+    63, 165, 372, 854, 739, 740, 373, 196, 494, 1054,
+   173, 174, 175, 176, 505, 194, 177, 372, 199, 994,
+  1059, 373, 208, 930, 1012, 178, 800, 219, 855, 500,
+   501, 502, 503, 350, 348, 504, 343, 344, 345, 346,
+   372, 675, 203, 204, 373, 372, 347, 920, 1127, 373,
+   794, 179, 180, 181, 987, 884, 885, 198, 692, 795,
+   349, 220, 183, 988, 938, 830, 62, 801, 1123, 372,
+   805, 63, 807, 373, 809, 62, 841, 1124, 1125, 844,
+    63, 350, 221, 60, 213, 226, 227, 228, 229, 816,
+   350, 350, 223, 230, 231, 239, 348, 896, 898, 930,
+    62, 242, 184, 243, 185, 63, 614, 186, 187, 188,
+   189, 190, 191, 173, 174, 175, 176, 842, 245, 341,
+   845, 253, 349, 856, 614, 205, 206, 852, 147, 211,
+    60, 290, 858, 859, 860, 861, 862, 272, 78, 79,
+    60, 432, 902, 173, 174, 175, 176, 62, 909, 177,
+   491, 267, 63, 273, 274, 141, 278, 62, 178, 279,
+   922, 284, 63, 614, 614, 614, 142, 85, 143, 86,
+   144, 111, 288, 145, 114, 115, 179, 180, 181, 60,
+   466, 291, 854, 903, 179, 180, 181, 494, 565, 566,
+   333, 334, 215, 87, 313, 183, 62, 216, 217, 88,
+   315, 63, 511, 512, 513, 329, 89, 855, 60, 467,
+  1005, 1006, 330, 1010, 519, 613, 975, 173, 174, 175,
+   176, 983, 335, 177, 336, 62, 337, 949, 950, 491,
+    63, 953, 178, 955, 996, 957, 352, 185, 578, 666,
+   186, 187, 188, 189, 190, 191, 353, 1008, 60, 635,
+   695, 696, 519, 735, 354, 179, 180, 181, 179, 180,
+   181, 492, 984, 355, 493, 62, 494, 495, 1098, 183,
+    63, 796, 797, 357, 856, 997, 226, 227, 228, 358,
+    60, 655, 496, 497, 230, 359, 498, 1037, 826, 827,
+   363, 1013, 350, 1015, 1016, 1017, 1018, 62, 890, 1046,
+   364, 413, 63, 365, 614, 614, 796, 888, 376, 414,
+   415, 185, 368, 675, 186, 187, 188, 189, 190, 191,
+   519, 908, 519, 927, 382, 692, 480, 381, 1038, 173,
+   174, 175, 176, 60, 656, 481, 179, 180, 181, 1094,
+  1095, 1096, 416, 1048, 482, 856, 383, 417, 519, 965,
+    62, 394, 614, 418, 419, 63, 519, 966, 1084, 173,
+   174, 175, 176, 519, 967, 481, 60, 713, 60, 733,
+   179, 180, 181, 408, 482, 1070, 483, 484, 485, 486,
+   487, 488, 412, 62, 410, 62, 491, 1078, 63, 430,
+    63, 519, 1076, 519, 1077, 431, 1028, 709, 710, 1085,
+   179, 180, 181, 550, 551, 433, 489, 484, 485, 486,
+   487, 488, 179, 180, 181, 60, 734, 413, 1097, 435,
+   413, 493, 436, 494, 495, 414, 415, 1106, 414, 415,
+   439, 440, 62, 450, 454, 451, 489, 63, 455, 496,
+   497, 413, 1119, 498, 457, 60, 752, 460, 541, 414,
+   415, 469, 179, 180, 181, 179, 180, 181, 557, 474,
+   519, 760, 62, 417, 522, 523, 417, 63, 524, 418,
+   419, 413, 418, 419, 60, 773, 179, 180, 181, 414,
+   415, 1145, 776, 60, 818, 525, 531, 417, 532, 537,
+   413, 62, 552, 418, 419, 553, 63, 563, 414, 415,
+    62, 564, 578, 582, 583, 63, 179, 180, 181, 1158,
+  1105, 413, 821, 585, 587, 60, 819, 417, 589, 414,
+   415, 592, 593, 418, 419, 179, 180, 181, 595, 596,
+   413, 823, 62, 597, 60, 874, 417, 63, 414, 415,
+   599, 598, 418, 419, 668, 603, 179, 180, 181, 604,
+   413, 62, 825, 413, 608, 610, 63, 417, 414, 415,
+   611, 414, 415, 418, 419, 179, 180, 181, 633, 636,
+   638, 968, 413, 642, 644, 654, 417, 657, 673, 689,
+   414, 415, 418, 419, 686, 179, 180, 181, 179, 180,
+   181, 969, 690, 60, 878, 1131, 417, 60, 880, 417,
+   693, 694, 418, 419, 705, 418, 419, 179, 180, 181,
+    62, 738, 712, 716, 62, 63, 717, 719, 417, 63,
+   721, 723, 558, 559, 418, 419, 67, 68, 69, 70,
+   724, 71, 72, 73, 74, 60, 882, 75, 67, 68,
+    69, 70, 729, 71, 72, 73, 74, 60, 887, 75,
+    60, 916, 62, 60, 919, 730, 731, 63, 732, 60,
+   926, 60, 933, 741, 62, 744, 1027, 62, 746, 63,
+    62, 748, 63, 60, 934, 63, 62, 750, 62, 60,
+   935, 63, 751, 63, 756, 60, 936, 60, 937, 761,
+    62, 60, 974, 60, 1021, 63, 62, 60, 1022, 60,
+  1024, 63, 62, 769, 62, 60, 1025, 63, 62, 63,
+    62, 60, 1026, 63, 62, 63, 62, 60, 1045, 63,
+   771, 63, 62, 60, 1052, 60, 1061, 63, 62, 60,
+  1062, 60, 1063, 63, 62, 60, 1064, 60, 1065, 63,
+    62, 777, 62, 60, 1080, 63, 62, 63, 62, 60,
+  1086, 63, 62, 63, 62, 60, 1101, 63, 785, 63,
+    62, 60, 1107, 60, 1114, 63, 62, 60, 1126, 60,
+  1130, 63, 62, 60, 1136, 60, 1150, 63, 62, 786,
+    62, 60, 1159, 63, 62, 63, 62, 788, 789, 63,
+    62, 63, 62, 790, 829, 63, 802, 63, 62, 67,
+    68, 69, 70, 63, 71, 72, 73, 74, 806, 808,
+    75, 91, 92, 93, 94, 95, 96, 810, 97, 813,
+   814, 98, 832, 864, 840, 843, 866, 857, 867, 868,
+   872, 873, 877, 889, 895, 897, 899, 911, 914, 917,
+   915, 918, 928, 931, 932, 945, 951, 946, 947, 948,
+   952, 954, 956, 958, 959, 960, 970, 962, 963, 964,
+   971, 973, 977, 980, 164, 985, 989, 990, 992, 993,
+   995, 998, 999, 1019, 1002, 1003, 1011, 1014, 1020, 222,
+  1029, 695, 1036, 1041, 1043, 1044, 1050, 1051, 1055, 1053,
+  1058, 1068, 1069, 1071, 1072, 1073, 1074, 820, 1079, 1088,
+  1089, 1093, 1099, 1100, 1102, 1103, 1104, 1108, 1109, 1110,
+   132, 1111, 1113, 1115, 1116, 1117, 1118, 1121, 1122, 1128,
+  1132, 1133, 1134, 1135, 1137, 1138, 1139, 1140, 1141, 1142,
+  1144, 1147, 1149, 1151, 1152, 1153, 1162, 1154, 1155, 1160,
+   393, 101, 517, 641, 643, 986, 1087, 687, 979, 1092,
+   396, 1004, 404, 1156, 102, 1032, 706, 972, 530, 574,
+    22, 817, 651, 24, 0, 0, 212, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 104, 107, 109
+};
+static const short yycheck[] = { 117,
+   193, 35, 670, 557, 305, 231, 253, 421, 674, 133,
+     1, 678, 691, 770, 207, 139, 50, 303, 304, 177,
+   787, 12, 86, 586, 293, 89, 3, 377, 378, 3,
+   438, 230, 3, 4, 483, 153, 187, 188, 189, 190,
+     4, 0, 838, 20, 3, 26, 3, 21, 25, 3,
+     3, 4, 7, 8, 9, 10, 137, 21, 13, 40,
+    32, 33, 4, 46, 47, 258, 3, 22, 13, 3,
+    22, 25, 13, 32, 33, 4, 22, 22, 745, 237,
+   747, 22, 13, 32, 33, 354, 28, 24, 17, 22,
+    24, 22, 243, 244, 198, 32, 33, 39, 3, 250,
+   251, 252, 57, 58, 59, 88, 22, 59, 142, 54,
+    91, 92, 526, 59, 59, 239, 21, 913, 182, 200,
+   238, 245, 94, 54, 3, 4, 59, 58, 59, 84,
+   579, 539, 81, 359, 198, 94, 240, 114, 84, 113,
+   111, 112, 411, 59, 93, 94, 32, 33, 815, 342,
+   343, 344, 345, 346, 111, 112, 355, 350, 111, 112,
+    17, 103, 13, 19, 282, 283, 45, 46, 47, 3,
+    11, 22, 51, 736, 53, 31, 240, 14, 15, 16,
+    17, 847, 22, 850, 13, 33, 865, 24, 4, 340,
+    24, 492, 226, 22, 185, 41, 3, 483, 32, 33,
+   191, 427, 428, 429, 22, 21, 760, 93, 94, 772,
+   479, 22, 626, 20, 65, 66, 62, 96, 25, 59,
+   211, 86, 776, 102, 89, 54, 55, 56, 57, 58,
+    59, 22, 7, 8, 9, 10, 13, 74, 13, 57,
+     3, 59, 60, 3, 4, 22, 19, 22, 59, 442,
+   443, 444, 445, 446, 27, 413, 13, 75, 76, 383,
+    19, 79, 21, 100, 19, 22, 3, 821, 59, 823,
+   394, 825, 27, 48, 49, 50, 4, 54, 55, 54,
+     4, 110, 59, 13, 59, 1042, 3, 1054, 26, 17,
+   591, 13, 22, 579, 285, 709, 710, 288, 965, 966,
+    22, 25, 59, 529, 530, 29, 4, 533, 658, 535,
+    35, 36, 37, 38, 39, 14, 434, 42, 22, 17,
+    19, 520, 21, 481, 99, 26, 101, 52, 4, 104,
+   105, 106, 107, 108, 109, 4, 19, 59, 4, 64,
+   587, 66, 3, 26, 48, 49, 50, 465, 42, 25,
+   468, 4, 545, 29, 547, 59, 25, 515, 4, 25,
+    29, 630, 631, 29, 4, 90, 19, 20, 3, 4,
+     4, 96, 1040, 437, 438, 79, 20, 17, 103, 25,
+    11, 25, 17, 29, 4, 584, 80, 81, 82, 24,
+     7, 8, 9, 10, 88, 594, 13, 32, 33, 3,
+   518, 95, 671, 672, 23, 22, 599, 13, 4, 3,
+   603, 604, 1091, 537, 968, 969, 22, 1083, 576, 688,
+    24, 17, 4, 17, 4, 459, 4, 4, 32, 33,
+    24, 48, 49, 50, 3, 17, 554, 555, 32, 33,
+    17, 3, 59, 4, 3, 19, 20, 21, 22, 648,
+    24, 25, 26, 27, 578, 19, 30, 615, 4, 577,
+   659, 660, 661, 1131, 25, 589, 14, 4, 29, 20,
+   588, 3, 4, 464, 25, 539, 1143, 25, 4, 25,
+    17, 29, 99, 29, 101, 1039, 3, 104, 105, 106,
+   107, 108, 109, 19, 20, 4, 4, 7, 8, 9,
+    10, 22, 4, 13, 14, 15, 16, 17, 3, 4,
+    84, 4, 20, 13, 24, 17, 25, 25, 676, 3,
+    29, 679, 22, 4, 558, 20, 4, 48, 49, 50,
+    25, 3, 25, 54, 652, 653, 29, 81, 59, 60,
+     7, 8, 9, 10, 54, 4, 13, 25, 4, 4,
+     4, 29, 26, 854, 4, 22, 714, 19, 79, 7,
+     8, 9, 10, 17, 74, 13, 14, 15, 16, 17,
+    25, 770, 68, 69, 29, 25, 24, 846, 4, 29,
+     4, 48, 49, 50, 13, 811, 812, 54, 787, 4,
+   100, 4, 59, 22, 863, 753, 20, 715, 4, 25,
+   718, 25, 720, 29, 722, 20, 764, 4, 4, 767,
+    25, 17, 14, 3, 4, 80, 81, 82, 83, 737,
+    17, 17, 4, 88, 89, 3, 74, 826, 827, 930,
+    20, 3, 99, 19, 101, 25, 835, 104, 105, 106,
+   107, 108, 109, 7, 8, 9, 10, 765, 3, 13,
+   768, 3, 100, 777, 853, 71, 72, 775, 3, 4,
+     3, 4, 780, 781, 782, 783, 784, 4, 35, 36,
+     3, 4, 830, 7, 8, 9, 10, 20, 836, 13,
+    22, 82, 25, 3, 4, 52, 33, 20, 22, 33,
+   848, 3, 25, 892, 893, 894, 63, 64, 65, 66,
+    67, 51, 5, 70, 54, 55, 48, 49, 50, 3,
+     4, 21, 54, 831, 48, 49, 50, 59, 23, 24,
+    54, 55, 14, 90, 3, 59, 20, 19, 20, 96,
+     3, 25, 85, 86, 87, 4, 103, 79, 3, 4,
+   933, 934, 22, 936, 3, 4, 904, 7, 8, 9,
+    10, 909, 4, 13, 4, 20, 4, 875, 876, 22,
+    25, 879, 22, 881, 922, 883, 3, 101, 3, 4,
+   104, 105, 106, 107, 108, 109, 3, 935, 3, 4,
+    23, 24, 3, 4, 3, 48, 49, 50, 48, 49,
+    50, 54, 910, 88, 57, 20, 59, 60, 1067, 59,
+    25, 3, 4, 4, 928, 923, 80, 81, 82, 83,
+     3, 4, 75, 76, 88, 89, 79, 975, 46, 47,
+     4, 939, 17, 941, 942, 943, 944, 20, 819, 987,
+     4, 13, 25, 4, 1033, 1034, 3, 4, 61, 21,
+    22, 101, 22, 1042, 104, 105, 106, 107, 108, 109,
+     3, 4, 3, 4, 3, 1054, 4, 97, 976, 7,
+     8, 9, 10, 3, 4, 13, 48, 49, 50, 1062,
+  1063, 1064, 54, 991, 22, 999, 3, 59, 3, 4,
+    20, 3, 1081, 65, 66, 25, 3, 4, 1046, 7,
+     8, 9, 10, 3, 4, 13, 3, 4, 3, 4,
+    48, 49, 50, 3, 22, 1023, 54, 55, 56, 57,
+    58, 59, 3, 20, 34, 20, 22, 1035, 25, 4,
+    25, 3, 4, 3, 4, 4, 960, 605, 606, 1047,
+    48, 49, 50, 447, 448, 4, 84, 55, 56, 57,
+    58, 59, 48, 49, 50, 3, 4, 13, 1066, 4,
+    13, 57, 4, 59, 60, 21, 22, 1075, 21, 22,
+     4, 4, 20, 4, 26, 30, 84, 25, 22, 75,
+    76, 13, 1090, 79, 3, 3, 4, 4, 4, 21,
+    22, 6, 48, 49, 50, 48, 49, 50, 54, 21,
+     3, 54, 20, 59, 3, 3, 59, 25, 3, 65,
+    66, 13, 65, 66, 3, 4, 48, 49, 50, 21,
+    22, 1129, 54, 3, 4, 3, 3, 59, 3, 3,
+    13, 20, 4, 65, 66, 4, 25, 3, 21, 22,
+    20, 4, 3, 3, 3, 25, 48, 49, 50, 1157,
+  1074, 13, 54, 3, 3, 3, 4, 59, 3, 21,
+    22, 3, 3, 65, 66, 48, 49, 50, 3, 3,
+    13, 54, 20, 3, 3, 4, 59, 25, 21, 22,
+    73, 3, 65, 66, 3, 73, 48, 49, 50, 73,
+    13, 20, 54, 13, 33, 4, 25, 59, 21, 22,
+     4, 21, 22, 65, 66, 48, 49, 50, 4, 4,
+     4, 54, 13, 4, 4, 4, 59, 61, 3, 22,
+    21, 22, 65, 66, 4, 48, 49, 50, 48, 49,
+    50, 54, 3, 3, 4, 55, 59, 3, 4, 59,
+    24, 24, 65, 66, 4, 65, 66, 48, 49, 50,
+    20, 33, 4, 3, 20, 25, 3, 3, 59, 25,
+     3, 3, 3, 4, 65, 66, 19, 20, 21, 22,
+     4, 24, 25, 26, 27, 3, 4, 30, 19, 20,
+    21, 22, 4, 24, 25, 26, 27, 3, 4, 30,
+     3, 4, 20, 3, 4, 4, 4, 25, 4, 3,
+     4, 3, 4, 4, 20, 3, 59, 20, 3, 25,
+    20, 3, 25, 3, 4, 25, 20, 98, 20, 3,
+     4, 25, 4, 25, 4, 3, 4, 3, 4, 3,
+    20, 3, 4, 3, 4, 25, 20, 3, 4, 3,
+     4, 25, 20, 3, 20, 3, 4, 25, 20, 25,
+    20, 3, 4, 25, 20, 25, 20, 3, 4, 25,
+     3, 25, 20, 3, 4, 3, 4, 25, 20, 3,
+     4, 3, 4, 25, 20, 3, 4, 3, 4, 25,
+    20, 3, 20, 3, 4, 25, 20, 25, 20, 3,
+     4, 25, 20, 25, 20, 3, 4, 25, 3, 25,
+    20, 3, 4, 3, 4, 25, 20, 3, 4, 3,
+     4, 25, 20, 3, 4, 3, 4, 25, 20, 3,
+    20, 3, 4, 25, 20, 25, 20, 3, 3, 25,
+    20, 25, 20, 3, 3, 25, 22, 25, 20, 19,
+    20, 21, 22, 25, 24, 25, 26, 27, 22, 22,
+    30, 38, 39, 40, 41, 42, 43, 22, 45, 4,
+     4, 48, 3, 22, 4, 3, 24, 4, 24, 24,
+     4, 4, 3, 20, 3, 3, 3, 3, 3, 22,
+     4, 4, 3, 3, 3, 3, 22, 82, 4, 4,
+     4, 4, 4, 4, 4, 3, 26, 4, 4, 4,
+     4, 4, 3, 3, 125, 4, 4, 4, 4, 4,
+     4, 3, 3, 22, 4, 4, 4, 4, 3, 168,
+     4, 23, 4, 4, 4, 4, 4, 4, 4, 22,
+     4, 4, 4, 4, 4, 4, 3, 742, 4, 4,
+     4, 4, 4, 4, 4, 4, 4, 4, 4, 3,
+    85, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+     4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+     4, 4, 4, 4, 4, 3, 0, 4, 4, 4,
+   304, 49, 414, 545, 547, 913, 1049, 591, 906, 1060,
+   305, 930, 306, 22, 49, 967, 602, 901, 424, 478,
+    12, 738, 563, 14, -1, -1, 148, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, 49, 49, 49
+};
+
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+
+int
+ PDDL_Parser::
+     yyparse(void)
+{
+  register int yystate;
+  register int yyn;
+  register short *yyssp;
+  register yy_PDDL_Parser_stype *yyvsp;
+  int yyerrstatus;
+  int yychar1=0;
+  short yyssa[200];
+  yy_PDDL_Parser_stype yyvsa[200];
+  short *yyss = yyssa;
+  yy_PDDL_Parser_stype *yyvs = yyvsa;
+  int yystacksize = 200;
+  yy_PDDL_Parser_stype yyval;
+  int yylen;
+
+  if (yydebug)
+    fprintf(stderr, "Starting parse\n");
+  yystate = 0;
+  yyerrstatus = 0;
+  yynerrs = 0;
+  yychar = -2;
+  yyssp = yyss - 1;
+  yyvsp = yyvs;
+yynewstate:
+  *++yyssp = yystate;
+  if (yyssp >= yyss + yystacksize - 1)
+    {
+      yy_PDDL_Parser_stype *yyvs1 = yyvs;
+      short *yyss1 = yyss;
+      int size = yyssp - yyss + 1;
+      if (yystacksize >= 10000)
+ {
+   log_error("parser stack overflow");
+   return(2);
+ }
+      yystacksize *= 2;
+      if (yystacksize > 10000)
+ yystacksize = 10000;
+      yyss = (short *) __builtin_alloca(yystacksize * sizeof (*yyssp));
+      __builtin_memcpy((char *)yyss,(char *)yyss1,size * sizeof (*yyssp));
+      ;
+      yyvs = (yy_PDDL_Parser_stype *) __builtin_alloca(yystacksize * sizeof (*yyvsp));
+      __builtin_memcpy((char *)yyvs,(char *)yyvs1,size * sizeof (*yyvsp));
+      ;
+      yyssp = yyss + size - 1;
+      yyvsp = yyvs + size - 1;
+      if (yydebug)
+ fprintf(stderr, "Stack size increased to %d\n", yystacksize);
+      if (yyssp >= yyss + yystacksize - 1)
+ return(1);
+    }
+  if (yydebug)
+    fprintf(stderr, "Entering state %d\n", yystate);
+  goto yybackup;
+yybackup:
+  yyn = yypact[yystate];
+  if (yyn == -32768)
+    goto yydefault;
+  if (yychar == -2)
+    {
+      if (yydebug)
+ fprintf(stderr, "Reading a token: ");
+      yychar = next_token();
+    }
+  if (yychar <= 0)
+    {
+      yychar1 = 0;
+      yychar = 0;
+      if (yydebug)
+ fprintf(stderr, "Now at end of input.\n");
+    }
+  else
+    {
+      yychar1 = ((unsigned)(yychar) <= 369 ? yytranslate[yychar] : 369);
+      if (yydebug)
+ {
+   fprintf (stderr, "Next token is %d (%s", yychar, yytname[yychar1]);
+   fprintf (stderr, ")\n");
+ }
+    }
+  yyn += yychar1;
+  if (yyn < 0 || yyn > 1519 || yycheck[yyn] != yychar1)
+    goto yydefault;
+  yyn = yytable[yyn];
+  if (yyn < 0)
+    {
+      if (yyn == -32768)
+ goto yyerrlab;
+      yyn = -yyn;
+      goto yyreduce;
+    }
+  else if (yyn == 0)
+    goto yyerrlab;
+  if (yyn == 1162)
+    return(0);
+  if (yydebug)
+    fprintf(stderr, "Shifting token %d (%s), ", yychar, yytname[yychar1]);
+  if (yychar != 0)
+    yychar = -2;
+  *++yyvsp = yylval;
+  if (yyerrstatus) yyerrstatus--;
+  yystate = yyn;
+  goto yynewstate;
+yydefault:
+  yyn = yydefact[yystate];
+  if (yyn == 0)
+    goto yyerrlab;
+yyreduce:
+  yylen = yyr2[yyn];
+  if (yylen > 0)
+    yyval = yyvsp[1-yylen];
+  if (yydebug)
+    {
+      int i;
+      fprintf (stderr, "Reducing via rule %d (line %d), ",
+        yyn, yyrline[yyn]);
+      for (i = yyprhs[yyn]; yyrhs[i] > 0; i++)
+ fprintf (stderr, "%s ", yytname[yyrhs[i]]);
+      fprintf (stderr, " -> %s\n", yytname[yyr1[yyn]]);
+    }
+  switch (yyn) {
+case 17:
+{
+  domain_name = yyvsp[-1].sym->text;
+  if (current_file()) domain_file = strdup(current_file());
+;
+    break;}
+case 18:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 19:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 20:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 21:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 22:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 23:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 24:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 25:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 26:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 27:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 28:
+{ yyval.sym = yyvsp[0].sym; ;
+    break;}
+case 37:
+{
+  current_param.clear()
+;
+    break;}
+case 38:
+{
+  PredicateSymbol* p = new PredicateSymbol(yyvsp[-3].sym->text);
+  p->param = current_param;
+  dom_predicates.append(p);
+  clear_context(current_param);
+  yyvsp[-3].sym->val = p;
+;
+    break;}
+case 39:
+{
+  set_variable_type(current_param, (TypeSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 40:
+{
+  current_type_set.clear();
+;
+    break;}
+case 41:
+{
+  set_variable_type(current_param, current_type_set);
+;
+    break;}
+case 42:
+{
+  set_variable_type(current_param, dom_top_type);
+;
+    break;}
+case 44:
+{
+  yyvsp[0].sym->val = new VariableSymbol(yyvsp[0].sym->text);
+  current_param.append((VariableSymbol*)yyvsp[0].sym->val);
+  if (trace_print_context) {
+    std::cerr << "variable ";
+    current_param[current_param.length() - 1]->print(std::cerr);
+    std::cerr << " added to context (now "
+       << current_param.length() << " variables)"
+       << std::endl;
+  }
+;
+    break;}
+case 45:
+{
+  std::cerr << "error: variable ";
+  ((VariableSymbol*)yyvsp[0].sym->val)->print(std::cerr);
+  std::cerr << " redeclared" << std::endl;
+  exit(255);
+;
+    break;}
+case 46:
+{
+  yyvsp[0].sym->val = new VariableSymbol(yyvsp[0].sym->text);
+  current_param.append((VariableSymbol*)yyvsp[0].sym->val);
+  if (trace_print_context) {
+    std::cerr << "variable ";
+    current_param[current_param.length() - 1]->print(std::cerr);
+    std::cerr << " added to context (now "
+       << current_param.length() << " variables)"
+       << std::endl;
+  }
+;
+    break;}
+case 47:
+{
+  std::cerr << "error: variable ";
+  ((VariableSymbol*)yyvsp[0].sym->val)->print(std::cerr);
+  std::cerr << " redeclared" << std::endl;
+  exit(255);
+;
+    break;}
+case 48:
+{
+  current_type_set.append((TypeSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 49:
+{
+  current_type_set.append((TypeSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 50:
+{
+  last_n_functions = dom_functions.length();
+;
+    break;}
+case 52:
+{
+  last_n_functions = dom_functions.length();
+;
+    break;}
+case 54:
+{
+  TypeSymbol* t = (TypeSymbol*)yyvsp[0].sym->val;
+  for (hsps::index_type k = last_n_functions; k < dom_functions.length(); k++){
+    if (write_info) {
+      std::cerr << "info: converting ";
+      dom_functions[k]->print(std::cerr);
+      std::cerr << " to object function with type " << t->print_name
+  << std::endl;
+    }
+    hsps::PDDL_Base::ObjectFunctionSymbol* f =
+      new hsps::PDDL_Base::ObjectFunctionSymbol(dom_functions[k]->print_name);
+    f->param = dom_functions[k]->param;
+    f->sym_types.assign_value(t, 1);
+    dom_object_functions.append(f);
+    hsps::StringTable::Cell* c =
+      (hsps::StringTable::Cell*)tab.find(f->print_name);
+    if (c == 0) {
+      std::cerr << "very bad error: function "
+  << dom_functions[k]->print_name
+  << " declared but not found in string table!"
+  << std::endl;
+      exit(255);
+    }
+    c->val = f;
+  }
+  dom_functions.set_length(last_n_functions);
+;
+    break;}
+case 56:
+{
+  for (hsps::index_type k = last_n_functions; k < dom_functions.length(); k++){
+    if (write_info) {
+      std::cerr << "info: converting ";
+      dom_functions[k]->print(std::cerr);
+      std::cerr << " to object function with type ";
+      current_type_set.write_type(std::cerr);
+      std::cerr << std::endl;
+    }
+    hsps::PDDL_Base::ObjectFunctionSymbol* f =
+      new hsps::PDDL_Base::ObjectFunctionSymbol(dom_functions[k]->print_name);
+    f->param = dom_functions[k]->param;
+    f->sym_types.assign_copy(current_type_set);
+    dom_object_functions.append(f);
+    hsps::StringTable::Cell* c =
+      (hsps::StringTable::Cell*)tab.find(f->print_name);
+    if (c == 0) {
+      std::cerr << "very bad error: function "
+  << dom_functions[k]->print_name
+  << " declared but not found in string table!"
+  << std::endl;
+      exit(255);
+    }
+    c->val = f;
+  }
+  dom_functions.set_length(last_n_functions);
+;
+    break;}
+case 58:
+{
+  last_n_functions = dom_functions.length();
+;
+    break;}
+case 62:
+{
+  current_param.clear();
+;
+    break;}
+case 63:
+{
+  FunctionSymbol* f = new FunctionSymbol(yyvsp[-3].sym->text);
+  f->param = current_param;
+  dom_functions.append(f);
+  clear_context(current_param);
+  yyvsp[-3].sym->val = f;
+;
+    break;}
+case 64:
+{
+  current_type_set.clear();
+;
+    break;}
+case 66:
+{
+  for (hsps::index_type k = 0; k < current_type_set.length(); k++)
+    current_type_set[k]->sym_types.assign_value((TypeSymbol*)yyvsp[0].sym->val, 1);
+  current_type_set.clear();
+;
+    break;}
+case 67:
+{
+  yyvsp[0].sym->val = new TypeSymbol(yyvsp[0].sym->text);
+  ((TypeSymbol*)yyvsp[0].sym->val)->sym_types.assign_value(dom_top_type, 1);
+  dom_types.append((TypeSymbol*)yyvsp[0].sym->val);
+  for (hsps::index_type k = 0; k < current_type_set.length(); k++)
+    current_type_set[k]->sym_types.assign_value((TypeSymbol*)yyvsp[0].sym->val, 1);
+  current_type_set.clear();
+;
+    break;}
+case 68:
+{
+  for (hsps::index_type k = 0; k < current_type_set.length(); k++)
+    current_type_set[k]->sym_types.assign_value(dom_top_type, 1);
+  current_type_set.clear();
+;
+    break;}
+case 70:
+{
+  current_type_set.append((TypeSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 71:
+{
+  yyvsp[0].sym->val = new TypeSymbol(yyvsp[0].sym->text);
+  dom_types.append((TypeSymbol*)yyvsp[0].sym->val);
+  current_type_set.append((TypeSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 75:
+{
+  set_constant_type(dom_constants, (TypeSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 76:
+{
+  set_constant_type(dom_constants, dom_top_type);
+;
+    break;}
+case 78:
+{
+  yyvsp[0].sym->val = new Symbol(yyvsp[0].sym->text);
+  if (problem_name) {
+    ((Symbol*)yyvsp[0].sym->val)->defined_in_problem = true;
+  }
+  dom_constants.append((Symbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 79:
+{
+  yyvsp[0].sym->val = new Symbol(yyvsp[0].sym->text);
+  if (problem_name) {
+    ((Symbol*)yyvsp[0].sym->val)->defined_in_problem = true;
+  }
+  dom_constants.append((Symbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 80:
+{
+  if (write_warnings) {
+    std::cerr << "warning: redeclaration of constant " << yyvsp[0].sym->text
+       << " ignored" << std::endl;
+  }
+;
+    break;}
+case 81:
+{
+  if (write_warnings) {
+    std::cerr << "warning: redeclaration of constant " << yyvsp[0].sym->text
+       << " ignored" << std::endl;
+  }
+;
+    break;}
+case 85:
+{
+  dom_actions.append(new ActionSymbol(yyvsp[0].sym->text));
+;
+    break;}
+case 86:
+{
+  clear_context(current_param);
+  yyvsp[-3].sym->val = dom_actions[dom_actions.length() - 1];
+;
+    break;}
+case 87:
+{
+  current_param.clear();
+;
+    break;}
+case 88:
+{
+  dom_actions[dom_actions.length() - 1]->param = current_param;
+;
+    break;}
+case 95:
+{
+  dom_actions[dom_actions.length() - 1]->assoc = yyvsp[0].sval;
+;
+    break;}
+case 97:
+{
+  SetSymbol* ssym = new SetSymbol(yyvsp[0].sym->text);
+  yyvsp[0].sym->val = ssym;
+  partitions.append(ssym);
+  SetName* s = new SetName(ssym);
+  current_atom = s;
+;
+    break;}
+case 98:
+{
+  dom_actions[dom_actions.length() - 1]->part = (SetName*)current_atom;
+;
+    break;}
+case 99:
+{
+  SetName* s = new SetName((SetSymbol*)yyvsp[0].sym->val);
+  current_atom = s;
+;
+    break;}
+case 100:
+{
+  dom_actions[dom_actions.length() - 1]->part = (SetName*)current_atom;
+;
+    break;}
+case 112:
+{
+  dom_actions[dom_actions.length() - 1]->num_pre.append(yyvsp[0].rel);
+;
+    break;}
+case 113:
+{
+  yyval.tkw = PDDL_Base::md_start;
+;
+    break;}
+case 114:
+{
+  yyval.tkw = PDDL_Base::md_end;
+;
+    break;}
+case 115:
+{
+  yyval.tkw = PDDL_Base::md_all;
+;
+    break;}
+case 116:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 117:
+{
+  ((Atom*)current_atom)->check();
+  dom_actions[dom_actions.length() - 1]->pos_pre.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+;
+    break;}
+case 118:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-2].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-1].sym->val;
+  dom_actions[dom_actions.length() - 1]->pos_pre.append(eq_atom);
+;
+    break;}
+case 119:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, yyvsp[-2].tkw);
+;
+    break;}
+case 120:
+{
+  ((Atom*)current_atom)->check();
+  dom_actions[dom_actions.length() - 1]->pos_pre.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+;
+    break;}
+case 121:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred, yyvsp[-6].tkw);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-3].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-2].sym->val;
+  dom_actions[dom_actions.length() - 1]->pos_pre.append(eq_atom);
+;
+    break;}
+case 122:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 123:
+{
+  ((Atom*)current_atom)->check();
+  dom_actions[dom_actions.length() - 1]->neg_pre.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+;
+    break;}
+case 124:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-3].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-2].sym->val;
+  dom_actions[dom_actions.length() - 1]->neg_pre.append(eq_atom);
+;
+    break;}
+case 125:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, yyvsp[-4].tkw);
+;
+    break;}
+case 126:
+{
+  ((Atom*)current_atom)->check();
+  dom_actions[dom_actions.length() - 1]->neg_pre.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+;
+    break;}
+case 127:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred, yyvsp[-9].tkw);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-4].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-3].sym->val;
+  dom_actions[dom_actions.length() - 1]->neg_pre.append(eq_atom);
+;
+    break;}
+case 128:
+{
+  if (current_atom != 0) {
+    current_atom->param.append((Symbol*)yyvsp[0].sym->val);
+  }
+;
+    break;}
+case 130:
+{
+  if (current_atom != 0) {
+    current_atom->param.append((Symbol*)yyvsp[0].sym->val);
+  }
+;
+    break;}
+case 132:
+{
+  if (yyvsp[0].sym->val == 0) {
+    log_error("undeclared variable in atom argument");
+  }
+  yyval.sym = yyvsp[0].sym;
+;
+    break;}
+case 133:
+{
+  yyval.sym = yyvsp[0].sym;
+;
+    break;}
+case 134:
+{
+  current_atom_stack.append(current_atom);
+  current_atom = new FTerm((ObjectFunctionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 135:
+{
+  ObjectFunctionSymbol* f = (ObjectFunctionSymbol*)yyvsp[-3].sym->val;
+  VariableSymbol* v =
+    (VariableSymbol*)gensym(sym_variable, "?omsk", f->sym_types);
+  v->binding = (FTerm*)current_atom;
+  assert(current_atom_stack.length() > 0);
+  current_atom = current_atom_stack[current_atom_stack.length() - 1];
+  current_atom_stack.dec_length();
+  hsps::StringTable::Cell* c =
+    (hsps::StringTable::Cell*)tab.find(v->print_name);
+  if (c == 0) {
+    std::cerr << "very bad error: omsk symbol " << v->print_name
+       << " generated but not found in string table!"
+       << std::endl;
+    exit(255);
+  }
+  yyval.sym = c;
+;
+    break;}
+case 136:
+{
+  yyval.sym = yyvsp[0].sym;
+;
+    break;}
+case 137:
+{
+  yyval.sym = yyvsp[0].sym;
+;
+    break;}
+case 138:
+{
+  yyval.rel = new Relation(yyvsp[-3].rkw, yyvsp[-2].exp, yyvsp[-1].exp);
+  yyvsp[-2].exp->mark_functions_in_condition();
+  yyvsp[-1].exp->mark_functions_in_condition();
+;
+    break;}
+case 139:
+{
+  yyval.rel = new Relation(yyvsp[-4].rkw, yyvsp[-6].tkw, yyvsp[-3].exp, yyvsp[-2].exp);
+  yyvsp[-3].exp->mark_functions_in_condition();
+  yyvsp[-2].exp->mark_functions_in_condition();
+;
+    break;}
+case 140:
+{
+  yyval.rkw = rel_greater;
+;
+    break;}
+case 141:
+{
+  yyval.rkw = rel_greater_equal;
+;
+    break;}
+case 142:
+{
+  yyval.rkw = rel_less;
+;
+    break;}
+case 143:
+{
+  yyval.rkw = rel_less_equal;
+;
+    break;}
+case 144:
+{
+  yyval.rkw = rel_equal;
+;
+    break;}
+case 145:
+{
+  yyval.exp = new BinaryExpression(exp_sub, new ConstantExpression(0), yyvsp[-1].exp);
+;
+    break;}
+case 146:
+{
+  yyval.exp = new BinaryExpression(exp_add, yyvsp[-2].exp, yyvsp[-1].exp);
+;
+    break;}
+case 147:
+{
+  yyval.exp = new BinaryExpression(exp_sub, yyvsp[-2].exp, yyvsp[-1].exp);
+;
+    break;}
+case 148:
+{
+  yyval.exp = new BinaryExpression(exp_mul, yyvsp[-2].exp, yyvsp[-1].exp);
+;
+    break;}
+case 149:
+{
+  yyval.exp = new BinaryExpression(exp_div, yyvsp[-2].exp, yyvsp[-1].exp);
+;
+    break;}
+case 150:
+{
+  yyval.exp = new BinaryExpression(exp_div, yyvsp[-2].exp, yyvsp[0].exp);
+;
+    break;}
+case 151:
+{
+  yyval.exp = new ConstantExpression(yyvsp[0].ival);
+;
+    break;}
+case 152:
+{
+  yyval.exp = new ConstantExpression(hsps::rational(yyvsp[0].rval));
+;
+    break;}
+case 153:
+{
+  yyval.exp = new TimeExpression();
+;
+    break;}
+case 154:
+{
+  yyval.exp = new PreferenceExpression((Symbol*)yyvsp[-1].sym->val);
+;
+    break;}
+case 155:
+{
+  yyval.exp = yyvsp[0].exp;
+;
+    break;}
+case 156:
+{
+  yyval.exp = yyvsp[0].exp;
+;
+    break;}
+case 157:
+{
+  yyval.exp = new BinaryExpression(exp_add, yyvsp[-1].exp, yyvsp[0].exp);
+;
+    break;}
+case 158:
+{
+  yyval.exp = yyvsp[0].exp;
+;
+    break;}
+case 159:
+{
+  yyval.exp = new BinaryExpression(exp_mul, yyvsp[-1].exp, yyvsp[0].exp);
+;
+    break;}
+case 160:
+{
+  yyval.exp = new FunctionExpression((FunctionSymbol*)yyvsp[-2].sym->val, yyvsp[-1].lst);
+;
+    break;}
+case 161:
+{
+  yyval.exp = new FunctionExpression((FunctionSymbol*)yyvsp[0].sym->val, 0);
+;
+    break;}
+case 162:
+{
+  yyval.lst = new ListExpression((VariableSymbol*)yyvsp[-1].sym->val, yyvsp[0].lst);
+;
+    break;}
+case 163:
+{
+  yyval.lst = new ListExpression((Symbol*)yyvsp[-1].sym->val, yyvsp[0].lst);
+;
+    break;}
+case 164:
+{
+  yyval.lst = 0;
+;
+    break;}
+case 165:
+{
+  stored_n_param.append(current_param.length());
+  current_context = new SetOf();
+;
+    break;}
+case 166:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 167:
+{
+  ((Atom*)current_atom)->check();
+  SetOf* s = (SetOf*)current_context;
+  s->pos_atoms.append((Atom*)current_atom);
+  dom_actions[dom_actions.length() - 1]->set_pre.append(s);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+  assert(stored_n_param.length() > 0);
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  current_context = 0;
+;
+    break;}
+case 168:
+{
+  stored_n_param.append(current_param.length());
+  current_context = new SetOf();
+;
+    break;}
+case 169:
+{
+  SetOf* s = (SetOf*)current_context;
+  for (hsps::index_type k = stored_n_param[stored_n_param.length() - 1];
+       k < current_param.length(); k++) {
+    s->param.append(current_param[k]);
+  }
+  dom_actions[dom_actions.length() - 1]->set_pre.append(s);
+;
+    break;}
+case 170:
+{
+  assert(stored_n_param.length() > 0);
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  current_context = 0;
+;
+    break;}
+case 171:
+{
+  current_context = new SetOf();
+;
+    break;}
+case 172:
+{
+  SetOf* s = (SetOf*)current_context;
+  dom_actions[dom_actions.length() - 1]->set_pre.append(s);
+;
+    break;}
+case 173:
+{
+  stored_n_param.append(current_param.length());
+  current_context = new SetOf();
+;
+    break;}
+case 174:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 175:
+{
+  ((Atom*)current_atom)->check();
+  SetOf* s = (SetOf*)current_context;
+  s->pos_atoms.append((Atom*)current_atom);
+  s->set_mode(yyvsp[-12].tkw);
+  dom_actions[dom_actions.length() - 1]->set_pre.append(s);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+  assert(stored_n_param.length() > 0);
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  current_context = 0;
+;
+    break;}
+case 176:
+{
+  stored_n_param.append(current_param.length());
+  current_context = new SetOf();
+;
+    break;}
+case 177:
+{
+  SetOf* s = (SetOf*)current_context;
+  for (hsps::index_type k = stored_n_param[stored_n_param.length() - 1];
+       k < current_param.length(); k++) {
+    s->param.append(current_param[k]);
+  }
+  dom_actions[dom_actions.length() - 1]->set_pre.append(s);
+;
+    break;}
+case 178:
+{
+  SetOf* s = (SetOf*)current_context;
+  s->set_mode(yyvsp[-10].tkw);
+  assert(stored_n_param.length() > 0);
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  current_context = 0;
+;
+    break;}
+case 179:
+{
+  current_context = new SetOf();
+;
+    break;}
+case 180:
+{
+  SetOf* s = (SetOf*)current_context;
+  s->set_mode(yyvsp[-7].tkw);
+  dom_actions[dom_actions.length() - 1]->set_pre.append(s);
+;
+    break;}
+case 189:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 190:
+{
+  ((Atom*)current_atom)->check();
+  SetOf* s = (SetOf*)current_context;
+  s->pos_atoms.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+;
+    break;}
+case 191:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 192:
+{
+  ((Atom*)current_atom)->check();
+  SetOf* s = (SetOf*)current_context;
+  s->neg_atoms.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+;
+    break;}
+case 193:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-2].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-1].sym->val;
+  SetOf* s = (SetOf*)current_context;
+  s->pos_atoms.append(eq_atom);
+;
+    break;}
+case 194:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-3].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-2].sym->val;
+  SetOf* s = (SetOf*)current_context;
+  s->neg_atoms.append(eq_atom);
+;
+    break;}
+case 195:
+{
+  current_context = new SetOf();
+;
+    break;}
+case 196:
+{
+  SetOf* s = (SetOf*)current_context;
+  dom_actions[dom_actions.length() - 1]->dis_pre.append(s);
+  current_context = 0;
+;
+    break;}
+case 198:
+{
+  stored_n_param.append(current_param.length());
+  current_context = new SetOf();
+;
+    break;}
+case 199:
+{
+  SetOf* s = (SetOf*)current_context;
+  for (hsps::index_type k = stored_n_param[stored_n_param.length() - 1];
+       k < current_param.length(); k++) {
+    s->param.append(current_param[k]);
+  }
+  dom_actions[dom_actions.length() - 1]->dis_pre.append(s);
+;
+    break;}
+case 200:
+{
+  assert(stored_n_param.length() > 0);
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  current_context = 0;
+;
+    break;}
+case 206:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 207:
+{
+  ((Atom*)current_atom)->check();
+  ((SetOf*)current_context)->pos_atoms.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+;
+    break;}
+case 208:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-2].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-1].sym->val;
+  ((SetOf*)current_context)->pos_atoms.append(eq_atom);
+;
+    break;}
+case 209:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 210:
+{
+  ((Atom*)current_atom)->check();
+  ((SetOf*)current_context)->neg_atoms.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+;
+    break;}
+case 211:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-3].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-2].sym->val;
+  ((SetOf*)current_context)->neg_atoms.append(eq_atom);
+;
+    break;}
+case 216:
+{
+  stored_n_param.append(current_param.length());
+  current_context = new SetOf();
+;
+    break;}
+case 217:
+{
+  SetOf* s = (SetOf*)current_context;
+  for (hsps::index_type k = stored_n_param[stored_n_param.length() - 1];
+       k < current_param.length(); k++) {
+    s->param.append(current_param[k]);
+  }
+;
+    break;}
+case 218:
+{
+  dom_actions[dom_actions.length() - 1]->set_eff.append((SetOf*)current_context);
+  assert(stored_n_param.length() > 0);
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  current_context = 0;
+;
+    break;}
+case 219:
+{
+  current_context = new SetOf();
+;
+    break;}
+case 220:
+{
+  dom_actions[dom_actions.length() - 1]->set_eff.append((SetOf*)current_context);
+  current_context = 0;
+;
+    break;}
+case 221:
+{
+  stored_n_param.append(current_param.length());
+  current_context = new SetOf();
+;
+    break;}
+case 222:
+{
+  SetOf* s = (SetOf*)current_context;
+  for (hsps::index_type k = stored_n_param[stored_n_param.length() - 1];
+       k < current_param.length(); k++) {
+    s->param.append(current_param[k]);
+  }
+;
+    break;}
+case 223:
+{
+  SetOf* s = (SetOf*)current_context;
+  s->set_mode(yyvsp[-10].tkw);
+  dom_actions[dom_actions.length() - 1]->set_eff.append(s);
+  assert(stored_n_param.length() > 0);
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  current_context = 0;
+;
+    break;}
+case 224:
+{
+  current_context = new SetOf();
+;
+    break;}
+case 225:
+{
+  SetOf* s = (SetOf*)current_context;
+  s->set_mode(yyvsp[-6].tkw);
+  dom_actions[dom_actions.length() - 1]->set_eff.append(s);
+  current_context = 0;
+;
+    break;}
+case 238:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+  ((PredicateSymbol*)yyvsp[0].sym->val)->modded = true;
+;
+    break;}
+case 239:
+{
+  ((Atom*)current_atom)->check();
+  if (current_context != 0) {
+    ((SetOf*)current_context)->pos_atoms.append((Atom*)current_atom);
+  }
+  else {
+    dom_actions[dom_actions.length() - 1]->adds.append((Atom*)current_atom);
+  }
+;
+    break;}
+case 240:
+{
+  current_atom = new FTerm((ObjectFunctionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 241:
+{
+  FTerm* ft = (FTerm*)current_atom;
+  ft->fun->modded = true;
+  VariableSymbol* v =
+    (VariableSymbol*)gensym(sym_variable,"?omsk",ft->fun->sym_types);
+  v->binding = ft;
+  Atom* a = new Atom(dom_assign_pred);
+  a->param.set_length(2);
+  a->param[0] = v;
+  a->param[1] = (Symbol*)yyvsp[-1].sym->val;
+  if (current_context != 0) {
+    if (write_warnings || !best_effort) {
+      std::cerr << "warning: object function assignment ";
+      a->print(std::cerr);
+      std::cerr << " in quantified/conditional effect ignored"
+  << std::endl;
+    }
+    if (!best_effort) exit(1);
+  }
+  else {
+    dom_actions[dom_actions.length() - 1]->adds.append(a);
+  }
+;
+    break;}
+case 242:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, yyvsp[-2].tkw);
+  ((PredicateSymbol*)yyvsp[0].sym->val)->modded = true;
+;
+    break;}
+case 243:
+{
+  ((Atom*)current_atom)->check();
+  if (current_context != 0) {
+    ((SetOf*)current_context)->pos_atoms.append((Atom*)current_atom);
+  }
+  else {
+    dom_actions[dom_actions.length() - 1]->adds.append((Atom*)current_atom);
+  }
+;
+    break;}
+case 244:
+{
+  yyval.sym = yyvsp[0].sym;
+;
+    break;}
+case 245:
+{
+  yyval.sym = (hsps::StringTable::Cell*)tab.find("undefined");
+  assert(yyval.sym != 0);
+;
+    break;}
+case 246:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+  ((PredicateSymbol*)yyvsp[0].sym->val)->modded = true;
+;
+    break;}
+case 247:
+{
+  ((Atom*)current_atom)->check();
+  if (current_context != 0) {
+    ((SetOf*)current_context)->neg_atoms.append((Atom*)current_atom);
+  }
+  else {
+    dom_actions[dom_actions.length() - 1]->dels.append((Atom*)current_atom);
+  }
+;
+    break;}
+case 248:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, yyvsp[-4].tkw);
+  ((PredicateSymbol*)yyvsp[0].sym->val)->modded = true;
+;
+    break;}
+case 249:
+{
+  ((Atom*)current_atom)->check();
+  if (current_context != 0) {
+    ((SetOf*)current_context)->neg_atoms.append((Atom*)current_atom);
+  }
+  else {
+    dom_actions[dom_actions.length() - 1]->dels.append((Atom*)current_atom);
+  }
+;
+    break;}
+case 250:
+{
+  current_atom = new FChangeAtom((FunctionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 251:
+{
+  ((FChangeAtom*)current_atom)->val = yyvsp[-1].exp;
+  ((FChangeAtom*)current_atom)->fun->modified = true;
+  if (!yyvsp[-1].exp->is_integral()) ((FChangeAtom*)current_atom)->fun->integral = false;
+  dom_actions[dom_actions.length() - 1]->incs.append((FChangeAtom*)current_atom);
+;
+    break;}
+case 252:
+{
+  current_atom = new FChangeAtom((FunctionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 253:
+{
+  ((FChangeAtom*)current_atom)->val = yyvsp[-1].exp;
+  ((FChangeAtom*)current_atom)->fun->modified = true;
+  if (!yyvsp[-1].exp->is_integral()) ((FChangeAtom*)current_atom)->fun->integral = false;
+  dom_actions[dom_actions.length() - 1]->decs.append((FChangeAtom*)current_atom);
+;
+    break;}
+case 254:
+{
+  current_atom = new FChangeAtom((FunctionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 255:
+{
+  ((FChangeAtom*)current_atom)->val = yyvsp[-1].exp;
+  ((FChangeAtom*)current_atom)->fun->modified = true;
+  if (!yyvsp[-1].exp->is_integral()) ((FChangeAtom*)current_atom)->fun->integral = false;
+  dom_actions[dom_actions.length() - 1]->fass.append((FChangeAtom*)current_atom);
+;
+    break;}
+case 256:
+{
+  current_atom = new FChangeAtom((FunctionSymbol*)yyvsp[0].sym->val, yyvsp[-4].tkw);
+;
+    break;}
+case 257:
+{
+  ((FChangeAtom*)current_atom)->val = yyvsp[-2].exp;
+  ((FChangeAtom*)current_atom)->fun->modified = true;
+  if (!yyvsp[-2].exp->is_integral()) ((FChangeAtom*)current_atom)->fun->integral = false;
+  dom_actions[dom_actions.length() - 1]->incs.append((FChangeAtom*)current_atom);
+;
+    break;}
+case 258:
+{
+  current_atom = new FChangeAtom((FunctionSymbol*)yyvsp[0].sym->val, yyvsp[-4].tkw);
+;
+    break;}
+case 259:
+{
+  ((FChangeAtom*)current_atom)->val = yyvsp[-2].exp;
+  ((FChangeAtom*)current_atom)->fun->modified = true;
+  if (!yyvsp[-2].exp->is_integral()) ((FChangeAtom*)current_atom)->fun->integral = false;
+  dom_actions[dom_actions.length() - 1]->decs.append((FChangeAtom*)current_atom);
+;
+    break;}
+case 260:
+{
+  current_atom = new FChangeAtom((FunctionSymbol*)yyvsp[0].sym->val, yyvsp[-4].tkw);
+;
+    break;}
+case 261:
+{
+  ((FChangeAtom*)current_atom)->val = yyvsp[-2].exp;
+  ((FChangeAtom*)current_atom)->fun->modified = true;
+  if (!yyvsp[-2].exp->is_integral()) ((FChangeAtom*)current_atom)->fun->integral = false;
+  dom_actions[dom_actions.length() - 1]->fass.append((FChangeAtom*)current_atom);
+;
+    break;}
+case 269:
+{
+  dom_actions[dom_actions.length() - 1]->dmin = yyvsp[-1].exp;
+  dom_actions[dom_actions.length() - 1]->dmax = yyvsp[-1].exp;
+;
+    break;}
+case 270:
+{
+  dom_actions[dom_actions.length() - 1]->dmin = yyvsp[0].exp;
+  dom_actions[dom_actions.length() - 1]->dmax = yyvsp[0].exp;
+;
+    break;}
+case 271:
+{
+  dom_actions[dom_actions.length() - 1]->dmax = yyvsp[-1].exp;
+;
+    break;}
+case 274:
+{
+  dom_actions[dom_actions.length() - 1]->dmin = yyvsp[-1].exp;
+;
+    break;}
+case 277:
+{
+  current_context = new SequentialTaskNet();
+  stored_n_param.append(current_param.length());
+  if (trace_print_context) {
+    std::cerr << "pushed context (" << current_param.length() << " variables)"
+       << std::endl;
+  }
+;
+    break;}
+case 278:
+{
+  SequentialTaskNet* n = (SequentialTaskNet*)current_context;
+  n->abs_act = dom_actions[dom_actions.length() - 1];
+  dom_actions[dom_actions.length() - 1]->exps.append(n);
+  if (trace_print_context) {
+    std::cerr << "poping context from "
+       << current_param.length()
+       << " to "
+       << stored_n_param[stored_n_param.length() - 1]
+       << " variables..." << std::endl;
+  }
+  assert(stored_n_param.length() > 0);
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  current_context = 0;
+;
+    break;}
+case 281:
+{
+  current_atom = new Reference((ActionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 282:
+{
+  Reference* ref = (Reference*)current_atom;
+  SequentialTaskNet* task_net = (SequentialTaskNet*)current_context;
+  task_net->tasks.append(ref);
+;
+    break;}
+case 284:
+{
+  problem_name = yyvsp[-1].sym->text;
+  if (current_file()) problem_file = strdup(current_file());
+;
+    break;}
+case 301:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 302:
+{
+  ((Atom*)current_atom)->check();
+  PredicateSymbol* p = (PredicateSymbol*)yyvsp[-3].sym->val;
+  if (p->param.length() != current_atom->param.length()) {
+    log_error("wrong number of arguments for predicate in (:init ...");
+  }
+  ((Atom*)current_atom)->insert(p->init);
+  current_atom->at_time = 0;
+  dom_init.append((Atom*)current_atom);
+;
+    break;}
+case 303:
+{
+  current_atom = new OInitAtom((ObjectFunctionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 304:
+{
+  ObjectFunctionSymbol* f = (ObjectFunctionSymbol*)yyvsp[-5].sym->val;
+  if (f->param.length() != current_atom->param.length()) {
+    log_error("wrong number of arguments for object function in (:init ...");
+  }
+  ((OInitAtom*)current_atom)->val = (Symbol*)yyvsp[-1].sym->val;
+  current_atom->at_time = 0;
+  ((OInitAtom*)current_atom)->insert(f->init);
+  dom_obj_init.append((OInitAtom*)current_atom);
+;
+    break;}
+case 305:
+{
+  current_atom = new FInitAtom((FunctionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 306:
+{
+  FunctionSymbol* f = (FunctionSymbol*)yyvsp[-5].sym->val;
+  if (f->param.length() != current_atom->param.length()) {
+    log_error("wrong number of arguments for function in (:init ...");
+  }
+  ((FInitAtom*)current_atom)->val = hsps::rational(yyvsp[-1].rval);
+  if (!(((FInitAtom*)current_atom)->val).integral())
+    ((FInitAtom*)current_atom)->fun->integral = false;
+  ((FInitAtom*)current_atom)->insert(f->init);
+  current_atom->at_time = 0;
+  dom_fun_init.append((FInitAtom*)current_atom);
+;
+    break;}
+case 307:
+{
+  FunctionSymbol* f = (FunctionSymbol*)yyvsp[-2].sym->val;
+  current_atom = new FInitAtom((FunctionSymbol*)yyvsp[-2].sym->val);
+  if (f->param.length() != 0) {
+    log_error("wrong number of arguments for function in (:init ...");
+  }
+  ((FInitAtom*)current_atom)->val = hsps::rational(yyvsp[-1].rval);
+  if (!(((FInitAtom*)current_atom)->val).integral())
+    ((FInitAtom*)current_atom)->fun->integral = false;
+  current_atom->at_time = 0;
+  ((FInitAtom*)current_atom)->insert(f->init);
+  dom_fun_init.append((FInitAtom*)current_atom);
+;
+    break;}
+case 312:
+{
+  dom_goals.append(yyvsp[0].goal);
+;
+    break;}
+case 313:
+{
+  Symbol* name = new Symbol(sym_preference, yyvsp[-2].sym->text);
+  yyvsp[-2].sym->val = name;
+  dom_preferences.append(new Preference(name, yyvsp[-1].goal));
+;
+    break;}
+case 316:
+{
+  yyval.goal = yyvsp[0].goal;
+;
+    break;}
+case 317:
+{
+  current_goal.append(new ConjunctiveGoal());
+;
+    break;}
+case 318:
+{
+  assert(current_goal.length() > 0);
+  yyval.goal = current_goal[current_goal.length() - 1];
+  current_goal.dec_length();
+;
+    break;}
+case 319:
+{
+  current_goal.append(new DisjunctiveGoal());
+;
+    break;}
+case 320:
+{
+  assert(current_goal.length() > 0);
+  yyval.goal = current_goal[current_goal.length() - 1];
+  current_goal.dec_length();
+;
+    break;}
+case 321:
+{
+  assert(current_goal.length() > 0);
+  ConjunctiveGoal* cg = current_goal[current_goal.length() - 1];
+  assert(cg != 0);
+  cg->goals.append(yyvsp[-1].goal);
+;
+    break;}
+case 323:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 324:
+{
+  ((Atom*)current_atom)->check();
+  yyval.goal = new AtomicGoal((Atom*)current_atom, false);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+  ((Atom*)current_atom)->insert(((Atom*)current_atom)->pred->pos_goal);
+;
+    break;}
+case 325:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 326:
+{
+  ((Atom*)current_atom)->check();
+  yyval.goal = new AtomicGoal((Atom*)current_atom, true);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+  ((Atom*)current_atom)->insert(((Atom*)current_atom)->pred->neg_goal);
+;
+    break;}
+case 327:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-2].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-1].sym->val;
+  yyval.goal = new AtomicGoal(eq_atom, false);
+;
+    break;}
+case 328:
+{
+  yyval.goal = new NumericGoal(yyvsp[0].rel);
+;
+    break;}
+case 329:
+{
+  yyval.goal = new SimpleSequenceGoal(goal_always, yyvsp[-1].goal);
+;
+    break;}
+case 330:
+{
+  yyval.goal = new SimpleSequenceGoal(goal_sometime, yyvsp[-1].goal);
+;
+    break;}
+case 331:
+{
+  yyval.goal = new SimpleSequenceGoal(goal_at_most_once, yyvsp[-1].goal);
+;
+    break;}
+case 332:
+{
+  yyval.goal = new TriggeredSequenceGoal(goal_sometime_before, yyvsp[-2].goal, yyvsp[-1].goal);
+;
+    break;}
+case 333:
+{
+  yyval.goal = new TriggeredSequenceGoal(goal_sometime_after, yyvsp[-2].goal, yyvsp[-1].goal);
+;
+    break;}
+case 334:
+{
+  yyval.goal = new DeadlineGoal(yyvsp[-2].rval, yyvsp[-1].goal);
+;
+    break;}
+case 335:
+{
+  yyval.goal = new TriggeredDeadlineGoal(yyvsp[-2].goal, yyvsp[-3].rval, yyvsp[-1].goal);
+;
+    break;}
+case 337:
+{
+  if (metric_type != metric_none) {
+    if (write_warnings) {
+      std::cerr << "warning: multiple :metric expressions - overwriting previous definition" << std::endl;
+    }
+  }
+  metric_type = metric_minimize;
+;
+    break;}
+case 338:
+{
+  if (metric_type != metric_none) {
+    if (write_warnings) {
+      std::cerr << "warning: multiple :metric expressions - overwriting previous definition" << std::endl;
+    }
+  }
+  metric_type = metric_maximize;
+;
+    break;}
+case 339:
+{
+  if (yyvsp[0].exp->exp_class == exp_time) {
+    metric = 0;
+    metric_type = metric_makespan;
+    yyval.exp = 0;
+  }
+  else {
+    metric = yyvsp[0].exp;
+    yyval.exp = yyvsp[0].exp;
+  }
+;
+    break;}
+case 340:
+{
+  serial_length = hsps::rational(yyvsp[-1].ival);
+;
+    break;}
+case 341:
+{
+  parallel_length = hsps::rational(yyvsp[-1].ival);
+;
+    break;}
+case 342:
+{ yyval.rval = yyvsp[0].ival; ;
+    break;}
+case 343:
+{ yyval.rval = (hsps::rational(yyvsp[-2].ival,yyvsp[0].ival).reduce()); ;
+    break;}
+case 344:
+{ yyval.rval = yyvsp[0].rval; ;
+    break;}
+case 345:
+{ yyval.rval = POS_INF; ;
+    break;}
+case 346:
+{
+  current_item = new DKEL_Item(":invariant");
+  current_context = current_item;
+;
+    break;}
+case 348:
+{
+  dom_sc_invariants.append(new SetConstraint(current_item));
+;
+    break;}
+case 349:
+{
+  dom_sc_invariants[dom_sc_invariants.length() - 1]->sc_type = yyvsp[-4].sckw;
+  dom_sc_invariants[dom_sc_invariants.length() - 1]->sc_count = yyvsp[-3].ival;
+  clear_context(current_param);
+  current_context = 0;
+;
+    break;}
+case 350:
+{
+  dom_f_invariants.append(new InvariantFormula(current_item, yyvsp[-1].ff));
+  clear_context(current_param);
+  current_context = 0;
+;
+    break;}
+case 351:
+{
+  yyval.ff = new Formula(fc_false);
+;
+    break;}
+case 352:
+{
+  yyval.ff = new Formula(fc_true);
+;
+    break;}
+case 353:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 354:
+{
+  ((Atom*)current_atom)->check();
+  yyval.ff = new AFormula((Atom*)current_atom);
+;
+    break;}
+case 355:
+{
+  yyval.ff = new EqFormula((Symbol*)yyvsp[-2].sym->val, (Symbol*)yyvsp[-1].sym->val);
+;
+    break;}
+case 356:
+{
+  yyval.ff = new NFormula(yyvsp[-1].ff);
+;
+    break;}
+case 357:
+{
+  yyval.ff = yyvsp[-1].ff;
+  yyval.ff->fc = fc_conjunction;
+;
+    break;}
+case 358:
+{
+  yyval.ff = yyvsp[-1].ff;
+  yyval.ff->fc = fc_conjunction;
+;
+    break;}
+case 359:
+{
+  yyval.ff = new BFormula(fc_implication, yyvsp[-2].ff, yyvsp[-1].ff);
+;
+    break;}
+case 360:
+{
+  yyval.ff = new BFormula(fc_equivalence, yyvsp[-2].ff, yyvsp[-1].ff);
+;
+    break;}
+case 361:
+{
+  stored_n_param.append(current_param.length());
+;
+    break;}
+case 362:
+{
+  QFormula* qf = new QFormula(fc_universal, yyvsp[-1].ff);
+  assert(stored_n_param.length() > 0);
+  for (hsps::index_type k = stored_n_param[stored_n_param.length() - 1];
+       k < current_param.length(); k++) {
+    qf->vars.append(current_param[k]);
+  }
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  yyval.ff = qf;
+;
+    break;}
+case 363:
+{
+  stored_n_param.append(current_param.length());
+;
+    break;}
+case 364:
+{
+  QFormula* qf = new QFormula(fc_existential, yyvsp[-1].ff);
+  assert(stored_n_param.length() > 0);
+  for (hsps::index_type k = stored_n_param[stored_n_param.length() - 1];
+       k < current_param.length(); k++) {
+    qf->vars.append(current_param[k]);
+  }
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  yyval.ff = qf;
+;
+    break;}
+case 365:
+{
+  ((CFormula*)yyval.ff)->add(yyvsp[0].ff);
+;
+    break;}
+case 366:
+{
+  yyval.ff = new CFormula(fc_list);
+;
+    break;}
+case 367:
+{
+  current_item = new IrrelevantItem();
+  if (problem_name) current_item->defined_in_problem = true;
+  current_context = current_item;
+;
+    break;}
+case 371:
+{
+  current_atom = new Reference((ActionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 372:
+{
+  IrrelevantItem* item = (IrrelevantItem*)current_item;
+  item->entity = (Reference*)current_atom;
+  dom_irrelevant.append(item);
+  ActionSymbol* act = (ActionSymbol*)yyvsp[-4].sym->val;
+  act->irr_ins.append(item);
+  clear_context(current_param);
+  current_context = 0;
+;
+    break;}
+case 373:
+{
+  current_atom = new Reference((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 374:
+{
+  IrrelevantItem* item = (IrrelevantItem*)current_item;
+  item->entity = (Reference*)current_atom;
+  dom_irrelevant.append(item);
+  PredicateSymbol* pred = (PredicateSymbol*)yyvsp[-4].sym->val;
+  pred->irr_ins.append(item);
+  clear_context(current_param);
+  current_context = 0;
+;
+    break;}
+case 375:
+{
+  current_item = new DKEL_Item(":invariant");
+  current_item->defined_in_problem = true;
+  current_context = current_item;
+;
+    break;}
+case 377:
+{
+  dom_sc_invariants.append(new SetConstraint(current_item));
+;
+    break;}
+case 378:
+{
+  dom_sc_invariants[dom_sc_invariants.length() - 1]->sc_type = yyvsp[-4].sckw;
+  dom_sc_invariants[dom_sc_invariants.length() - 1]->sc_count = yyvsp[-3].ival;
+  clear_context(current_param);
+  current_context = 0;
+;
+    break;}
+case 379:
+{
+  dom_f_invariants.append(new InvariantFormula(current_item, yyvsp[-1].ff));
+  clear_context(current_param);
+  current_context = 0;
+;
+    break;}
+case 385:
+{
+  current_item->item_tags.insert(yyvsp[0].sym->text);
+;
+    break;}
+case 386:
+{
+  yyvsp[0].sym->val = new Symbol(sym_misc, yyvsp[0].sym->text);
+  current_item->name = (Symbol*)yyvsp[0].sym->val;
+  current_item->item_tags.insert(yyvsp[0].sym->text);
+;
+    break;}
+case 387:
+{
+  current_item->name = (Symbol*)yyvsp[0].sym->val;
+  current_item->item_tags.insert(yyvsp[0].sym->text);
+;
+    break;}
+case 388:
+{
+  current_param.clear();
+;
+    break;}
+case 389:
+{
+  current_context->param = current_param;
+;
+    break;}
+case 392:
+{
+  for (hsps::index_type k = stored_n_param[stored_n_param.length() - 1];
+       k < current_param.length(); k++) {
+    current_context->param.append(current_param[k]);
+  }
+;
+    break;}
+case 417:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 418:
+{
+  ((Atom*)current_atom)->check();
+  current_context->pos_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+;
+    break;}
+case 419:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 420:
+{
+  ((Atom*)current_atom)->check();
+  current_context->pos_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+;
+    break;}
+case 421:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, md_init);
+;
+    break;}
+case 422:
+{
+  ((Atom*)current_atom)->check();
+  current_context->pos_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+;
+    break;}
+case 423:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-2].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-1].sym->val;
+  current_context->pos_con.append(eq_atom);
+;
+    break;}
+case 424:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 425:
+{
+  ((Atom*)current_atom)->check();
+  current_context->neg_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+;
+    break;}
+case 426:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 427:
+{
+  ((Atom*)current_atom)->check();
+  current_context->neg_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+;
+    break;}
+case 428:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, md_init);
+;
+    break;}
+case 429:
+{
+  ((Atom*)current_atom)->check();
+  current_context->neg_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+;
+    break;}
+case 430:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, md_init);
+;
+    break;}
+case 431:
+{
+  ((Atom*)current_atom)->check();
+  current_context->neg_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+;
+    break;}
+case 432:
+{
+  Atom* eq_atom = new Atom(dom_eq_pred);
+  eq_atom->param.set_length(2);
+  eq_atom->param[0] = (Symbol*)yyvsp[-3].sym->val;
+  eq_atom->param[1] = (Symbol*)yyvsp[-2].sym->val;
+  current_context->neg_con.append(eq_atom);
+;
+    break;}
+case 433:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, md_pos_goal);
+;
+    break;}
+case 434:
+{
+  ((Atom*)current_atom)->check();
+  current_context->pos_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+;
+    break;}
+case 435:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, md_neg_goal);
+;
+    break;}
+case 436:
+{
+  ((Atom*)current_atom)->check();
+  current_context->pos_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->pos_pre = true;
+;
+    break;}
+case 437:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, md_pos_goal);
+;
+    break;}
+case 438:
+{
+  ((Atom*)current_atom)->check();
+  current_context->neg_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+;
+    break;}
+case 439:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val, md_neg_goal);
+;
+    break;}
+case 440:
+{
+  ((Atom*)current_atom)->check();
+  current_context->neg_con.append((Atom*)current_atom);
+  ((Atom*)current_atom)->pred->neg_pre = true;
+;
+    break;}
+case 441:
+{
+  TypeConstraint* c =
+    new TypeConstraint((VariableSymbol*)yyvsp[-1].sym->val, (TypeSymbol*)yyvsp[-2].sym->val);
+  current_context->type_con.append(c);
+;
+    break;}
+case 442:
+{
+  TypeConstraint* c =
+    new TypeConstraint((VariableSymbol*)yyvsp[-1].sym->val, (TypeSymbol*)yyvsp[-2].sym->val);
+  current_context->type_con.append(c);
+;
+    break;}
+case 443:
+{
+  yyval.sckw = sc_at_least;
+;
+    break;}
+case 444:
+{
+  yyval.sckw = sc_at_most;
+;
+    break;}
+case 445:
+{
+  yyval.sckw = sc_exactly;
+;
+    break;}
+case 449:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 450:
+{
+  ((Atom*)current_atom)->check();
+  dom_sc_invariants[dom_sc_invariants.length()-1]->pos_atoms.append((Atom*)current_atom);
+;
+    break;}
+case 451:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 452:
+{
+  ((Atom*)current_atom)->check();
+  dom_sc_invariants[dom_sc_invariants.length()-1]->neg_atoms.append((Atom*)current_atom);
+;
+    break;}
+case 453:
+{
+  stored_n_param.append(current_param.length());
+  current_context = new SetOf();
+;
+    break;}
+case 454:
+{
+  SetOf* s = (SetOf*)current_context;
+  for (hsps::index_type k = stored_n_param[stored_n_param.length() - 1];
+       k < current_param.length(); k++) {
+    s->param.append(current_param[k]);
+  }
+;
+    break;}
+case 455:
+{
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 456:
+{
+  ((Atom*)current_atom)->check();
+  SetOf* s = (SetOf*)current_context;
+  s->pos_atoms.append((Atom*)current_atom);
+  dom_sc_invariants[dom_sc_invariants.length()-1]->atom_sets.append(s);
+  assert(stored_n_param.length() > 0);
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  current_context = 0;
+;
+    break;}
+case 457:
+{
+  input_plans.append(new InputPlan());
+  if (current_plan_file != current_file()) {
+    n_plans_in_current_file = 0;
+    current_plan_file = current_file();
+  }
+;
+    break;}
+case 458:
+{
+  if (input_plans[input_plans.length() - 1]->name == 0)
+    if (current_plan_file) {
+      std::ostringstream pn;
+      pn << current_plan_file << ":" << n_plans_in_current_file;
+      Symbol* plan_file_name = new Symbol(sym_misc, strdup(pn.str().c_str()));
+      input_plans[input_plans.length() - 1]->name = plan_file_name;
+    }
+  n_plans_in_current_file += 1;
+;
+    break;}
+case 460:
+{
+  assert(input_plans.length() > 0);
+  input_plans[input_plans.length() - 1]->is_opt = true;
+;
+    break;}
+case 463:
+{
+  assert(input_plans.length() > 0);
+  input_plans[input_plans.length() - 1]->name = new Symbol(yyvsp[0].sym->text);
+;
+    break;}
+case 464:
+{
+  current_atom = new Reference((ActionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 465:
+{
+  Reference* ref = (Reference*)current_atom;
+  ActionSymbol* act = (ActionSymbol*)yyvsp[-3].sym->val;
+  act->refs.append(ref);
+  assert(input_plans.length() > 0);
+  input_plans[input_plans.length() - 1]->
+    steps.append(new InputPlanStep(ref, yyvsp[-6].rval));
+  clear_context(current_param);
+;
+    break;}
+case 466:
+{
+  current_plan_file = 0;
+;
+    break;}
+case 467:
+{
+  current_plan_file = 0;
+;
+    break;}
+case 470:
+{
+  current_atom = new Reference((ActionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 471:
+{
+  Reference* ref = (Reference*)current_atom;
+  ActionSymbol* act = (ActionSymbol*)yyvsp[-4].sym->val;
+  act->refs.append(ref);
+  if (input_plans.length() == 0) {
+    at_position(std::cerr) << "beginning of new plan" << std::endl;
+    input_plans.append(new InputPlan());
+    if (current_file()) {
+      Symbol* plan_file_name = new Symbol(sym_misc, current_file());
+      input_plans[input_plans.length() - 1]->name = plan_file_name;
+    }
+    current_plan_file = current_file();
+  }
+  else if (current_file() != current_plan_file) {
+    at_position(std::cerr) << "beginning of new plan (new file)" << std::endl;
+    input_plans.append(new InputPlan());
+    if (current_file()) {
+      Symbol* plan_file_name = new Symbol(sym_misc, current_file());
+      input_plans[input_plans.length() - 1]->name = plan_file_name;
+    }
+    current_plan_file = current_file();
+  }
+  input_plans[input_plans.length() - 1]->
+    steps.append(new InputPlanStep(ref, yyvsp[-7].rval));
+  clear_context(current_param);
+;
+    break;}
+case 476:
+{
+  current_atom = new Reference((ActionSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 477:
+{
+  Reference* ref = (Reference*)current_atom;
+  ActionSymbol* act = (ActionSymbol*)yyvsp[-3].sym->val;
+  act->refs.append(ref);
+  if (input_plans.length() == 0) {
+    at_position(std::cerr) << "beginning of new plan" << std::endl;
+    input_plans.append(new InputPlan());
+    if (current_file()) {
+      Symbol* plan_file_name = new Symbol(sym_misc, current_file());
+      input_plans[input_plans.length() - 1]->name = plan_file_name;
+    }
+    current_plan_file = current_file();
+  }
+  else if (current_file() != current_plan_file) {
+    at_position(std::cerr) << "beginning of new plan (new file)" << std::endl;
+    input_plans.append(new InputPlan());
+    if (current_file()) {
+      Symbol* plan_file_name = new Symbol(sym_misc, current_file());
+      input_plans[input_plans.length() - 1]->name = plan_file_name;
+    }
+    current_plan_file = current_file();
+  }
+  hsps::index_type n = input_plans[input_plans.length() - 1]->steps.length();
+  input_plans[input_plans.length() - 1]->
+    steps.append(new InputPlanStep(ref, n));
+  clear_context(current_param);
+;
+    break;}
+case 481:
+{
+  current_entry = new HTableEntry();
+;
+    break;}
+case 482:
+{
+  h_table.append(current_entry);
+  current_entry = 0;
+;
+    break;}
+case 483:
+{
+  current_entry->cost = yyvsp[0].rval;
+  current_entry->opt = true;
+;
+    break;}
+case 484:
+{
+  current_entry->cost = yyvsp[0].rval;
+;
+    break;}
+case 489:
+{
+  assert(current_entry);
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 490:
+{
+  ((Atom*)current_atom)->check();
+  current_entry->atoms.append((Atom*)current_atom);
+  current_entry->neg.append(false);
+  assert(current_entry->atoms.length() == current_entry->neg.length());
+;
+    break;}
+case 491:
+{
+  assert(current_entry);
+  current_atom = new Atom((PredicateSymbol*)yyvsp[0].sym->val);
+;
+    break;}
+case 492:
+{
+  ((Atom*)current_atom)->check();
+  current_entry->atoms.append((Atom*)current_atom);
+  current_entry->neg.append(true);
+  assert(current_entry->atoms.length() == current_entry->neg.length());
+;
+    break;}
+case 493:
+{
+  ReferenceSet* set = new ReferenceSet();
+  current_context = set;
+  stored_n_param.assign_value(0, 1);
+  current_param.clear();
+  input_sets.append(set);
+;
+    break;}
+case 494:
+{
+  clear_context(current_param);
+  current_context = 0;
+;
+    break;}
+case 495:
+{
+  yyvsp[0].sym->val = new Symbol(sym_misc, yyvsp[0].sym->text);
+  ((ReferenceSet*)current_context)->name = (Symbol*)yyvsp[0].sym->val;
+;
+    break;}
+case 496:
+{
+  ((ReferenceSet*)current_context)->name = (Symbol*)yyvsp[0].sym->val;
+;
+    break;}
+case 501:
+{
+  if (yyvsp[0].sym->val) {
+    current_atom = new Reference((Symbol*)yyvsp[0].sym->val, false, true);
+  }
+  else {
+    current_atom = new Reference(new Symbol(sym_misc, yyvsp[0].sym->text), false, true);
+  }
+;
+    break;}
+case 502:
+{
+  assert(input_sets.length() > 0);
+  assert(input_sets[input_sets.length() - 1] != 0);
+  input_sets[input_sets.length() - 1]->
+    add(new SimpleReferenceSet((Reference*)current_atom));
+;
+    break;}
+case 503:
+{
+  assert(input_sets.length() > 0);
+  assert(input_sets[input_sets.length() - 1] != 0);
+  if (yyvsp[0].sym->val) {
+    input_sets[input_sets.length() - 1]->add
+      (new SimpleReferenceSet(new Reference((Symbol*)yyvsp[0].sym->val, false, false)));
+  }
+  else {
+    input_sets[input_sets.length() - 1]->add
+      (new SimpleReferenceSet(new Reference(new Symbol(sym_misc, yyvsp[0].sym->text), false, false)));
+  }
+;
+    break;}
+case 504:
+{
+  stored_n_param.append(current_param.length());
+  stored_context.append(current_context);
+  current_context = new SimpleReferenceSet(0);
+;
+    break;}
+case 505:
+{
+  assert(stored_n_param.length() > 0);
+  assert(stored_context.length() > 0);
+  clear_context(current_param,
+  stored_n_param[stored_n_param.length() - 1],
+  current_param.length());
+  current_param.set_length(stored_n_param[stored_n_param.length() - 1]);
+  stored_n_param.dec_length();
+  current_context = stored_context[stored_context.length() - 1];
+  stored_context.dec_length();
+;
+    break;}
+case 506:
+{
+  if (yyvsp[0].sym->val) {
+    current_atom = new Reference((Symbol*)yyvsp[0].sym->val, false, true);
+  }
+  else {
+    current_atom = new Reference(new Symbol(sym_misc, yyvsp[0].sym->text), false, true);
+  }
+;
+    break;}
+case 507:
+{
+  SimpleReferenceSet* s = (SimpleReferenceSet*)current_context;
+  s->ref = (Reference*)current_atom;
+  assert(input_sets.length() > 0);
+  assert(input_sets[input_sets.length() - 1] != 0);
+  input_sets[input_sets.length() - 1]->add(s);
+;
+    break;}
+case 508:
+{
+  if (yyvsp[0].sym->val) {
+    current_atom = new Reference((Symbol*)yyvsp[0].sym->val, true, true);
+  }
+  else {
+    current_atom = new Reference(new Symbol(sym_misc, yyvsp[0].sym->text), true, true);
+  }
+;
+    break;}
+case 509:
+{
+  SimpleReferenceSet* s = (SimpleReferenceSet*)current_context;
+  s->ref = (Reference*)current_atom;
+  assert(input_sets.length() > 0);
+  assert(input_sets[input_sets.length() - 1] != 0);
+  input_sets[input_sets.length() - 1]->add(s);
+;
+    break;}
+}
+  yyvsp -= yylen;
+  yyssp -= yylen;
+  if (yydebug)
+    {
+      short *ssp1 = yyss - 1;
+      fprintf (stderr, "state stack now");
+      while (ssp1 != yyssp)
+ fprintf (stderr, " %d", *++ssp1);
+      fprintf (stderr, "\n");
+    }
+  *++yyvsp = yyval;
+  yyn = yyr1[yyn];
+  yystate = yypgoto[yyn - 115] + *yyssp;
+  if (yystate >= 0 && yystate <= 1519 && yycheck[yystate] == *yyssp)
+    yystate = yytable[yystate];
+  else
+    yystate = yydefgoto[yyn - 115];
+  goto yynewstate;
+yyerrlab:
+  if (! yyerrstatus)
+    {
+      ++yynerrs;
+      yyn = yypact[yystate];
+      if (yyn > -32768 && yyn < 1519)
+ {
+   int size = 0;
+   char *msg;
+   int x, count;
+   count = 0;
+   for (x = (yyn < 0 ? -yyn : 0);
+        x < (sizeof(yytname) / sizeof(char *)); x++)
+     if (yycheck[x + yyn] == x)
+       size += strlen(yytname[x]) + 15, count++;
+   msg = (char *) malloc(size + 15);
+   if (msg != 0)
+     {
+       strcpy(msg, "parse error");
+       if (count < 5)
+  {
+    count = 0;
+    for (x = (yyn < 0 ? -yyn : 0);
+         x < (sizeof(yytname) / sizeof(char *)); x++)
+      if (yycheck[x + yyn] == x)
+        {
+   strcat(msg, count == 0 ? ", expecting `" : " or `");
+   strcat(msg, yytname[x]);
+   strcat(msg, "'");
+   count++;
+        }
+  }
+       log_error(msg);
+       free(msg);
+     }
+   else
+     log_error ("parse error; also virtual memory exceeded");
+ }
+      else
+ log_error("parse error");
+    }
+  goto yyerrlab1;
+yyerrlab1:
+  if (yyerrstatus == 3)
+    {
+      if (yychar == 0)
+ return(1);
+      if (yydebug)
+ fprintf(stderr, "Discarding token %d (%s).\n", yychar, yytname[yychar1]);
+      yychar = -2;
+    }
+  yyerrstatus = 3;
+  goto yyerrhandle;
+yyerrdefault:
+yyerrpop:
+  if (yyssp == yyss) return(1);
+  yyvsp--;
+  yystate = *--yyssp;
+  if (yydebug)
+    {
+      short *ssp1 = yyss - 1;
+      fprintf (stderr, "Error: state stack now");
+      while (ssp1 != yyssp)
+ fprintf (stderr, " %d", *++ssp1);
+      fprintf (stderr, "\n");
+    }
+yyerrhandle:
+  yyn = yypact[yystate];
+  if (yyn == -32768)
+    goto yyerrdefault;
+  yyn += 1;
+  if (yyn < 0 || yyn > 1519 || yycheck[yyn] != 1)
+    goto yyerrdefault;
+  yyn = yytable[yyn];
+  if (yyn < 0)
+    {
+      if (yyn == -32768)
+ goto yyerrpop;
+      yyn = -yyn;
+      goto yyreduce;
+    }
+  else if (yyn == 0)
+    goto yyerrpop;
+  if (yyn == 1162)
+    return(0);
+  if (yydebug)
+    fprintf(stderr, "Shifting error token, ");
+  *++yyvsp = yylval;
+  yystate = yyn;
+  goto yynewstate;
+ 
+}

--- a/pr/seq-opt-hspsf/graph.ccx
+++ b/pr/seq-opt-hspsf/graph.ccx
@@ -1,0 +1,5194 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+graph::graph()
+  : _size(0), comp()
+{
+}
+graph::graph(index_type s)
+  : _size(0), comp()
+{
+  init(s);
+}
+graph::graph(const graph& g)
+  : _size(0), comp()
+{
+  copy(g);
+}
+graph::graph(const graph& g, const index_set& n)
+  : _size(0), comp()
+{
+  g.subgraph(*this, n);
+}
+graph::graph(const graph& g, const equivalence& eq)
+  : _size(0), comp()
+{
+  g.quotient(*this, eq);
+}
+graph::~graph()
+{
+}
+bool graph::empty() const
+{
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = 0; j < _size; j++)
+      if (adj[i][j]) return false;
+  return true;
+}
+bool graph::reachable(index_type n0, index_type n1) const
+{
+  assert(n0 < _size);
+  assert(n1 < _size);
+  bool_vec v(false, _size);
+  reachable(n0, v);
+  return v[n1];
+}
+index_type graph::count_reachable(index_type n0) const
+{
+  bool_vec v(false, _size);
+  reachable(n0, v);
+  return v.count(true);
+}
+void graph::reachable(bool_vec& v) const
+{
+  for (index_type k = 0; k < _size; k++)
+    if (v[k])
+      reachable(k, v);
+}
+void graph::descendants(index_type n0, bool_vec& s) const
+{
+  s.assign_value(false, _size);
+  reachable(n0, s);
+}
+void graph::descendants(const index_set& s0, bool_vec& s) const
+{
+  s.assign_value(false, _size);
+  for (index_type k = 0; k < s0.length(); k++)
+    reachable(s0[k], s);
+}
+void graph::descendants(index_type n0, index_set& s) const
+{
+  bool_vec v(false, _size);
+  reachable(n0, v);
+  v.copy_to(s);
+}
+void graph::descendants(const index_set& s0, index_set& s) const
+{
+  bool_vec v(false, _size);
+  for (index_type k = 0; k < s0.length(); k++)
+    reachable(s0[k], v);
+  v.copy_to(s);
+}
+void graph::ancestors(index_type n0, bool_vec& s) const
+{
+  s.assign_value(false, _size);
+  reverse_reachable(n0, s);
+}
+void graph::ancestors(const index_set& s0, bool_vec& s) const
+{
+  s.assign_value(false, _size);
+  for (index_type k = 0; k < s0.length(); k++)
+    reverse_reachable(s0[k], s);
+}
+void graph::ancestors(index_type n0, index_set& s) const
+{
+  bool_vec v(false, _size);
+  reverse_reachable(n0, v);
+  v.copy_to(s);
+}
+void graph::ancestors(const index_set& s0, index_set& s) const
+{
+  bool_vec v(false, _size);
+  for (index_type k = 0; k < s0.length(); k++)
+    reverse_reachable(s0[k], v);
+  v.copy_to(s);
+}
+bool graph::acyclic() const
+{
+  bool_vec _reach(false, _size);
+  for (index_type k = 0; k < _size; k++) {
+    _reach.assign_value(false, _size);
+    for (index_type i = 0; i < out[k].length(); i++)
+      reachable(out[k][i], _reach);
+    if (_reach[k]) return false;
+  }
+  return true;
+}
+bool graph::top_sort(index_vec& s) const
+{
+  s.clear();
+  bool_vec rem(true, size());
+  while (rem.count(true) > 0) {
+    index_type n = no_such_index;
+    for (index_type i = 0; (i < size()) && (n == no_such_index); i++)
+      if (rem[i] && (in[i].count_common(rem) == 0))
+ n = i;
+    if (n == no_such_index)
+      return false;
+    s.append(n);
+    rem[n] = false;
+  }
+  return true;
+}
+index_type graph::max_out_degree() const
+{
+  assert(_size > 0);
+  index_type m = out[0].length();
+  for (index_type k = 1; k < _size; k++)
+    if (out[k].length() > m) m = out[k].length();
+  return m;
+}
+index_type graph::max_in_degree() const
+{
+  assert(_size > 0);
+  index_type m = in[0].length();
+  for (index_type k = 1; k < _size; k++)
+    if (in[k].length() > m) m = in[k].length();
+  return m;
+}
+index_type graph::max_bi_degree() const
+{
+  assert(_size > 0);
+  index_type m = bi[0].length();
+  for (index_type k = 1; k < _size; k++)
+    if (bi[k].length() > m) m = bi[k].length();
+  return m;
+}
+index_type graph::min_out_degree() const
+{
+  assert(_size > 0);
+  index_type m = out[0].length();
+  for (index_type k = 1; k < _size; k++)
+    if (out[k].length() < m) m = out[k].length();
+  return m;
+}
+index_type graph::min_in_degree() const
+{
+  assert(_size > 0);
+  index_type m = in[0].length();
+  for (index_type k = 1; k < _size; k++)
+    if (in[k].length() < m) m = in[k].length();
+  return m;
+}
+index_type graph::min_bi_degree() const
+{
+  assert(_size > 0);
+  index_type m = bi[0].length();
+  for (index_type k = 1; k < _size; k++)
+    if (bi[k].length() < m) m = bi[k].length();
+  return m;
+}
+index_type graph::first_root() const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (in_degree(k) == 0) return k;
+  return no_such_index;
+}
+index_type graph::first_leaf() const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (out_degree(k) == 0) return k;
+  return no_such_index;
+}
+void graph::fringe(const index_set& n, index_set& fn) const
+{
+  fn.clear();
+  for (index_type k = 0; k < n.length(); k++) {
+    fn.insert(successors(n[k]));
+  }
+  fn.subtract(n);
+}
+void graph::bi_fringe(const index_set& n, index_set& fn) const
+{
+  fn.clear();
+  for (index_type k = 0; k < n.length(); k++) {
+    fn.insert(bidirectional(n[k]));
+  }
+  fn.subtract(n);
+}
+void graph::distance(index_type s0, index_vec& d) const
+{
+  index_set s0s;
+  s0s.assign_singleton(s0);
+  distance(s0s, d);
+}
+void graph::distance(const index_set& s0, index_vec& d) const
+{
+  d.assign_value(no_such_index, size());
+  for (index_type k = 0; k < s0.length(); k++) {
+    assert(s0[k] < size());
+    d[s0[k]] = 0;
+  }
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type i = 0; i < size(); i++)
+      for (index_type j = 0; j < out[i].length(); j++)
+ if (d[i] != no_such_index) {
+   if ((d[i] + 1) < d[out[i][j]]) {
+     d[out[i][j]] = d[i] + 1;
+     done = false;
+   }
+ }
+  }
+}
+index_type graph::distance(index_type s0, index_type s1) const
+{
+  index_vec d;
+  distance(s0, d);
+  return d[s1];
+}
+pair_set& graph::bidirectional_edges(pair_set& s) const
+{
+  s.clear();
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = i+1; j < _size; j++)
+      if (adj[i][j] && adj[j][i]) s.insert(index_pair(i, j));
+  return s;
+}
+bool graph::adjacent(index_type i, const index_set& n) const
+{
+  for (index_type j = 0; j < n.length(); j++)
+    if (adjacent(i, n[j])) return true;
+  return false;
+}
+bool graph::adjacent(const index_set& n, index_type i) const
+{
+  for (index_type j = 0; j < n.length(); j++)
+    if (adjacent(n[j], i)) return true;
+  return false;
+}
+bool graph::adjacent(const index_set& n0, const index_set& n1) const
+{
+  for (index_type i = 0; i < n0.length(); i++)
+    for (index_type j = 0; j < n1.length(); j++)
+      if (adjacent(n0[i], n1[j])) return true;
+  return false;
+}
+bool graph::bi_adjacent(index_type i, const index_set& n) const
+{
+  for (index_type j = 0; j < n.length(); j++)
+    if (bi_adjacent(i, n[j])) return true;
+  return false;
+}
+index_type graph::n_edges() const
+{
+  index_type n = 0;
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = 0; j < _size; j++)
+      if (adj[i][j]) n += 1;
+  return n;
+}
+index_type graph::n_edges(const index_set& from, const index_set& to) const
+{
+  index_type n = 0;
+  for (index_type i = 0; i < from.length(); i++)
+    for (index_type j = 0; j < to.length(); j++)
+      if (adj[from[i]][to[j]]) n += 1;
+  return n;
+}
+pair_set& graph::edges(pair_set& s) const
+{
+  s.clear();
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = 0; j < _size; j++)
+      if (adj[i][j]) s.insert(index_pair(i, j));
+  return s;
+}
+index_type graph::n_induced_undirected_edges() const
+{
+  index_type n = 0;
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = i; j < _size; j++)
+      if (adj[i][j] || adj[j][i]) n += 1;
+  return n;
+}
+index_type graph::n_induced_undirected_edges
+(const index_set& n0, const index_set& n1) const
+{
+  index_type n = 0;
+  for (index_type i = 0; i < n0.length(); i++)
+    for (index_type j = 0; j < n1.length(); j++)
+      if (adj[n0[i]][n1[j]] || adj[n1[j]][n0[i]]) n += 1;
+  return n;
+}
+index_type graph::n_bidirectional_edges() const
+{
+  index_type n = 0;
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = i; j < _size; j++)
+      if (adj[i][j] && adj[j][i]) n += 1;
+  return n;
+}
+index_type graph::n_bidirectional_edges
+(const index_set& n0, const index_set& n1) const
+{
+  index_type n = 0;
+  for (index_type i = 0; i < n0.length(); i++)
+    for (index_type j = 0; j < n1.length(); j++)
+      if (adj[n0[i]][n1[j]] && adj[n1[j]][n0[i]]) n += 1;
+  return n;
+}
+index_type graph::component_node(index_type i) const
+{
+  for (index_type k = 0; k < _size; k++)
+    if (comp[k] == i) return k;
+  return no_such_index;
+}
+index_type graph::component_size(index_type i) const
+{
+  index_type n = 0;
+  for (index_type k = 0; k < _size; k++)
+    if (comp[k] == i) n += 1;
+  return n;
+}
+void graph::component_node_set(index_type i, index_set& set) const
+{
+  set.clear();
+  for (index_type k = 0; k < _size; k++)
+    if (comp[k] == i) set.insert(k);
+}
+index_type graph::maximal_non_unit_component() const
+{
+  index_type k_max = no_such_index;
+  index_type s_max = 1;
+  for (index_type k = 0; k < n_components(); k++)
+    if (component_size(k) > s_max) {
+      k_max = k;
+      s_max = component_size(k);
+    }
+  return k_max;
+}
+bool graph::equals(const graph& g) const
+{
+  if (g.size() != size()) return false;
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) != g.adjacent(i, j)) return false;
+  return true;
+}
+bool graph::equals(const graph& g, const index_vec& c) const
+{
+  if (g.size() != size()) return false;
+  if (c.length() != g.size()) {
+    ::std::cerr << "error: size of graph " << g
+       << " and permutation vector " << c
+       << " do not agree"
+       << ::std::endl;
+    exit(255);
+  }
+  for (index_type i = 0; i < size(); i++) {
+    assert(c[i] < g.size());
+    for (index_type j = 0; j < size(); j++) {
+      assert(c[j] < g.size());
+      if (adjacent(i, j) != g.adjacent(c[i], c[j])) return false;
+    }
+  }
+  return true;
+}
+void graph::difference
+(const graph& g, const index_vec& c, pair_set& d0, pair_set& d1) const
+{
+  assert(g.size() == size());
+  assert(c.length() == g.size());
+  d0.clear();
+  d1.clear();
+  for (index_type i = 0; i < size(); i++) {
+    assert(c[i] < g.size());
+    for (index_type j = 0; j < size(); j++) {
+      assert(c[j] < g.size());
+      if (adjacent(i, j) && !g.adjacent(c[i], c[j]))
+ d0.insert(index_pair(i, j));
+      if (!adjacent(i, j) && g.adjacent(c[i], c[j]))
+ d1.insert(index_pair(c[i], c[j]));
+    }
+  }
+}
+void graph::difference
+(const graph& g, pair_set& d0, pair_set& d1) const
+{
+  assert(g.size() == size());
+  d0.clear();
+  d1.clear();
+  for (index_type i = 0; i < size(); i++) {
+    for (index_type j = 0; j < size(); j++) {
+      if (adjacent(i, j) && !g.adjacent(i, j))
+ d0.insert(index_pair(i, j));
+      if (!adjacent(i, j) && g.adjacent(i, j))
+ d1.insert(index_pair(i, j));
+    }
+  }
+}
+index_type graph::cardinality_of_difference(const graph& g) const
+{
+  assert(g.size() == size());
+  index_type d = 0;
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adj[i][j] != g.adj[i][j]) d += 1;
+  return d;
+}
+void graph::init(index_type size)
+{
+  _size = size;
+  adj.assign_value(false, _size, _size);
+  in.assign_value(EMPTYSET, _size);
+  out.assign_value(EMPTYSET, _size);
+  bi.assign_value(EMPTYSET, _size);
+  comp.assign_value(0, _size);
+  n_comp = 0;
+}
+void graph::copy(const graph& g)
+{
+  _size = g._size;
+  adj.assign_copy(g.adj);
+  in.assign_copy(g.in);
+  out.assign_copy(g.out);
+  bi.assign_copy(g.bi);
+  comp.assign_copy(g.comp);
+  n_comp = g.n_comp;
+}
+void graph::copy(const graph& g, const index_vec& map)
+{
+  assert(map.length() == g.size());
+  index_type m = mapping::range(map, map.length());
+  init(m);
+  for (index_type i = 0; i < g.size(); i++)
+    if (map[i] != no_such_index) {
+      assert(map[i] < size());
+      for (index_type j = 0; j < g.size(); j++)
+ if (map[j] != no_such_index) {
+   assert(map[j] < _size);
+   if (g.adjacent(i, j))
+     add_edge(map[i], map[j]);
+ }
+    }
+}
+void graph::copy_and_rename(const graph& g, const index_vec& map)
+{
+  assert(map.length() == g.size());
+  init(g.size());
+  for (index_type i = 0; i < _size; i++) {
+    assert(map[i] < _size);
+    for (index_type j = 0; j < _size; j++) {
+      assert(map[j] < _size);
+      if (g.adjacent(i, j))
+ add_edge(map[i], map[j]);
+    }
+  }
+}
+index_type graph::add_node()
+{
+  adj.set_size(_size + 1, _size + 1);
+  for (index_type k = 0; k < _size; k++) {
+    adj[k][_size] = false;
+    adj[_size][k] = false;
+  }
+  adj[_size][_size] = false;
+  in.set_length(_size + 1);
+  in[_size].clear();
+  out.set_length(_size + 1);
+  out[_size].clear();
+  bi.set_length(_size + 1);
+  bi[_size].clear();
+  comp.set_length(_size + 1);
+  comp[_size] = 0;
+  _size += 1;
+  return _size - 1;
+}
+void graph::add_graph(const graph& g, mapping& m)
+{
+  index_type _new_size = _size + g.size();
+  adj.set_size(_new_size, _new_size);
+  in.set_length(_new_size);
+  out.set_length(_new_size);
+  bi.set_length(_new_size);
+  comp.set_length(_new_size);
+  m.assign_identity(g.size());
+  for (index_type k = 0; k < g.size(); k++) {
+    m[k] = _size + k;
+    for (index_type i = 0; i < _new_size; i++) {
+      adj[i][m[k]] = false;
+      adj[m[k]][i] = false;
+    }
+    in[m[k]].clear();
+    out[m[k]].clear();
+    bi[m[k]].clear();
+    comp[m[k]] = 0;
+  }
+  _size = _new_size;
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ add_edge(m[i], m[j]);
+}
+void graph::add_edge(index_type src, index_type dst)
+{
+  assert((src < _size) && (dst < _size));
+  if (adj[src][dst]) return;
+  adj[src][dst] = true;
+  out[src].insert(dst);
+  in[dst].insert(src);
+  if (adj[dst][src]) {
+    bi[src].insert(dst);
+    bi[dst].insert(src);
+  }
+}
+void graph::add_edge(const index_set& srcs, index_type dst)
+{
+  for (index_type k = 0; k < srcs.length(); k++)
+    if (!adj[srcs[k]][dst])
+      add_edge(srcs[k], dst);
+}
+void graph::add_edge(index_type src, const index_set& dsts)
+{
+  for (index_type k = 0; k < dsts.length(); k++)
+    if (!adj[src][dsts[k]])
+      add_edge(src, dsts[k]);
+}
+void graph::add_edge_to_transitive_closure
+(index_type src, index_type dst, pair_set& e)
+{
+  if (!adj[src][dst]) {
+    add_edge(src, dst);
+    e.insert(index_pair(src, dst));
+  }
+  for (index_type i = 0; i < in[src].length(); i++) {
+    if (!adj[in[src][i]][dst]) {
+      e.insert(index_pair(in[src][i], dst));
+    }
+    for (index_type j = 0; j < out[dst].length(); j++) {
+      if (!adj[in[src][i]][out[dst][j]]) {
+ e.insert(index_pair(in[src][i], out[dst][j]));
+      }
+    }
+  }
+  for (index_type j = 0; j < out[dst].length(); j++) {
+    if (!adj[src][out[dst][j]]) {
+      e.insert(index_pair(src, out[dst][j]));
+    }
+  }
+  for (index_type k = 0; k < e.length(); k++)
+    add_edge(e[k].first, e[k].second);
+}
+void graph::remove_edge(index_type src, index_type dst)
+{
+  assert((src < _size) && (dst < _size));
+  if (adj[src][dst]) {
+    adj[src][dst] = false;
+    out[src].subtract(dst);
+    in[dst].subtract(src);
+    if (adj[dst][src]) {
+      bi[src].subtract(dst);
+      bi[dst].subtract(src);
+    }
+  }
+}
+void graph::remove_undirected_edge(index_type n0, index_type n1)
+{
+  assert((n0 < _size) && (n1 < _size));
+  if (adj[n0][n1]) {
+    adj[n0][n1] = false;
+    out[n0].subtract(n1);
+    in[n1].subtract(n0);
+    bi[n0].subtract(n1);
+  }
+  if (adj[n1][n0]) {
+    adj[n1][n0] = false;
+    out[n1].subtract(n0);
+    in[n0].subtract(n1);
+    bi[n1].subtract(n0);
+  }
+}
+void graph::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+void graph::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+void graph::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+void graph::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++)
+    remove_edge(e[k].first, e[k].second);
+}
+void graph::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++)
+    remove_undirected_edge(e[k].first, e[k].second);
+}
+void graph::add_undirected_edge(index_type n0, index_type n1)
+{
+  add_edge(n0, n1);
+  add_edge(n1, n0);
+}
+void graph::remove_node(index_type n)
+{
+  assert(n < _size);
+  graph g(*this);
+  init(g.size() - 1);
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && (i != n) && (j != n)) {
+ index_type s = (i > n ? i - 1 : i);
+ index_type d = (j > n ? j - 1 : j);
+ add_edge(s, d);
+      }
+}
+void graph::clear_edges()
+{
+  adj.assign_value(false);
+  in.assign_value(EMPTYSET);
+  out.assign_value(EMPTYSET);
+  bi.assign_value(EMPTYSET);
+}
+void graph::recalculate()
+{
+  for (index_type i = 0; i < _size; i++) {
+    in[i].clear();
+    out[i].clear();
+  }
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = 0; j < _size; j++)
+      if (adj[i][j]) {
+ out[i].insert(j);
+ in[j].insert(i);
+      }
+  for (index_type k = 0; k < _size; k++) {
+    bi[k].assign_copy(out[k]);
+    bi[k].intersect(in[k]);
+  }
+  comp.set_length(_size);
+  comp.assign_value(0);
+  n_comp = 0;
+}
+void graph::complement()
+{
+  for (index_type i = 0; i < _size; i++) {
+    for (index_type j = 0; j < _size; j++)
+      adj[i][j] = !adj[i][j];
+    adj[i][i] = false;
+  }
+  recalculate();
+}
+void graph::complement_with_loops()
+{
+  for (index_type i = 0; i < _size; i++) {
+    for (index_type j = 0; j < _size; j++)
+      adj[i][j] = !adj[i][j];
+  }
+  recalculate();
+}
+void graph::remove_loops()
+{
+  for (index_type i = 0; i < _size; i++) if (adj[i][i]) {
+    adj[i][i] = false;
+    out[i].subtract(i);
+    in[i].subtract(i);
+    bi[i].subtract(i);
+  }
+}
+void graph::reverse()
+{
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = i+1; j < _size; j++) {
+      if (adj[i][j] && !adj[j][i]) {
+ adj[i][j] = false;
+ adj[j][i] = true;
+      }
+      else if (!adj[i][j] && adj[j][i]) {
+ adj[i][j] = true;
+ adj[j][i] = false;
+      }
+    }
+  recalculate();
+}
+void graph::transitive_closure()
+{
+  for (index_type k = 0; k < _size; k++)
+    for (index_type i = 0; i < _size; i++)
+      if (adj[i][k])
+ for (index_type j = 0; j < _size; j++)
+   if (adj[k][j]) adj[i][j] = true;
+  recalculate();
+}
+void graph::missing_transitive_edges(pair_set& e) const
+{
+  e.clear();
+  for (index_type i = 0; i < _size; i++) {
+    bool_vec v(false, _size);
+    reachable(i, v);
+    for (index_type j = 0; j < _size; j++)
+      if ((i != j) && v[j] && (!adj[i][j]))
+ e.insert(index_pair(i, j));
+  }
+}
+void graph::transitive_reduction()
+{
+  bool_matrix m2(adj);
+  m2.transitive_closure();
+  bool_matrix m3;
+  m3.multiply(adj, m2);
+  adj.subtract(m3);
+  recalculate();
+}
+void graph::intersect(const graph& g)
+{
+  if (g._size != _size) {
+    ::std::cerr << "error: can't intersect " << *this << " of size " << _size
+       << " with graph " << g << " of size" << g._size << ::std::endl;
+    exit(255);
+  }
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = 0; j < _size; j++)
+      if (!g.adj[i][j]) adj[i][j] = false;
+  recalculate();
+}
+graph& graph::subgraph(graph& sg, const index_set& nodes) const
+{
+  sg.init(nodes.length());
+  for (index_type i = 0; i < nodes.length(); i++)
+    for (index_type j = 0; j < nodes.length(); j++)
+      if (adj[nodes[i]][nodes[j]]) sg.add_edge(i, j);
+  return sg;
+}
+graph& graph::edge_subgraph(graph& sg, const index_set& nodes) const
+{
+  sg.init(size());
+  for (index_type i = 0; i < nodes.length(); i++)
+    for (index_type j = 0; j < nodes.length(); j++)
+      if (adj[nodes[i]][nodes[j]]) sg.add_edge(nodes[i], nodes[j]);
+  return sg;
+}
+graph& graph::component_tree(graph& cg) const
+{
+  cg.init(n_comp);
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = 0; j < _size; j++)
+      if (adj[i][j] && (comp[i] != comp[j])) cg.add_edge(comp[i], comp[j]);
+  return cg;
+}
+equivalence& graph::component_partitioning(equivalence& eq) const
+{
+  eq.extend(_size);
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = i + 1; j < _size; j++)
+      if ((comp[i] == comp[j])) eq.merge(i, j);
+  return eq;
+}
+equivalence& graph::induced_partitioning(equivalence& eq) const
+{
+  eq.clear();
+  eq.extend(_size);
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = 0; j < _size; j++)
+      if (adj[i][j]) eq.merge(i, j);
+  return eq;
+}
+graph& graph::induced_undirected_graph(graph& g) const
+{
+  g.copy(*this);
+  for (index_type i = 0; i < g._size; i++)
+    for (index_type j = 0; j < g._size; j++)
+      if (g.adj[i][j] && !g.adj[j][i]) g.add_edge(j, i);
+  return g;
+}
+graph& graph::minimal_equivalent_digraph(graph& g) const
+{
+  graph cg;
+  component_tree(cg);
+  cg.transitive_reduction();
+  g.init(size());
+  for (index_type k = 0; k < n_components(); k++) {
+    index_set c;
+    component_node_set(k, c);
+    if (c.length() > 1) {
+      for (index_type i = 0; i < (c.length() - 1); i++)
+ g.add_edge(c[i], c[i+1]);
+      g.add_edge(c[c.length() - 1], c[0]);
+    }
+  }
+  for (index_type i = 0; i < cg.size(); i++)
+    for (index_type j = 0; j < cg.size(); j++)
+      if (cg.adjacent(i, j)) {
+ index_type ci = component_node(i);
+ index_type cj = component_node(j);
+ assert(ci != no_such_index);
+ assert(cj != no_such_index);
+ g.add_edge(ci, cj);
+      }
+  return g;
+}
+graph& graph::minimal_distance_graph(graph& g, const index_set& s0) const
+{
+  index_vec d;
+  distance(s0, d);
+  g.init(size());
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (d[i] != no_such_index) && (d[j] == (d[i] + 1)))
+ g.add_edge(i, j);
+  return g;
+}
+graph& graph::quotient(graph& g, const equivalence& eq) const
+{
+  g.init(eq.n_classes());
+  index_vec m;
+  eq.make_map(m);
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && !eq(i, j)) {
+ assert(m[i] < eq.n_classes());
+ assert(m[j] < eq.n_classes());
+ g.add_edge(m[i], m[j]);
+      }
+}
+bool graph::is_clique(const index_set& nodes) const
+{
+  for (index_type i = 0; i < nodes.length(); i++)
+    for (index_type j = i + 1; j < nodes.length(); j++)
+      if (!adj[nodes[i]][nodes[j]] || !adj[nodes[j]][nodes[i]])
+ return false;
+  return true;
+}
+bool graph::is_independent(const index_set& nodes) const
+{
+  for (index_type i = 0; i < nodes.length(); i++)
+    for (index_type j = i + 1; j < nodes.length(); j++)
+      if (adj[nodes[i]][nodes[j]] || adj[nodes[j]][nodes[i]])
+ return false;
+  return true;
+}
+bool graph::is_independent_range(index_type l, index_type u) const
+{
+  for (index_type i = l; i <= u; i++)
+    for (index_type j = i + 1; j <= u; j++)
+      if (adjacent(i, j) || adjacent(j, i)) return false;
+  return true;
+}
+void graph::write_node_set(::std::ostream& s) const
+{
+  s << '{';
+  for (index_type i = 0; i < _size; i++) {
+    if (i > 0) s << ',';
+    s << i << "[" << comp[i] << "]";
+  }
+  s << '}';
+}
+void graph::write_edge_set(::std::ostream& s) const
+{
+  s << '{';
+  bool first = true;
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = 0; j < _size; j++)
+      if (adj[i][j]) {
+ if (!first) s << ',';
+ first = false;
+ s << i << "->" << j;
+      }
+  s << '}';
+}
+void graph::write_compact(::std::ostream& s) const
+{
+  s << '(';
+  write_node_set(s);
+  s << ',';
+  write_edge_set(s);
+  s << '}';
+}
+void graph::write_undirected_edge_set(::std::ostream& s) const
+{
+  s << '{';
+  bool first = true;
+  for (index_type i = 0; i < _size; i++)
+    for (index_type j = i+1; j < _size; j++)
+      if (adj[i][j]) {
+ if (!first) s << ',';
+ first = false;
+ s << i << "-" << j;
+      }
+  s << '}';
+}
+void graph::write_adjacency_lists(::std::ostream& s) const
+{
+  for (index_type k = 0; k < _size; k++) {
+    s << "node " << k << " (component " << comp[k] << "):" << ::std::endl;
+    s << " in (" << in[k].length() << "):";
+    for (index_type i = 0; i < _size; i++)
+      if (adj[i][k]) s << " " << i;
+    s << ::std::endl << " out (" << out[k].length() << "):";
+    for (index_type i = 0; i < _size; i++)
+      if (adj[k][i]) s << " " << i;
+    s << ::std::endl;
+  }
+}
+void graph::randomize(count_type n, RNG& rnd)
+{
+  assert(_size > 1);
+  for (index_type s = 0; s < n; s++) {
+    index_type i = rnd.random_in_range(_size);
+    index_type j = rnd.random_in_range(_size);
+    if (i != j) {
+      if (adj[i][j]) {
+ adj[i][j] = false;
+      }
+      else {
+ adj[i][j] = true;
+      }
+    }
+  }
+  recalculate();
+}
+void graph::randomize_connected(count_type n, RNG& rnd)
+{
+  assert(_size > 1);
+  for (index_type s = 0; s < n; s++) {
+    index_type i = rnd.random_in_range(_size);
+    index_type j = rnd.random_in_range(_size, i);
+    if (adj[i][j]) {
+      adj[i][j] = false;
+      if (!connected()) adj[i][j] = true;
+    }
+    else {
+      adj[i][j] = true;
+    }
+  }
+  recalculate();
+}
+void graph::randomize_strongly_connected(count_type n, RNG& rnd)
+{
+  assert(_size > 1);
+  strongly_connected_components();
+  index_type c = n_components();
+  for (index_type s = 0; s < n; s++) {
+    index_type i = rnd.random_in_range(_size);
+    index_type j = rnd.random_in_range(_size, i);
+    if (adj[i][j]) {
+      adj[i][j] = false;
+      strongly_connected_components();
+      if (n_components() > c)
+ adj[i][j] = true;
+    }
+    else {
+      adj[i][j] = true;
+    }
+  }
+  recalculate();
+}
+void graph::random_digraph(count_type n, RNG& rnd)
+{
+  clear_edges();
+  randomize(n, rnd);
+}
+void graph::random_connected_digraph(count_type n, RNG& rnd)
+{
+  assert(_size > 1);
+  clear_edges();
+  for (index_type i = 0; i < _size - 1; i++) {
+    adj[i][i+1] = true;
+  }
+  randomize_connected(n, rnd);
+}
+void graph::random_strongly_connected_digraph(count_type n, RNG& rnd)
+{
+  assert(_size > 1);
+  clear_edges();
+  for (index_type i = 0; i < _size - 1; i++) {
+    adj[i][i+1] = true;
+  }
+  adj[_size - 1][0] = true;
+  randomize_strongly_connected(n, rnd);
+}
+void graph::random_digraph_with_density(rational density, RNG& rnd)
+{
+  clear_edges();
+  index_set e;
+  index_type n = (_size * (_size - 1));
+  index_type m = rational::floor(density*n).numerator();
+  rnd.select_fixed_set(e, m, n);
+  for (index_type k = 0; k < e.length(); k++) {
+    index_type s = e[k] / (_size - 1);
+    index_type t = e[k] % (_size - 1);
+    if (t >= s) t += 1;
+    add_edge(s, t);
+  }
+}
+void graph::random_tree(RNG& rnd)
+{
+  clear_edges();
+  for (index_type k = 1; k < size(); k++) {
+    index_type i = rnd.random_in_range(k);
+    add_edge(i, k);
+  }
+}
+void graph::random_tree(index_type b, index_type d, RNG& rnd)
+{
+  clear_edges();
+  for (index_type k = 1; k < size(); k++) {
+    index_set c;
+    for (index_type i = 0; i < k; i++) {
+      if ((out_degree(i) < b) && (distance(0, i) < d))
+ c.insert(i);
+    }
+    assert(!c.empty());
+    index_type j = rnd.select_one_of(c);
+    add_edge(j, k);
+  }
+}
+void graph::max_clique
+(index_set& sel, index_type next, index_set& clique) const
+{
+  if (next >= _size) {
+    if (sel.length() > clique.length()) clique = sel;
+  }
+  else if (sel.contains(next)) {
+    max_clique(sel, next + 1, clique);
+  }
+  else {
+    if (bi[next].contains(sel)) {
+      sel.insert(next);
+      max_clique(sel, next + 1, clique);
+      sel.subtract(next);
+    }
+    max_clique(sel, next + 1, clique);
+  }
+}
+void graph::maximal_clique(index_set& clique) const
+{
+  assert(_size > 0);
+  clique.clear();
+  index_set sel;
+  max_clique(sel, 0, clique);
+}
+void graph::maximal_clique_including
+(index_type node, index_set& clique) const
+{
+  assert((0 <= node) && (node < _size) && (_size > 0));
+  clique.clear();
+  index_set sel;
+  sel.assign_singleton(node);
+  max_clique(sel, 0, clique);
+}
+void graph::maximal_clique_cover(index_set_vec& sets) const
+{
+  sets.clear();
+  index_set clique;
+  index_set uncovered;
+  uncovered.fill(_size);
+  while (!uncovered.empty()) {
+    maximal_clique_including(uncovered[0], clique);
+    assert(!clique.empty());
+    sets.append(clique);
+    uncovered.subtract(clique);
+  }
+}
+void graph::all_max_cliques
+(index_set& sel, index_type next, index_set_vec& cliques) const
+{
+  if (next >= _size) {
+    if (sel.length() > cliques[0].length()) {
+      cliques[0] = sel;
+      cliques.set_length(1);
+    }
+    else if (sel.length() == cliques[0].length()) {
+      cliques.append(sel);
+    }
+  }
+  else if (sel.contains(next)) {
+    all_max_cliques(sel, next + 1, cliques);
+  }
+  else {
+    if (bi[next].contains(sel)) {
+      sel.insert(next);
+      all_max_cliques(sel, next + 1, cliques);
+      sel.subtract(next);
+    }
+    all_max_cliques(sel, next + 1, cliques);
+  }
+}
+void graph::all_maximal_cliques(index_set_vec& cliques) const
+{
+  assert(_size > 0);
+  cliques.assign_value(EMPTYSET, 1);
+  index_set sel;
+  all_max_cliques(sel, 0, cliques);
+}
+void graph::all_maximal_cliques_including
+(index_type node, index_set_vec& cliques) const
+{
+  assert(_size > 0);
+  cliques.assign_value(EMPTYSET, 1);
+  index_set sel;
+  sel.assign_singleton(node);
+  all_max_cliques(sel, 0, cliques);
+}
+void graph::scc_first_dfs
+(index_type n, bool_vec& visited, index_vec& num) const
+{
+  visited[n] = true;
+  for (index_type k = 0; k < _size; k++)
+    if (adj[n][k] && !visited[k])
+      scc_first_dfs(k, visited, num);
+  num.append(n);
+}
+void graph::scc_second_dfs
+(index_type n, bool_vec& visited, index_type c_id)
+{
+  visited[n] = true;
+  comp[n] = c_id;
+  for (index_type k = 0; k < _size; k++)
+    if (adj[k][n] && !visited[k])
+      scc_second_dfs(k, visited, c_id);
+}
+void graph::undirected_dfs
+(index_type n, bool_vec& visited) const
+{
+  visited[n] = true;
+  for (index_type k = 0; k < _size; k++)
+    if ((adj[n][k] || adj[k][n]) && !visited[k])
+      undirected_dfs(k, visited);
+}
+void graph::reachable(index_type n, bool_vec& visited) const
+{
+  visited[n] = true;
+  for (index_type k = 0; k < _size; k++)
+    if (adj[n][k] && !visited[k])
+      reachable(k, visited);
+}
+void graph::reverse_reachable(index_type n, bool_vec& visited) const
+{
+  visited[n] = true;
+  for (index_type k = 0; k < _size; k++)
+    if (adj[k][n] && !visited[k])
+      reverse_reachable(k, visited);
+}
+void graph::strongly_connected_components()
+{
+  index_vec num(no_such_index, 0);
+  bool_vec visited(false, _size);
+  visited.set_length(_size);
+  for (index_type k = 0; k < _size; k++) {
+    if (!visited[k]) {
+      scc_first_dfs(k, visited, num);
+    }
+  }
+  assert(num.length() == _size);
+  visited.assign_value(false);
+  n_comp = 0;
+  for (index_type k = num.length(); k > 0; k--) if (!visited[num[k - 1]]) {
+    scc_second_dfs(num[k - 1], visited, n_comp);
+    n_comp += 1;
+  }
+}
+void graph::ramsey(const index_set& nodes, index_set& I, index_set& C) const
+{
+  I.clear();
+  C.clear();
+  if (nodes.empty()) return;
+  index_type v = nodes[0];
+  index_set n_v(nodes);
+  n_v.intersect(bi[v]);
+  n_v.subtract(v);
+  ramsey(n_v, I, C);
+  C.insert(v);
+  index_set I2;
+  index_set C2;
+  n_v.assign_copy(nodes);
+  n_v.subtract(out[v]);
+  n_v.subtract(in[v]);
+  n_v.subtract(v);
+  ramsey(n_v, I2, C2);
+  I2.insert(v);
+  if (C2.length() > C.length()) C.assign_copy(C2);
+  if (I2.length() > I.length()) I.assign_copy(I2);
+}
+void graph::apx_independent_set(const index_set& nodes, index_set& set) const
+{
+  set.clear();
+  index_set n(nodes);
+  index_set nextI;
+  index_set nextC;
+  while (!n.empty()) {
+    ramsey(n, nextI, nextC);
+    if (nextI.length() > set.length()) set.assign_copy(nextI);
+    n.subtract(nextC);
+  }
+}
+void graph::apx_independent_set(index_set& set) const
+{
+  index_set nodes;
+  nodes.fill(_size);
+  apx_independent_set(nodes, set);
+}
+void graph::apx_independent_set_including
+(index_type node, index_set& set) const
+{
+  assert((0 <= node) && (node < _size) && (_size > 0));
+  set.clear();
+  index_set nodes;
+  nodes.fill(_size);
+  nodes.subtract(in[node]);
+  nodes.subtract(out[node]);
+  nodes.subtract(node);
+  index_set nextI;
+  index_set nextC;
+  while (!nodes.empty()) {
+    ramsey(nodes, nextI, nextC);
+    if (nextI.length() > set.length()) set.assign_copy(nextI);
+    nodes.subtract(nextC);
+  }
+  set.insert(node);
+}
+void graph::apx_independent_set_cover(index_set_vec& sets) const
+{
+  sets.clear();
+  index_set I;
+  apx_independent_set(I);
+  assert(!I.empty());
+  sets.append(I);
+  index_set uncovered;
+  uncovered.fill(_size);
+  uncovered.subtract(I);
+  while (!uncovered.empty()) {
+    apx_independent_set_including(uncovered[0], I);
+    assert(!I.empty());
+    sets.append(I);
+    uncovered.subtract(I);
+  }
+}
+void graph::apx_independent_set_disjoint_cover(index_set_vec& sets) const
+{
+  sets.clear();
+  index_set uncovered;
+  uncovered.fill(_size);
+  index_set I;
+  while (!uncovered.empty()) {
+    apx_independent_set(uncovered, I);
+    assert(!I.empty());
+    sets.append(I);
+    uncovered.subtract(I);
+  }
+}
+void graph::all_nondominated_cliques(index_set_vec &cliques) const
+{
+  assert(cliques.empty());
+  if (_size > 0) {
+    for (index_type i = 0; i < _size; i++)
+      assert(!adjacent(i, i));
+    index_set current_clique;
+    index_set candidates;
+    candidates.fill(_size);
+    all_nondominated_cliques_aux(cliques, current_clique, candidates, 1);
+  }
+}
+void graph::all_cliques_geq
+(index_type k, index_set_vec& cliques) const
+{
+  cliques.clear();
+  if (_size > 0) {
+    for (index_type i = 0; i < _size; i++)
+      assert(!adjacent(i, i));
+    index_set current_clique;
+    index_set candidates;
+    candidates.fill(_size);
+    all_nondominated_cliques_aux(cliques, current_clique, candidates, k);
+  }
+}
+void graph::all_nondominated_cliques_aux
+(index_set_vec& cliques,
+ index_set& current_clique,
+ const index_set& candidates,
+ index_type min) const
+{
+  if (candidates.empty()) {
+    cliques.append(current_clique);
+  }
+  else {
+    index_type best_vertex = no_such_index;
+    int max_degree = 0;
+    for (index_type i = 0; i < candidates.length(); i++) {
+      index_type vertex = candidates[i];
+      index_set neighbors = successors(vertex);
+      neighbors.intersect(candidates);
+      if (i == 0 || neighbors.length() > max_degree) {
+        max_degree = neighbors.length();
+        best_vertex = vertex;
+      }
+    }
+    assert(best_vertex != no_such_index);
+    index_set chosen_set = candidates;
+    chosen_set.subtract(successors(best_vertex));
+    for (index_type i = 0; i < chosen_set.length(); i++) {
+      index_type chosen = chosen_set[i];
+      index_set new_candidates = candidates;
+      new_candidates.intersect(successors(chosen));
+      if ((current_clique.length() + new_candidates.length() + 1) >= min) {
+ current_clique.insert(chosen);
+ all_nondominated_cliques_aux(cliques,
+         current_clique,
+         new_candidates,
+         min);
+ current_clique.subtract(chosen);
+      }
+    }
+  }
+}
+bool graph::connected() const
+{
+  if (_size == 0) return true;
+  bool_vec visited(false, _size);
+  undirected_dfs(0, visited);
+  return (visited.count(true) == _size);
+}
+bool graph::strongly_connected() const
+{
+  if (_size == 0) return true;
+  bool_vec visited(false, _size);
+  index_vec num(no_such_index, 0);
+  scc_first_dfs(0, visited, num);
+  return (visited.count(true) == _size);
+}
+void graph::write_digraph
+(::std::ostream& s, bool with_node_indices, const char* name) const
+{
+  s << "digraph \"" << name << "\"" << "{" << ::std::endl;
+  if (with_node_indices) {
+    s << "node [shape=circle,width=0.5,height=0.5];" << ::std::endl;
+    for (index_type k = 0; k < size(); k++)
+      s << "\t" << k << " [label=\"" << k << "\"];" << std::endl;
+  }
+  else {
+    s << "node [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j))
+ s << "\t" << i << " -> " << j << ";" << ::std::endl;
+  s << "}" << ::std::endl;
+}
+void graph::write_component_labeled_digraph
+(::std::ostream& s, const char* name) const
+{
+  write_labeled_digraph<index_vec>(s, *this, comp, false, name, no_such_index);
+}
+void graph::write_graph_correspondance
+(::std::ostream& s,
+ const graph& g,
+ const index_vec& c,
+ const char* name) const
+{
+  assert(g.size() == size());
+  assert(c.length() == g.size());
+  s << "digraph \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  s << "node [width=0,height=0];" << ::std::endl;
+  s << "subgraph cluster0 {" << ::std::endl;
+  for (index_type k = 0; k < size(); k++) {
+    s << "\tG0_" << k << " [label=\"" << k << "\"]"
+      << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (!g.adjacent(c[i], c[j])) {
+   s << "\tG0_" << i << " -> G0_" << j << " [style=bold];" << ::std::endl;
+ }
+ else {
+   s << "\tG0_" << i << " -> G0_" << j << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+  s << "subgraph cluster1 {" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\tG1_" << k << " [label=\"" << k << "\"]"
+      << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (g.adjacent(c[i], c[j])) {
+ if (!adjacent(i, j)) {
+   s << "\tG1_" << i << " -> G1_" << j << " [style=bold];" << ::std::endl;
+ }
+ else {
+   s << "\tG1_" << i << " -> G1_" << j << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+  for (index_type k = 0; k < size(); k++) {
+    s << "G0_" << k << " -> G1_" << c[k] << " [style=dashed,dir=none];"
+      << ::std::endl;
+  }
+  s << "}" << ::std::endl;
+}
+void index_graph::reverse()
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = i+1; j < size(); j++) {
+      if (adjacent(i, j) && !adjacent(j, i)) {
+ index_type l = (edge_has_label(i, j) ? edge_label(i, j) : 0);
+ remove_edge(i, j);
+ if ((l & EDGE_DIR) == ED_FORWARD)
+   l += (ED_BACK - ED_FORWARD);
+ else if ((l & EDGE_DIR) == ED_BACK)
+   l -= (ED_BACK - ED_FORWARD);
+ add_edge(j, i, l);
+      }
+      else if (!adjacent(i, j) && adjacent(j, i)) {
+ index_type l = (edge_has_label(j, i) ? edge_label(j, i) : 0);
+ remove_edge(j, i);
+ if ((l & EDGE_DIR) == ED_FORWARD)
+   l += (ED_BACK - ED_FORWARD);
+ else if ((l & EDGE_DIR) == ED_BACK)
+   l -= (ED_BACK - ED_FORWARD);
+ add_edge(i, j, l);
+      }
+    }
+}
+void index_graph::reflect()
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = i + 1; j < size(); j++)
+      if (adjacent(i, j)) {
+ assert(!adjacent(j, i));
+ add_edge(j, i);
+ index_type l = (edge_has_label(i, j) ? edge_label(i, j) : 0);
+ edge_label(j, i) = l;
+ if ((l & EDGE_DIR) == ED_FORWARD)
+   edge_label(j, i) += (ED_BACK - ED_FORWARD);
+ else if ((l & EDGE_DIR) == ED_BACK)
+   edge_label(j, i) -= (ED_BACK - ED_FORWARD);
+      }
+      else if (adjacent(j, i)) {
+ add_edge(i, j);
+ index_type l = (edge_has_label(j, i) ? edge_label(j, i) : 0);
+ edge_label(i, j) = l;
+ if ((l & EDGE_DIR) == ED_FORWARD)
+   edge_label(i, j) += (ED_BACK - ED_FORWARD);
+ else if ((l & EDGE_DIR) == ED_BACK)
+   edge_label(i, j) -= (ED_BACK - ED_FORWARD);
+      }
+}
+void index_graph::write_node_style
+(std::ostream& s, index_type l)
+{
+  s << "shape=";
+  if ((l & NODE_SHAPE) == NS_ELLIPSE)
+    s << "ellipse";
+  else if ((l & NODE_SHAPE) == NS_BOX)
+    s << "box";
+  else if ((l & NODE_SHAPE) == NS_POINT)
+    s << "point";
+  else if ((l & NODE_SHAPE) == NS_DIAMOND)
+    s << "diamond";
+  else if ((l & NODE_SHAPE) == NS_HEXAGON)
+    s << "hexagon";
+  else if ((l & NODE_SHAPE) == NS_OCTAGON)
+    s << "octagon";
+  else if ((l & NODE_SHAPE) == NS_PLAINTEXT)
+    s << "plaintext";
+  else
+    s << "circle";
+  if ((l & NODE_STYLE) == NS_FILLED)
+    s << ",style=filled";
+  else if ((l & NODE_STYLE) == NS_BOLD)
+    s << ",style=bold";
+  else if ((l & NODE_STYLE) == NS_DASHED)
+    s << ",style=dashed";
+  else if ((l & NODE_STYLE) == NS_DOTTED)
+    s << ",style=dotted";
+  if ((l & NS_DOUBLE) == NS_DOUBLE)
+    s << ",peripheries=2";
+}
+void index_graph::write_edge_style
+(std::ostream& s, index_type l)
+{
+  if ((l & EDGE_DIR) == ED_FORWARD)
+    s << "dir=forward";
+  else if ((l & EDGE_DIR) == ED_BACK)
+    s << "dir=back";
+  else if ((l & EDGE_DIR) == ED_BOTH)
+    s << "dir=both";
+  else
+    s << "dir=none";
+  if ((l & EDGE_STYLE) == ES_BOLD)
+    s << ",style=bold";
+  else if ((l & EDGE_STYLE) == ES_DASHED)
+    s << ",style=dashed";
+  else if ((l & EDGE_STYLE) == ES_DOTTED)
+    s << ",style=dotted";
+}
+void index_graph::write_styled_digraph
+(std::ostream& s,
+ bool with_node_indices,
+ const char* name,
+ index_type c_id) const
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    write_node_style(s, node_has_label(k) ? node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"" << k << "\"];" << std::endl;
+    else
+      s << ",label=\"\"];" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ write_edge_style(s, edge_has_label(i, j) ? edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+void index_graph::write_matrix
+(std::ostream& s) const
+{
+  for (index_type i = 0; i < size(); i++) {
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j))
+ s << ' ' << (edge_has_label(i, j) ? edge_label(i, j) : 0) + 1;
+      else
+ s << ' ' << 0;
+    s << ' ' << (node_has_label(i) ? node_label(i) : 0) << std::endl;
+  }
+}
+void index_graph::write_MATLAB
+(std::ostream& s, const char* n, const char* t) const
+{
+  s << "defgraph('";
+  if (n)
+    s << n;
+  else
+    s << "NONAME";
+  s << "', '";
+  if (t)
+    s << t;
+  else
+    s << "NOTYPE";
+  s << "',[";
+  for (index_type i = 0; i < size(); i++) {
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j))
+ s << ' ' << (edge_has_label(i, j) ? edge_label(i, j) : 0) + 1;
+      else
+ s << ' ' << 0;
+    if (i + 1 < size()) s << ";";
+  }
+  s << "], [";
+  for (index_type i = 0; i < size(); i++) {
+    s << ' ' << (node_has_label(i) ? node_label(i) : 0);
+    if (i + 1 < size()) s << ";";
+  }
+  s << "]);" << std::endl;
+}
+weighted_graph& weighted_graph::quotient
+(weighted_graph& g, const equivalence& eq) const
+{
+  g.init(eq.n_classes());
+  index_vec m;
+  eq.make_map(m);
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && !eq(i, j))
+ g.increment_edge_weight(m[i], m[j], weight(i, j));
+}
+hsps::rational weighted_graph::apx_weighted_independent_set_1(index_set& set) const
+{
+  set.clear();
+  hsps::rational w_best = NEG_INF;
+  hsps::rational w_max = max_node_weight();
+  index_type m = ilog(size());
+  for (index_type k = 1; k <= m; k++) {
+    hsps::rational w_lb = (w_max / (1 << k));
+    assert(w_lb > 0);
+    hsps::rational w_ub = (w_max / (1 << (k - 1)));
+    index_set nodes;
+    for (index_type i = 0; i < size(); i++)
+      if ((w_lb < weight(i)) && (weight(i) <= w_ub))
+ nodes.insert(i);
+    index_set maxI;
+    apx_independent_set(nodes, maxI);
+    hsps::rational w = 0;
+    for (index_type i = 0; i < maxI.length(); i++)
+      w += weight(maxI[i]);
+    if (w > w_best) {
+      set.assign_copy(maxI);
+      w_best = w;
+    }
+  }
+  return w_best;
+}
+hsps::rational weighted_graph::apx_weighted_independent_set_2(index_set& set) const
+{
+  weighted_vec<index_type,hsps::rational> sorted;
+  for (index_type k = 0; k < size(); k++) {
+    hsps::rational wd = (weight(bidirectional(k)) / weight(k));
+    sorted.insert_increasing(k, wd);
+  }
+  set.clear();
+  bool_vec rem(true, size());
+  hsps::rational w = 0;
+  for (index_type k = 0; k < size(); k++) {
+    index_type i = sorted[k].value;
+    if (rem[i] && (weight(i) > 0)) {
+      set.insert(i);
+      rem.subtract(bidirectional(i));
+      w += weight(i);
+    }
+  }
+  return w;
+}
+hsps::rational weighted_graph::apx_weighted_independent_set(index_set& set) const
+{
+  hsps::rational v1 = apx_weighted_independent_set_1(set);
+  hsps::rational v2 = apx_weighted_independent_set_2(set);
+  return hsps::rational::max(v1,v2);
+}
+void weighted_graph::add_edge(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+void weighted_graph::add_edge(index_type src, index_type dst, hsps::rational w)
+{
+  graph::add_edge(src, dst);
+  set_weight(src, dst, w);
+}
+void weighted_graph::increment_edge_weight
+(index_type src, index_type dst, hsps::rational w)
+{
+  if (!adjacent(src, dst)) graph::add_edge(src, dst);
+  set_weight(src, dst, weight(src, dst) + w);
+}
+void weighted_graph::add_undirected_edge(index_type n0, index_type n1)
+{
+  graph::add_undirected_edge(n0, n1);
+}
+void weighted_graph::add_undirected_edge
+(index_type n0, index_type n1, hsps::rational w)
+{
+  graph::add_undirected_edge(n0, n1);
+  set_weight(n0, n1, w);
+  set_weight(n1, n0, w);
+}
+hsps::rational weighted_graph::weight(index_type n) const
+{
+  if (node_has_label(n)) {
+    return node_label(n);
+  }
+  else {
+    return 0;
+  }
+}
+hsps::rational weighted_graph::weight(const index_set& ns) const
+{
+  hsps::rational sw = 0;
+  for (index_type k = 0; k < ns.length(); k++) {
+    assert(ns[k] < size());
+    sw += weight(ns[k]);
+  }
+  return sw;
+}
+hsps::rational weighted_graph::weight(index_type n0, index_type n1) const
+{
+  if (edge_has_label(n0, n1)) {
+    return edge_label(n0, n1);
+  }
+  else {
+    return 0;
+  }
+}
+hsps::rational weighted_graph::max_node_weight() const
+{
+  hsps::rational w_max = NEG_INF;
+  for (index_type k = 0; k < size(); k++)
+    if (weight(k) > w_max) w_max = weight(k);
+  return w_max;
+}
+void weighted_graph::set_weight(index_type n, hsps::rational w)
+{
+  node_label(n) = w;
+}
+void weighted_graph::set_weight(index_type n0, index_type n1, hsps::rational w)
+{
+  edge_label(n0, n1) = w;
+}
+void weighted_graph::transitive_closure()
+{
+  for (index_type k = 0; k < size(); k++)
+    for (index_type i = 0; i < size(); i++)
+      for (index_type j = 0; j < size(); j++)
+ if (adjacent(i, k) && adjacent(k, j)) {
+   if (!adjacent(i, j)) {
+     add_edge(i, j, weight(i, k) + weight(k, j));
+   }
+   else if ((weight(i, k) + weight(k, j)) < weight(i, j)) {
+     set_weight(i, j, weight(i, k) + weight(k, j));
+   }
+ }
+  recalculate();
+}
+hsps::rational weighted_graph::critical_path(cost_vec& s)
+{
+  cost_vec e(POS_INF, size());
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type k = 0; k < size(); k++) {
+      hsps::rational p = 0;
+      for (index_type i = 0; i < predecessors(k).length(); i++)
+ p = hsps::rational::max(p,e[predecessors(k)[i]] + weight(predecessors(k)[i], k));
+      if ((p + weight(k)) < e[k]) {
+ e[k] = p + weight(k);
+ done = false;
+      }
+    }
+  }
+  s.set_length(size());
+  for (index_type k = 0; k < size(); k++)
+    s[k] = (e[k] - weight(k));
+  return cost_vec_util::max(e);
+}
+hsps::rational weighted_graph::max_flow(index_type s, index_type t)
+{
+  cost_matrix f(0, size(), size());
+  return max_flow(s, t, f);
+}
+hsps::rational weighted_graph::max_flow(index_type s, index_type t, weighted_graph& rg)
+{
+  cost_matrix f(0, size(), size());
+  hsps::rational m = max_flow(s, t, f);
+  rg.init(size());
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && ((weight(i, j) - f[i][j]) > 0))
+ rg.add_edge(i, j, weight(i, j) - f[i][j]);
+  return m;
+}
+hsps::rational weighted_graph::max_flow(index_type s, index_type t, cost_matrix& f)
+{
+  f.assign_value(0, size(), size());
+  pair_vec p;
+  hsps::rational m = 0;
+  hsps::rational a = augmenting_path(s, t, f, p);
+  while (a > 0) {
+    for (index_type k = 0; k < p.length(); k++) {
+      f[p[k].first][p[k].second] =
+ (f[p[k].first][p[k].second] + a);
+      f[p[k].second][p[k].first] =
+ (f[p[k].second][p[k].first] - a);
+    }
+    m += a;
+    a = augmenting_path(s, t, f, p);
+  }
+  return m;
+}
+hsps::rational weighted_graph::min_cut(index_type s, index_type t, bool_vec& s_set)
+{
+  weighted_graph rg;
+  hsps::rational c = max_flow(s, t, rg);
+  rg.descendants(s, s_set);
+}
+hsps::rational weighted_graph::min_cut(index_type s, index_type t, pair_set& e_set)
+{
+  weighted_graph rg;
+  hsps::rational c = max_flow(s, t, rg);
+  bool_vec a_set;
+  descendants(s, a_set);
+  bool_vec s_set;
+  rg.descendants(s, s_set);
+  for (index_type i = 0; i < size(); i++) if (a_set[i])
+    for (index_type j = 0; j < size(); j++) if (a_set[j])
+      if (adjacent(i, j) && s_set[i] && !s_set[j])
+ e_set.insert(index_pair(i, j));
+  return c;
+}
+hsps::rational weighted_graph::augmenting_path
+(index_type s, index_type t, const cost_matrix& f, pair_vec& p)
+{
+  cost_vec m(NEG_INF, size());
+  m[t] = POS_INF;
+  index_vec d(no_such_index, size());
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type i = 0; i < size(); i++) if (m[i] > 0) {
+      for (index_type j = 0; j < predecessors(i).length(); j++) {
+ hsps::rational fji =
+   hsps::rational::min(weight(predecessors(i)[j], i) - f[predecessors(i)[j]][i],m[i]);
+ if (fji > m[predecessors(i)[j]]) {
+   m[predecessors(i)[j]] = fji;
+   d[predecessors(i)[j]] = i;
+   done = false;
+ }
+      }
+    }
+  }
+  p.set_length(0);
+  if (m[s] > 0) {
+    index_type k = s;
+    while (k != t) {
+      assert(m[k] >= m[s]);
+      assert(d[k] != no_such_index);
+      p.append(index_pair(k,d[k]));
+      k = d[k];
+    }
+  }
+  return m[s];
+}
+index_pair weighted_graph::max_weight_edge() const
+{
+  hsps::rational w_max = NEG_INF;
+  index_type n0 = no_such_index;
+  index_type n1 = no_such_index;
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i,j) && ((n0 == no_such_index) || (weight(i, j) > w_max))) {
+ n0 = i;
+ n1 = j;
+ w_max = weight(i, j);
+      }
+  return index_pair(n0, n1);
+}
+void weighted_graph::min_and_max_edges
+(const index_set& nodes,
+ pair_set& e_min, hsps::rational& w_min,
+ pair_set& e_max, hsps::rational& w_max) const
+{
+  e_min.clear();
+  w_min = POS_INF;
+  e_max.clear();
+  w_max = NEG_INF;
+  for (index_type i = 0; i < nodes.length(); i++)
+    for (index_type j = 0; j < nodes.length(); j++)
+      if ((i != j) && adjacent(nodes[i], nodes[j])) {
+ if (weight(nodes[i], nodes[j]) < w_min) {
+   w_min = weight(nodes[i], nodes[j]);
+   e_min.clear();
+   e_min.insert(index_pair(nodes[i], nodes[j]));
+ }
+ else if (weight(nodes[i], nodes[j]) == w_min) {
+   e_min.insert(index_pair(nodes[i], nodes[j]));
+ }
+ if (weight(nodes[i], nodes[j]) > w_max) {
+   w_max = weight(nodes[i], nodes[j]);
+   e_max.clear();
+   e_max.insert(index_pair(nodes[i], nodes[j]));
+ }
+ else if (weight(nodes[i], nodes[j]) == w_max) {
+   e_max.insert(index_pair(nodes[i], nodes[j]));
+ }
+      }
+}
+void weighted_graph::write_node_set(::std::ostream& s) const
+{
+  s << '{';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ',';
+    s << i << "[" << weight(i) << "]";
+  }
+  s << '}';
+}
+void weighted_graph::write_edge_set(::std::ostream& s) const
+{
+  s << '{';
+  bool first = true;
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (!first) s << ',';
+ first = false;
+ if (edge_has_label(i, j)) {
+   s << i << "-[" << weight(i, j) << "]->" << j;
+ }
+ else {
+   s << i << "->" << j;
+ }
+      }
+  s << '}';
+}
+void weighted_graph::write_compact(::std::ostream& s) const
+{
+  s << '(';
+  write_node_set(s);
+  s << ',';
+  write_edge_set(s);
+  s << '}';
+}
+void weighted_graph::write_matrix(::std::ostream& s) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << std::resetiosflags(std::ios::scientific) << ((edge_label(i, j)).decimal());
+ }
+ else {
+   s << "?";
+ }
+      }
+      else {
+ s << "INF";
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+hsps::rational weighted_graph::maximal_matching(weighted_graph& matching)
+{
+  index_type ni = no_such_index;
+  index_type nj = no_such_index;
+  for (index_type i = 0; (i < size()) && (ni == no_such_index); i++)
+    for (index_type j = i + 1; (j < size()) && (nj == no_such_index); j++)
+      if (adjacent(i, j) && adjacent(j, i)) {
+ ni = i;
+ nj = j;
+      }
+  if ((ni != no_such_index) && (nj != no_such_index)) {
+    index_set s;
+    s.fill(size());
+    s.subtract(ni);
+    s.subtract(nj);
+    weighted_graph* g1 = new weighted_graph(*this, s);
+    weighted_graph* m1 = new weighted_graph();
+    hsps::rational v1 = weight(ni, nj) + g1->maximal_matching(*m1);
+    delete g1;
+    weighted_graph* g2 = new weighted_graph(*this);
+    g2->remove_edge(ni, nj);
+    hsps::rational v2 = g2->maximal_matching(matching);
+    delete g2;
+    if (v1 > v2) {
+      matching.init(size());
+      for (index_type i = 0; i < m1->size(); i++)
+ for (index_type j = i + 1; j < m1->size(); j++)
+   if (m1->adjacent(i, j) && m1->adjacent(j, i))
+     matching.add_undirected_edge(s[i], s[j], weight(s[i], s[j]));
+      matching.add_undirected_edge(ni, nj, weight(ni, nj));
+    }
+    delete m1;
+    return hsps::rational::max(v1,v2);
+  }
+  else {
+    matching.init(size());
+    return 0;
+  }
+}
+hsps::rational weighted_graph::apx_matching(bool_vec& matched)
+{
+  bool_vec rem(true, size());
+  matched.assign_value(false, size());
+  hsps::rational val[2] = {0,0};
+  index_type i = 0;
+  index_type v = rem.first(true);
+  while (v != no_such_index) {
+    rem[v] = false;
+    bool done = false;
+    while (!done) {
+      hsps::rational w_max = NEG_INF;
+      index_type v_next = no_such_index;
+      for (index_type k = 0; k < bidirectional(v).length(); k++)
+ if (rem[bidirectional(v)[k]] &&
+     (weight(v, bidirectional(v)[k]) > w_max)) {
+   w_max = weight(v, bidirectional(v)[k]);
+   v_next = bidirectional(v)[k];
+ }
+      if (v_next != no_such_index) {
+ val[i] += w_max;
+ i = ((i + 1) % 2);
+ matched[v] = true;
+ matched[v_next] = true;
+ rem[v_next] = false;
+ v = v_next;
+      }
+      else {
+ done = true;
+      }
+    }
+    v = rem.first(true);
+  }
+  return hsps::rational::max(val[0],val[1]);
+}
+index_set_graph::index_set_graph
+(const graph& g, const equivalence& eq)
+  : labeled_graph<index_set,index_set>(eq.n_classes())
+{
+  index_vec m;
+  eq.make_map(m);
+  assert(m.length() == g.size());
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && !eq(i, j))
+ add_edge(m[i], m[j]);
+  index_set ce;
+  eq.canonical_elements(ce);
+  assert(ce.length() == size());
+  for (index_type i = 0; i < size(); i++)
+    eq.class_elements(ce[i], node_label(i));
+}
+index_set_graph::index_set_graph
+(const index_set_graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+index_set_graph& index_set_graph::quotient
+(index_set_graph& g, const equivalence& eq) const
+{
+  graph::quotient(g, eq);
+  g.clear_node_labels();
+  g.clear_edge_labels();
+  index_vec m;
+  eq.make_map(m);
+  for (index_type i = 0; i < g.size(); i++)
+    g.node_label(i) = EMPTYSET;
+  for (index_type i = 0; i < size(); i++)
+    g.node_label(m[i]).insert(node_label(i));
+}
+index_set_graph& index_set_graph::union_reachable(index_set_graph& g) const
+{
+  g.copy(*this);
+  for (index_type k = 0; k < size(); k++) {
+    index_set n;
+    g.descendants(k, n);
+    for (index_type i = 0; i < n.length(); i++)
+      g.node_label(k).insert(node_label(n[i]));
+  }
+}
+void index_set_graph::merge_labels(const index_set& ns)
+{
+  if (ns.empty()) return;
+  assert(ns[0] < size());
+  for (index_type i = 1; i < ns.length(); i++) {
+    assert(ns[i] < size());
+    node_label(ns[0]).insert(node_label(ns[i]));
+  }
+  for (index_type i = 1; i < ns.length(); i++) {
+    node_label(ns[i]).assign_copy(node_label(ns[0]));
+  }
+}
+void index_set_graph::merge_labels_upwards()
+{
+  strongly_connected_components();
+  equivalence eq;
+  component_partitioning(eq);
+  index_set_graph cdag(*((graph*)this), eq);
+  for (index_type k = 0; k < cdag.size(); k++) {
+    assert(!cdag.node_label(k).empty());
+    merge_labels(cdag.node_label(k));
+  }
+  while (!cdag.empty()) {
+    index_type l = cdag.first_leaf();
+    assert(l != no_such_index);
+    for (index_type i = 0; i < cdag.predecessors(l).length(); i++) {
+      index_type n_i = cdag.predecessors(l)[i];
+      assert(n_i < size());
+      for (index_type j = 0; j < cdag.node_label(n_i).length(); j++) {
+ index_type n_j = cdag.node_label(n_i)[j];
+ assert(n_j < size());
+ assert(!cdag.node_label(l).empty());
+ assert(cdag.node_label(l)[0] < size());
+ node_label(n_j).insert(node_label(cdag.node_label(l)[0]));
+      }
+    }
+    cdag.remove_node(l);
+  }
+}
+void index_set_graph::merge_labels_downwards()
+{
+  strongly_connected_components();
+  equivalence eq;
+  component_partitioning(eq);
+  index_set_graph cdag(*((graph*)this), eq);
+  for (index_type k = 0; k < cdag.size(); k++) {
+    assert(!cdag.node_label(k).empty());
+    merge_labels(cdag.node_label(k));
+  }
+  while (!cdag.empty()) {
+    index_type l = cdag.first_root();
+    assert(l != no_such_index);
+    for (index_type i = 0; i < cdag.successors(l).length(); i++) {
+      index_type n_i = cdag.successors(l)[i];
+      for (index_type j = 0; j < cdag.node_label(n_i).length(); j++) {
+ index_type n_j = cdag.node_label(n_i)[j];
+ node_label(n_j).insert(node_label(cdag.node_label(l)[0]));
+      }
+    }
+    cdag.remove_node(l);
+  }
+}
+index_set_graph& index_set_graph::subgraph_set_size_gt
+(index_set_graph& g, index_type l)
+{
+  index_set r;
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k)) {
+      if (node_label(k).length() > l) r.insert(k);
+    }
+  subgraph(g, r);
+  return g;
+}
+void index_set_graph::write_edge_set(::std::ostream& s) const
+{
+  s << '{';
+  bool first = true;
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (!first) s << ',';
+ first = false;
+ s << i << ":";
+ if (node_has_label(i))
+   s << node_label(i);
+ else
+   s << "[]";
+ s << "->" << j << ":";
+ if (node_has_label(j))
+   s << node_label(j);
+ else
+   s << "[]";
+      }
+  s << '}';
+}
+void index_set_graph::write_digraph(::std::ostream& s, const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  for (index_type k = 0; k < size(); k++) {
+    s << "\t" << k << " [label=\"" << k << ":{";
+    if (node_has_label(k)) {
+      for (index_type i = 0; i < node_label(k).length(); i++) {
+ if (i > 0) s << ",";
+ s << node_label(k)[i];
+      }
+    }
+    s << "}\"];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j))
+ s << "\t" << i << " -> " << j << ";" << ::std::endl;
+  s << "}" << ::std::endl;
+}
+}

--- a/pr/seq-opt-hspsf/hashtable.ccx
+++ b/pr/seq-opt-hspsf/hashtable.ccx
@@ -1,0 +1,2741 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class HashTable {
+ public:
+  struct Entry {
+    State* state;
+    index_type depth;
+    hsps::rational cost;
+  };
+ private:
+  index_type size;
+  index_type nocc;
+  Entry* tab;
+  count_type hits;
+  count_type cols;
+  count_type miss;
+ public:
+  HashTable(index_type s);
+  ~HashTable();
+  void inc_occ_count() { nocc += 1; };
+  Entry& operator[](index_type i);
+  index_type index(State& s);
+  Entry* find(State& s);
+  void insert(State& s, hsps::rational v, index_type d);
+  void insert(State& s, hsps::rational v);
+  void clear();
+  double hit_ratio();
+  double HCF();
+  double TUF();
+};
+}
+namespace hsps {
+HashTable::HashTable(index_type s)
+  : size(s), tab(0), hits(0), cols(0)
+{
+  tab = new Entry[size];
+  for (index_type k = 0; k < size; k++) {
+    tab[k].state = 0;
+    tab[k].depth = no_such_index;
+    tab[k].cost = 0;
+  }
+}
+HashTable::~HashTable()
+{
+  assert(tab);
+  for (index_type k = 0; k < size; k++)
+    if (tab[k].state) delete tab[k].state;
+  delete tab;
+}
+HashTable::Entry& HashTable::operator[](index_type i)
+{
+  assert(i < size);
+  return tab[i];
+}
+index_type HashTable::index(State& s)
+{
+  return (s.hash() % size);
+}
+HashTable::Entry* HashTable::find(State& s)
+{
+  index_type h0 = s.hash();
+  index_type h = (h0 % size);
+  if (tab[h].state) {
+    if (tab[h].state->compare(s) == 0) {
+      hits += 1;
+      return &(tab[h]);
+    }
+    else {
+      cols += 1;
+      return 0;
+    }
+  }
+  else {
+    miss += 1;
+    return 0;
+  }
+}
+void HashTable::insert(State& s, hsps::rational v, index_type d)
+{
+  index_type h = (s.hash() % size);
+  if (tab[h].state) {
+    delete tab[h].state;
+  }
+  else {
+    nocc += 1;
+  }
+  tab[h].state = s.copy();
+  tab[h].depth = d;
+  tab[h].cost = v;
+}
+void HashTable::insert(State& s, hsps::rational v)
+{
+  insert(s, v, s.depth());
+}
+void HashTable::clear()
+{
+  for (index_type k = 0; k < size; k++) {
+    if (tab[k].state) {
+      delete tab[k].state;
+    }
+    tab[k].state = 0;
+    tab[k].depth = no_such_index;
+    tab[k].cost = 0;
+  }
+  nocc = 0;
+  hits = 0;
+  cols = 0;
+  miss = 0;
+}
+double HashTable::hit_ratio()
+{
+  return hits/(double)(hits + cols + miss);
+}
+double HashTable::HCF()
+{
+  return hits/(double)cols;
+}
+double HashTable::TUF()
+{
+  return nocc/(double)size;
+}
+}

--- a/pr/seq-opt-hspsf/heuristic.ccx
+++ b/pr/seq-opt-hspsf/heuristic.ccx
@@ -1,0 +1,5058 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+count_type Heuristic::eval_count = 0;
+int Heuristic::default_trace_level = 1;
+Heuristic::~Heuristic()
+{
+}
+void Heuristic::set_trace_level(int level)
+{
+  trace_level = level;
+}
+void Heuristic::write_eval
+(const index_set& s, ::std::ostream& st, char* p, bool e)
+{
+  if (p) st << p << ' ';
+  st << eval(s);
+  if (e) st << ::std::endl;
+}
+void Heuristic::write_eval
+(const bool_vec& s, ::std::ostream& st, char* p, bool e)
+{
+  if (p) st << p << ' ';
+  st << eval(s);
+  if (e) st << ::std::endl;
+}
+hsps::rational Heuristic::eval_precondition(const Instance::Action& a)
+{
+  return eval(a.pre);
+}
+hsps::rational Heuristic::incremental_eval(const index_set& s, index_type i_new)
+{
+  index_set s_new(s);
+  s_new.insert(i_new);
+  return eval(s_new);
+}
+hsps::rational Heuristic::incremental_eval(const bool_vec& s, index_type i_new)
+{
+  bool_vec s_new(s);
+  for (index_type k = 0; k < instance.n_atoms(); k++) s_new[k] = s[k];
+  s_new[i_new] = true;
+  return eval(s_new);
+}
+hsps::rational Heuristic::eval_to_bound(const index_set& s, hsps::rational bound)
+{
+  return eval(s);
+}
+hsps::rational Heuristic::eval_to_bound(const bool_vec& s, hsps::rational bound)
+{
+  return eval(s);
+}
+void Heuristic::store(const index_set& s, hsps::rational v, bool opt)
+{
+}
+void Heuristic::store(const bool_vec& s, hsps::rational v, bool opt)
+{
+}
+hsps::rational Heuristic::eval(index_type atom)
+{
+  index_set s;
+  s.assign_singleton(atom);
+  return eval(s);
+}
+void Heuristic::compute_heuristic_graph(const ACF& cost, graph& g)
+{
+  g.init(instance.n_atoms());
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    hsps::rational c = eval(instance.actions[k].pre) + cost(k);
+    for (index_type i = 0; i < instance.actions[k].add.length(); i++)
+      if (c <= eval(instance.actions[k].add[i]))
+ g.add_edge(instance.actions[k].pre, instance.actions[k].add[i]);
+  }
+}
+hsps::rational ZeroHeuristic::eval(const index_set& s)
+{
+  eval_count += 1;
+  return 0;
+}
+hsps::rational ZeroHeuristic::eval(const bool_vec& s)
+{
+  eval_count += 1;
+  return 0;
+}
+EvalActionCache::EvalActionCache(Instance& ins, Heuristic& h)
+  : Heuristic(ins), base_h(h), cache(0, instance.n_actions())
+{
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    cache[k] = base_h.eval(instance.actions[k].pre);
+}
+hsps::rational EvalActionCache::eval(const index_set& s)
+{
+  return base_h.eval(s);
+}
+hsps::rational EvalActionCache::eval(const bool_vec& s)
+{
+  return base_h.eval(s);
+}
+hsps::rational EvalActionCache::eval_precondition(const Instance::Action& a)
+{
+  return cache[a.index];
+}
+hsps::rational EvalActionCache::incremental_eval(const index_set& s, index_type i_new)
+{
+  return base_h.incremental_eval(s, i_new);
+}
+hsps::rational EvalActionCache::incremental_eval(const bool_vec& s, index_type i_new)
+{
+  return base_h.incremental_eval(s, i_new);
+}
+hsps::rational EvalActionCache::eval_to_bound(const index_set& s, hsps::rational bound)
+{
+  return base_h.eval_to_bound(s, bound);
+}
+hsps::rational EvalActionCache::eval_to_bound(const bool_vec& s, hsps::rational bound)
+{
+  return base_h.eval_to_bound(s, bound);
+}
+hsps::rational RegressionInvariantCheck::eval(const index_set& s)
+{
+  hsps::rational val = base_h.eval(s);
+  if ((val).finite()) {
+    for (index_type k = 0; (k < instance.n_invariants()) && (val).finite(); k++)
+      if (instance.invariants[k].verified || !verified_invariants_only)
+ if (!instance.eval_invariant_in_partial_state(s, instance.invariants[k])) val = POS_INF;
+  }
+  return val;
+}
+hsps::rational RegressionInvariantCheck::eval(const bool_vec& s)
+{
+  hsps::rational val = base_h.eval(s);
+  if ((val).finite()) {
+    for (index_type k = 0; (k < instance.n_invariants()) && (val).finite(); k++)
+      if (instance.invariants[k].verified || !verified_invariants_only)
+ if (!instance.eval_invariant_in_partial_state(s, instance.invariants[k])) val = POS_INF;
+  }
+  return val;
+}
+hsps::rational RegressionInvariantCheck::incremental_eval
+(const index_set& s, index_type i_new)
+{
+  hsps::rational val = base_h.incremental_eval(s, i_new);
+  if ((val).finite()) {
+    index_set s_new(s);
+    s_new.insert(i_new);
+    for (index_type k = 0; (k < instance.n_invariants()) && (val).finite(); k++)
+      if (instance.invariants[k].verified || !verified_invariants_only)
+ if (!instance.eval_invariant_in_partial_state(s_new, instance.invariants[k])) val = POS_INF;
+  }
+  return val;
+}
+hsps::rational RegressionInvariantCheck::incremental_eval
+(const bool_vec& s, index_type i_new)
+{
+  hsps::rational val = base_h.incremental_eval(s, i_new);
+  if ((val).finite()) {
+    bool_vec s_new(s);
+    s_new[i_new] = true;
+    for (index_type k = 0; (k < instance.n_invariants()) && (val).finite(); k++)
+      if (instance.invariants[k].verified || !verified_invariants_only)
+ if (!instance.eval_invariant_in_partial_state(s_new, instance.invariants[k])) val = POS_INF;
+  }
+  return val;
+}
+hsps::rational RegressionInvariantCheck::eval_to_bound
+(const index_set& s, hsps::rational bound)
+{
+  hsps::rational val = base_h.eval(s);
+  if (val < bound) {
+    for (index_type k = 0; (k < instance.n_invariants()) && (val).finite(); k++)
+      if (instance.invariants[k].verified || !verified_invariants_only)
+ if (!instance.eval_invariant_in_partial_state(s, instance.invariants[k])) val = POS_INF;
+  }
+  return val;
+}
+hsps::rational RegressionInvariantCheck::eval_to_bound
+(const bool_vec& s, hsps::rational bound)
+{
+  hsps::rational val = base_h.eval(s);
+  if (val < bound) {
+    for (index_type k = 0; (k < instance.n_invariants()) && (val).finite(); k++)
+      if (instance.invariants[k].verified || !verified_invariants_only)
+ if (!instance.eval_invariant_in_partial_state(s, instance.invariants[k])) val = POS_INF;
+  }
+  return val;
+}
+ForwardReachabilityCheck::ForwardReachabilityCheck
+(Instance& i, const index_set& g)
+  : Heuristic(i),
+    goals(g),
+    r(false, i.n_atoms()),
+    f(false, i.n_actions()),
+    d(false, i.n_actions())
+{
+}
+ForwardReachabilityCheck::~ForwardReachabilityCheck()
+{
+}
+hsps::rational ForwardReachabilityCheck::compute()
+{
+  f.assign_value(false);
+  for (index_type k = 0; k < instance.n_atoms(); k++) if (r[k]) {
+    for (index_type i = 0; i < instance.atoms[k].req_by.length(); i++)
+      f[instance.atoms[k].req_by[i]] = true;
+  }
+  for (index_type k = 0; k < instance.n_actions(); k++) d[k] = false;
+  bool done = false;
+  while (!done) {
+    done = true;
+    for (index_type k = 0; k < instance.n_actions(); k++) if (f[k] && !d[k]) {
+      bool app = true;
+      for (index_type i = 0; (i < instance.actions[k].pre.length())&&app; i++)
+ if (!r[instance.actions[k].pre[i]]) {
+   app = false;
+ }
+      if (app) {
+ for (index_type i = 0; i < instance.actions[k].add.length(); i++) {
+   index_type a = instance.actions[k].add[i];
+   if (!r[a]) {
+     r[a] = true;
+     for (index_type j = 0; j < instance.atoms[a].req_by.length(); j++){
+       f[instance.atoms[a].req_by[j]] = true;
+     }
+     done = false;
+   }
+ }
+ d[k] = true;
+      }
+    }
+  }
+  for (index_type k = 0; k < goals.length(); k++)
+    if (!r[goals[k]]) return POS_INF;
+  return 0;
+}
+hsps::rational ForwardReachabilityCheck::eval(const index_set& s)
+{
+  r.assign_value(false);
+  for (index_type k = 0; k < s.length(); k++) r[s[k]] = true;
+  return compute();
+}
+hsps::rational ForwardReachabilityCheck::eval(const bool_vec& s)
+{
+  r.assign_copy(s);
+  return compute();
+}
+hsps::rational RoundUp::eval(const index_set& s)
+{
+  hsps::rational v = h.eval(s);
+  return rational::floor_to(v, d);
+}
+hsps::rational RoundUp::eval(const bool_vec& s)
+{
+  hsps::rational v = h.eval(s);
+  return rational::floor_to(v, d);
+}
+hsps::rational RoundUp::incremental_eval(const index_set& s, index_type i_new)
+{
+  hsps::rational v = h.incremental_eval(s, i_new);
+  return rational::floor_to(v, d);
+}
+hsps::rational RoundUp::incremental_eval(const bool_vec& s, index_type i_new)
+{
+  hsps::rational v = h.incremental_eval(s, i_new);
+  return rational::floor_to(v, d);
+}
+hsps::rational RoundUp::eval_to_bound(const index_set& s, hsps::rational bound)
+{
+  hsps::rational v = h.eval_to_bound(s, bound);
+  return rational::floor_to(v, d);
+}
+hsps::rational RoundUp::eval_to_bound(const bool_vec& s, hsps::rational bound)
+{
+  hsps::rational v = h.eval_to_bound(s, bound);
+  return rational::floor_to(v, d);
+}
+hsps::rational Combine2ByMax::eval(const index_set& s)
+{
+  hsps::rational v0 = h0.eval(s);
+  hsps::rational v1 = h1.eval(s);
+  if (trace_level > 1) {
+    if (v0 != v1) {
+      ::std::cerr << "Combine2ByMax: ";
+      instance.write_atom_set(::std::cerr, s);
+      ::std::cerr << ", v0 = " << v0 << ", v1 = " << v1 << ::std::endl;
+    }
+  }
+  return hsps::rational::max(v0,v1);
+}
+hsps::rational Combine2ByMax::eval(const bool_vec& s)
+{
+  hsps::rational v0 = h0.eval(s);
+  hsps::rational v1 = h1.eval(s);
+  if (trace_level > 1) {
+    if (v0 != v1) {
+      ::std::cerr << "Combine2ByMax: ";
+      instance.write_atom_set(::std::cerr, s);
+      ::std::cerr << ", v0 = " << v0 << ", v1 = " << v1 << ::std::endl;
+    }
+  }
+  return hsps::rational::max(v0,v1);
+}
+hsps::rational Combine2ByMax::incremental_eval(const index_set& s, index_type i_new)
+{
+  hsps::rational v0 = h0.incremental_eval(s, i_new);
+  hsps::rational v1 = h1.incremental_eval(s, i_new);
+  return hsps::rational::max(v0,v1);
+}
+hsps::rational Combine2ByMax::incremental_eval(const bool_vec& s, index_type i_new)
+{
+  hsps::rational v0 = h0.incremental_eval(s, i_new);
+  hsps::rational v1 = h1.incremental_eval(s, i_new);
+  return hsps::rational::max(v0,v1);
+}
+hsps::rational Combine2ByMax::eval_to_bound(const index_set& s, hsps::rational bound)
+{
+  hsps::rational v0 = h0.eval_to_bound(s, bound);
+  if (v0 > bound) return v0;
+  hsps::rational v1 = h1.eval_to_bound(s, bound);
+  return hsps::rational::max(v0,v1);
+}
+hsps::rational Combine2ByMax::eval_to_bound(const bool_vec& s, hsps::rational bound)
+{
+  hsps::rational v0 = h0.eval_to_bound(s, bound);
+  if (v0 > bound) return v0;
+  hsps::rational v1 = h1.eval_to_bound(s, bound);
+  return hsps::rational::max(v0,v1);
+}
+hsps::rational CombineNByMax::eval(const index_set& s)
+{
+  hsps::rational v_max = 0;
+  for (index_type k = 0; k < h_vec.length(); k++)
+    v_max = hsps::rational::max(v_max,h_vec[k]->eval(s));
+  return v_max;
+}
+hsps::rational CombineNByMax::eval(const bool_vec& s)
+{
+  hsps::rational v_max = 0;
+  for (index_type k = 0; k < h_vec.length(); k++)
+    v_max = hsps::rational::max(v_max,h_vec[k]->eval(s));
+  return v_max;
+}
+hsps::rational CombineNByMax::incremental_eval(const index_set& s, index_type i_new)
+{
+  hsps::rational v_max = 0;
+  for (index_type k = 0; k < h_vec.length(); k++)
+    v_max = hsps::rational::max(v_max,h_vec[k]->incremental_eval(s, i_new));
+  return v_max;
+}
+hsps::rational CombineNByMax::incremental_eval(const bool_vec& s, index_type i_new)
+{
+  hsps::rational v_max = 0;
+  for (index_type k = 0; k < h_vec.length(); k++)
+    v_max = hsps::rational::max(v_max,h_vec[k]->incremental_eval(s, i_new));
+  return v_max;
+}
+hsps::rational CombineNByMax::eval_to_bound(const index_set& s, hsps::rational bound)
+{
+  hsps::rational v_max = 0;
+  for (index_type k = 0; k < h_vec.length(); k++) {
+    v_max = hsps::rational::max(v_max,h_vec[k]->eval(s));
+    if (v_max > bound) return v_max;
+  }
+  return v_max;
+}
+hsps::rational CombineNByMax::eval_to_bound(const bool_vec& s, hsps::rational bound)
+{
+  hsps::rational v_max = 0;
+  for (index_type k = 0; k < h_vec.length(); k++) {
+    v_max = hsps::rational::max(v_max,h_vec[k]->eval(s));
+    if (v_max > bound) return v_max;
+  }
+  return v_max;
+}
+hsps::rational CombineNBySum::eval(const index_set& s)
+{
+  hsps::rational v_sum = 0;
+  for (index_type k = 0; k < h_vec.length(); k++)
+    v_sum += h_vec[k]->eval(s);
+  return v_sum;
+}
+hsps::rational CombineNBySum::eval(const bool_vec& s)
+{
+  hsps::rational v_sum = 0;
+  for (index_type k = 0; k < h_vec.length(); k++)
+    v_sum += h_vec[k]->eval(s);
+  return v_sum;
+}
+hsps::rational CombineNBySum::incremental_eval(const index_set& s, index_type i_new)
+{
+  hsps::rational v_sum = 0;
+  for (index_type k = 0; k < h_vec.length(); k++)
+    v_sum += h_vec[k]->incremental_eval(s, i_new);
+  return v_sum;
+}
+hsps::rational CombineNBySum::incremental_eval(const bool_vec& s, index_type i_new)
+{
+  hsps::rational v_sum = 0;
+  for (index_type k = 0; k < h_vec.length(); k++)
+    v_sum += h_vec[k]->incremental_eval(s, i_new);
+  return v_sum;
+}
+hsps::rational CombineNBySum::eval_to_bound(const index_set& s, hsps::rational bound)
+{
+  hsps::rational v_sum = 0;
+  for (index_type k = 0; k < h_vec.length(); k++) {
+    v_sum += h_vec[k]->eval(s);
+    if (v_sum > bound) return v_sum;
+  }
+  return v_sum;
+}
+hsps::rational CombineNBySum::eval_to_bound(const bool_vec& s, hsps::rational bound)
+{
+  hsps::rational v_sum = 0;
+  for (index_type k = 0; k < h_vec.length(); k++) {
+    v_sum += h_vec[k]->eval(s);
+    if (v_sum > bound) return v_sum;
+  }
+  return v_sum;
+}
+hsps::rational HX::eval(const index_set& s)
+{
+  assert(!X.empty());
+  index_type c = s.first_common_element(X);
+  if (c == no_such_index) {
+    bool_vec sx(s, instance.n_atoms());
+    hsps::rational v = POS_INF;
+    for (index_type k = 0; k < X.length(); k++) {
+      assert(!sx[X[k]]);
+      sx[X[k]] = true;
+      v = hsps::rational::min(v,h0.eval(sx));
+      sx[X[k]] = false;
+    }
+    return v;
+  }
+  else {
+    return h0.eval(s);
+  }
+}
+hsps::rational HX::eval(const bool_vec& s)
+{
+  assert(!X.empty());
+  index_type c = X.first_common_element(s);
+  if (c == no_such_index) {
+    bool_vec sx(s);
+    hsps::rational v = POS_INF;
+    for (index_type k = 0; k < X.length(); k++) {
+      assert(!sx[X[k]]);
+      sx[X[k]] = true;
+      v = hsps::rational::min(v,h0.eval(sx));
+      sx[X[k]] = false;
+    }
+    return v;
+  }
+  else {
+    return h0.eval(s);
+  }
+}
+hsps::rational HX::incremental_eval(const index_set& s, index_type i_new)
+{
+  assert(!X.empty());
+  if (X.contains(i_new)) {
+    return h0.incremental_eval(s, i_new);
+  }
+  else {
+    index_type c = s.first_common_element(X);
+    if (c == no_such_index) {
+      bool_vec sx(s, instance.n_atoms());
+      sx[i_new] = true;
+      hsps::rational v = POS_INF;
+      for (index_type k = 0; k < X.length(); k++) {
+ assert(!sx[X[k]]);
+ sx[X[k]] = true;
+ v = hsps::rational::min(v,h0.eval(sx));
+ sx[X[k]] = false;
+      }
+      return v;
+    }
+    else {
+      return h0.incremental_eval(s, i_new);
+    }
+  }
+}
+hsps::rational HX::incremental_eval(const bool_vec& s, index_type i_new)
+{
+  if (X.contains(i_new)) {
+    return h0.incremental_eval(s, i_new);
+  }
+  else {
+    assert(!X.empty());
+    index_type c = X.first_common_element(s);
+    if (c == no_such_index) {
+      bool_vec sx(s);
+      bool i_new_set = sx[i_new];
+      sx[i_new] = true;
+      hsps::rational v = POS_INF;
+      for (index_type k = 0; k < X.length(); k++) {
+ assert(!sx[X[k]]);
+ sx[X[k]] = true;
+ v = hsps::rational::min(v,h0.eval(sx));
+ sx[X[k]] = false;
+      }
+      sx[i_new] = i_new_set;
+      return v;
+    }
+    else {
+      return h0.incremental_eval(s, i_new);
+    }
+  }
+}
+void HX::write_eval(const index_set& s, std::ostream& st, char* p, bool e)
+{
+  assert(!X.empty());
+  if (p) st << p << ' ';
+  index_type c = s.first_common_element(X);
+  if (c == no_such_index) {
+    st << "max {";
+    bool_vec sx(s, instance.n_atoms());
+    hsps::rational v = POS_INF;
+    for (index_type k = 0; k < X.length(); k++) {
+      assert(!sx[X[k]]);
+      if (k > 0) st << ", ";
+      st << "X=" << instance.atoms[X[k]].name << ": ";
+      sx[X[k]] = true;
+      h0.write_eval(s, st, 0, false);
+      v = hsps::rational::min(v,h0.eval(sx));
+      sx[X[k]] = false;
+    }
+    st << "} = " << v;
+  }
+  else {
+    st << "X=" << instance.atoms[c].name << ": ";
+    h0.write_eval(s, st, 0, false);
+  }
+  if (e) st << ::std::endl;
+}
+void HX::write_eval(const bool_vec& s, std::ostream& st, char* p, bool e)
+{
+  assert(!X.empty());
+  if (p) st << p << ' ';
+  index_type c = X.first_common_element(s);
+  if (c == no_such_index) {
+    st << "max {";
+    bool_vec sx(s);
+    hsps::rational v = POS_INF;
+    for (index_type k = 0; k < X.length(); k++) {
+      assert(!sx[X[k]]);
+      if (k > 0) st << ", ";
+      st << "X=" << instance.atoms[X[k]].name << ": ";
+      sx[X[k]] = true;
+      h0.write_eval(s, st, 0, false);
+      v = hsps::rational::min(v,h0.eval(sx));
+      sx[X[k]] = false;
+    }
+    st << "} = " << v;
+  }
+  else {
+    st << "X=" << instance.atoms[c].name << ": ";
+    h0.write_eval(s, st, 0, false);
+  }
+  if (e) st << ::std::endl;
+}
+hsps::rational AtomMapAdapter::eval(const index_set& s)
+{
+  index_set xs;
+  for (index_type k = 0; k < s.length(); k++)
+    if (map[s[k]] != no_such_index) xs.insert(map[s[k]]);
+  return base_h.eval(xs);
+}
+hsps::rational AtomMapAdapter::eval(const bool_vec& s)
+{
+  index_set xs;
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (s[k] && (map[k] != no_such_index)) xs.insert(map[k]);
+  return base_h.eval(xs);
+}
+hsps::rational AtomMapAdapter::incremental_eval(const index_set& s, index_type i_new)
+{
+  index_set xs;
+  for (index_type k = 0; k < s.length(); k++)
+    if (map[s[k]] != no_such_index) xs.insert(map[s[k]]);
+  if (map[i_new] != no_such_index)
+    return base_h.incremental_eval(xs, map[i_new]);
+  else
+    return base_h.eval(xs);
+}
+hsps::rational AtomMapAdapter::incremental_eval(const bool_vec& s, index_type i_new)
+{
+  index_set xs;
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (s[k] && (map[k] != no_such_index)) xs.insert(map[k]);
+  if (map[i_new] != no_such_index)
+    return base_h.incremental_eval(xs, map[i_new]);
+  else
+    return base_h.eval(xs);
+}
+count_type CompareEval::lower = 0;
+count_type CompareEval::equal = 0;
+count_type CompareEval::higher = 0;
+hsps::rational CompareEval::eval(const index_set& s)
+{
+  hsps::rational base_val = base_h.eval(s);
+  hsps::rational alt_val = alt_h.eval(s);
+  if (alt_val < base_val) {
+    lower += 1;
+  }
+  else if (alt_val > base_val) {
+    higher += 1;
+  }
+  else {
+    equal += 1;
+  }
+  if ((trace_level > 0) && (alt_val != base_val)) {
+    base_h.set_trace_level(trace_level);
+    ::std::cerr << "evaluating base heuristic..." << ::std::endl;
+    base_h.eval(s);
+    base_h.set_trace_level(0);
+    alt_h.set_trace_level(trace_level);
+    ::std::cerr << "evaluating alternative heuristic..." << ::std::endl;
+    alt_h.eval(s);
+    alt_h.set_trace_level(0);
+  }
+  if (max_h_val) {
+    return hsps::rational::max(base_val,alt_val);
+  }
+  else {
+    return base_val;
+  }
+}
+hsps::rational CompareEval::eval(const bool_vec& s)
+{
+  hsps::rational base_val = base_h.eval(s);
+  hsps::rational alt_val = alt_h.eval(s);
+  if (alt_val < base_val) {
+    lower += 1;
+  }
+  else if (alt_val > base_val) {
+    higher += 1;
+  }
+  else {
+    equal += 1;
+  }
+  if ((trace_level > 0) && (alt_val != base_val)) {
+    base_h.set_trace_level(trace_level);
+    ::std::cerr << "evaluating base heuristic..." << ::std::endl;
+    base_h.eval(s);
+    base_h.set_trace_level(0);
+    alt_h.set_trace_level(trace_level);
+    ::std::cerr << "evaluating alternative heuristic..." << ::std::endl;
+    alt_h.eval(s);
+    alt_h.set_trace_level(0);
+  }
+  if (max_h_val) {
+    return hsps::rational::max(base_val,alt_val);
+  }
+  else {
+    return base_val;
+  }
+}
+CompleteNegationAdapter::CompleteNegationAdapter
+(Instance& ins, const pair_vec& p, Heuristic& h)
+  : Heuristic(ins), h_base(h), pn_map(p), sc(false, p.length() * 2)
+{
+}
+CompleteNegationAdapter::~CompleteNegationAdapter()
+{
+}
+hsps::rational CompleteNegationAdapter::eval(const index_set& s)
+{
+  bool_vec sv(s, instance.n_atoms());
+  return eval(sv);
+}
+hsps::rational CompleteNegationAdapter::eval(const bool_vec& s)
+{
+  for (index_type k = 0; k < pn_map.length(); k++) {
+    sc[pn_map[k].first] = s[pn_map[k].first];
+    sc[pn_map[k].second] = !s[pn_map[k].first];
+  }
+  return h_base.eval(sc);
+}
+hsps::rational ACF::min_cost(index_type n) const
+{
+  hsps::rational c_min = POS_INF;
+  for (index_type k = 0; k < n; k++)
+    c_min = hsps::rational::min(c_min,(*this)(k));
+  return c_min;
+}
+hsps::rational ACF::max_cost(index_type n) const
+{
+  hsps::rational c_max = NEG_INF;
+  for (index_type k = 0; k < n; k++)
+    c_max = hsps::rational::max(c_max,(*this)(k));
+  return c_max;
+}
+hsps::rational ACF::avg_cost(index_type n) const
+{
+  hsps::rational c_sum = 0;
+  for (index_type k = 0; k < n; k++) {
+    hsps::rational c_k = (*this)(k);
+    c_sum += c_k;
+  }
+  return c_sum / n;
+}
+hsps::rational ACF::cost_gcd(index_type n) const
+{
+  bool first = true;
+  hsps::rational e = 0;
+  for (index_type k = 0; k < n; k++) if ((*this)(k) != 0) {
+    if (first) {
+      e = (*this)(k);
+      first = false;
+    }
+    else {
+      e = rational::rgcd(e, (*this)(k));
+    }
+  }
+  return e;
+}
+hsps::rational UnitACF::operator()(index_type a) const
+{
+  return 1;
+}
+hsps::rational UnitACF::min_cost(index_type n) const
+{
+  return 1;
+}
+hsps::rational UnitACF::max_cost(index_type n) const
+{
+  return 1;
+}
+hsps::rational UnitACF::avg_cost(index_type n) const
+{
+  return 1;
+}
+hsps::rational ZeroACF::operator()(index_type a) const
+{
+  return 0;
+}
+hsps::rational ZeroACF::min_cost(index_type n) const
+{
+  return 0;
+}
+hsps::rational ZeroACF::max_cost(index_type n) const
+{
+  return 0;
+}
+hsps::rational ZeroACF::avg_cost(index_type n) const
+{
+  return 0;
+}
+hsps::rational CostACF::operator()(index_type a) const
+{
+  return instance.actions[a].cost;
+}
+FracACF::FracACF(const ACF& b, index_type l)
+  : baseACF(b), df(1, l)
+{
+}
+FracACF::FracACF(const ACF& b, index_type l, hsps::rational f)
+  : baseACF(b), df(f, l)
+{
+}
+FracACF::~FracACF()
+{
+}
+void FracACF::set(index_type a, hsps::rational f)
+{
+  assert(a < df.length());
+  df[a] = f;
+}
+void FracACF::set(const index_set& d, hsps::rational f)
+{
+  for (index_type k = 0; k < d.length(); k++) {
+    assert(d[k] < df.length());
+    df[d[k]] = f;
+  }
+}
+hsps::rational FracACF::operator()(index_type a) const
+{
+  assert(a < df.length());
+  return (baseACF(a) * df[a]);
+}
+void DiscountACF::count_only(const bool_vec& d)
+{
+  assert(d.length() == discounted.length());
+  for (index_type k = 0; k < discounted.length(); k++)
+    discounted[k] = !d[k];
+}
+hsps::rational DiscountACF::operator()(index_type a) const
+{
+  if (discounted[a]) return 0;
+  else return baseACF(a);
+}
+hsps::rational MakespanACF::operator()(index_type a) const
+{
+  return instance.actions[a].dur;
+}
+ResourceConsACF::ResourceConsACF(Instance& i, index_type r)
+  : instance(i), resource_id(r)
+{
+  assert(r < instance.n_resources());
+}
+hsps::rational ResourceConsACF::operator()(index_type a) const
+{
+  return instance.actions[a].cons[resource_id];
+}
+ResourceReqACF::ResourceReqACF(Instance& i, index_type r)
+  : instance(i), resource_id(r)
+{
+  assert(r < instance.n_resources());
+}
+hsps::rational ResourceReqACF::operator()(index_type a) const
+{
+  return instance.actions[a].req(resource_id);
+}
+}

--- a/pr/seq-opt-hspsf/hsp0.ccx
+++ b/pr/seq-opt-hspsf/hsp0.ccx
@@ -1,0 +1,9487 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+void sort2(index_type& i, index_type& j);
+void sort3(index_type& i, index_type& j, index_type& l);
+class PairIndexFunction : index_vec {
+ public:
+  PairIndexFunction(index_type n);
+  ~PairIndexFunction();
+  index_type operator()(index_type i, index_type j) const;
+  index_type max_in() const;
+  index_type max_out() const;
+};
+class CostNode {
+ public:
+  struct Value {
+    hsps::rational val;
+    bool opt;
+    CostNode* next;
+    bool mark;
+    count_type work;
+    Value() : val(0), opt(false), next(0), mark(false), work(0) { };
+    Value(hsps::rational v, bool o) : val(v), opt(o), next(0), mark(false), work(0) { };
+    Value& operator=(const Value& v)
+    { val = v.val; opt = v.opt; return *this; };
+    Value& operator=(hsps::rational v) { val = v; return *this; };
+    bool operator==(const Value& v) { return (val == v.val); };
+    bool operator<(const Value& v) { return (val < v.val); };
+    bool operator<=(const Value& v) { return (val <= v.val); };
+    bool operator>(const Value& v) { return (val > v.val); };
+    bool operator>=(const Value& v) { return (val >= v.val); };
+    bool operator==(const hsps::rational v) { return (val == v); };
+    bool operator<(const hsps::rational v) { return (val < v); };
+    bool operator<=(const hsps::rational v) { return (val <= v); };
+    bool operator>(const hsps::rational v) { return (val > v); };
+    bool operator>=(const hsps::rational v) { return (val >= v); };
+    void clear() {
+      val = 0;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+    void clear(hsps::rational v_default) {
+      val = v_default;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+  };
+ private:
+  index_type _size;
+  index_type _depth;
+  index_type _first;
+  hsps::rational _default;
+  hsps::rational _max;
+  Value* _store;
+  CostNode* _prev;
+  CostNode(CostNode* p, index_type f);
+  hsps::rational eval(const index_set& s, index_type i);
+  hsps::rational eval(const bool_vec& s, index_type i);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, index_type i, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, index_type i, hsps::rational bound);
+  void find_all(const index_set& s, index_type i, const index_set& c,
+   index_set_vec& a);
+  void set_max(hsps::rational v);
+  void write(std::ostream& s, index_set q) const;
+  void write_pddl(std::ostream& s, Instance& ins, index_set q) const;
+ public:
+  static bool eval_set_mark;
+  CostNode(index_type size);
+  CostNode(index_type size, hsps::rational v_default);
+  ~CostNode();
+  index_type size() const { return _size; };
+  index_type depth() const { return _depth; };
+  index_type first() const { return _first; };
+  index_type last() const { return _size - 1; };
+  Value& val(index_type p);
+  const Value& val(index_type p) const;
+  hsps::rational max() const { return _max; };
+  hsps::rational max_finite() const;
+  CostNode& next(index_type p);
+  Value* val_p(index_type p);
+  CostNode* next_p(index_type p);
+  Value* find(const index_set& s);
+  Value* find(const bool_vec& s);
+  void find_all(const index_set& s, index_set_vec& a);
+  Value& insert(const index_set& s);
+  Value& insert(const bool_vec& s);
+  void store(index_type p, hsps::rational v, bool opt);
+  void store(index_type p, hsps::rational v);
+  hsps::rational eval(const index_set& s);
+  hsps::rational eval(const bool_vec& s);
+  hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  void store(const index_set& s, hsps::rational v, bool opt);
+  void store(const bool_vec& s, hsps::rational v, bool opt);
+  void store(const index_set& s, hsps::rational v);
+  void store(const bool_vec& s, hsps::rational v);
+  hsps::rational eval_min(const index_set& s);
+  void compute_max();
+  void clear_marks();
+  void clear();
+  void write(std::ostream& s) const;
+  void write_pddl(std::ostream& s, Instance& ins) const;
+};
+class CostTable : public Heuristic, public CostNode {
+ public:
+  class Entry {
+  public:
+    index_set set;
+    CostNode::Value& val;
+    Entry* prev;
+    Entry* next;
+    Entry(index_set s, CostNode::Value& v)
+      : set(s), val(v), prev(0), next(0) { };
+    Entry& operator=(const Entry& e);
+    bool operator==(const Entry& e) { return set == e.set; };
+    bool operator<(const Entry& e) { return val < e.val; };
+    bool operator<=(const Entry& e) { return val <= e.val; };
+    bool operator>(const Entry& e) { return val > e.val; };
+    bool operator>=(const Entry& e) { return val >= e.val; };
+    Entry* first();
+    Entry* last();
+    Entry* move_down();
+    Entry* move_up();
+    void unlink();
+    void place_before(Entry* p);
+    void place_after(Entry* p);
+    void delete_list();
+    count_type list_length();
+  };
+ private:
+  Statistics& stats;
+  hsps::rational* pre_cost;
+  hsps::rational* per_cost;
+  bool update(index_type i, hsps::rational v, bool_vec& f);
+  bool update(index_type i, hsps::rational v);
+  bool update(index_type i, index_type j, hsps::rational v);
+  bool update(index_type i, index_type j, index_type l, hsps::rational v);
+  Entry* entries(CostNode* n, index_set s, Entry* l,
+   const index_set* filter, bool ign_zero, bool ign_opt,
+   bool ign_inf, bool req_mark, bool sort);
+  count_type count_entries(CostNode* n, index_set s, bool ign_zero,
+      bool ign_opt, bool ign_inf);
+  void fill(index_set& s, index_type d);
+  Entry* create_new_entries(const index_set& set,
+       const index_set& conflict_set,
+       const index_set& cd_ignore,
+       CostTable::Entry* list);
+  void compute_hm_graph_min
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+  void compute_hm_graph_max
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+ public:
+  static bool strong_conflict_detection;
+  static bool ultra_weak_conflict_detection;
+  static bool boost_new_entries;
+  static count_type n_entries_boosted;
+  static count_type n_entries_solved;
+  static count_type n_entries_discarded;
+  static count_type n_entries_created;
+  static count_type n_boost_searches;
+  static count_type n_boost_searches_with_cd;
+  CostTable(Instance& i, Statistics& s);
+  CostTable(Instance& i, Statistics& s, hsps::rational v_default);
+  ~CostTable();
+  virtual hsps::rational eval(index_type i);
+  virtual hsps::rational eval(index_type i, index_type j);
+  virtual hsps::rational eval(index_type i, index_type j, index_type k);
+  virtual hsps::rational eval(const index_set& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational eval(const bool_vec& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual void store(const index_set& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const index_set& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  virtual void store(const bool_vec& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  void store_list(Entry* l);
+  static Entry* insert_entry(Entry* e, Entry* l);
+  static Entry* prepend_entry(Entry* e, Entry* l);
+  static Entry* remove_entry(Entry* e, Entry* l);
+  static Entry* find_entry(index_set& s, Entry* l);
+  static Entry* copy_list(Entry* l);
+  count_type write_list(std::ostream& s, Entry* l);
+  bool interesting(const index_set& s);
+  Entry* atoms();
+  Entry* pairs();
+  Entry* entries();
+  Entry* entries(bool ign_zero, bool ign_opt, bool ign_inf, bool req_mark);
+  Entry* entries(const index_set& s);
+  Entry* unsorted_entries(bool ign_zero, bool ign_opt, bool ign_inf,
+     bool req_mark);
+  Entry* boostable_entries();
+  Entry* boostable_entries(const index_set& s);
+  Entry* boost_cd_entries();
+  Entry* marked_entries(bool ign_nb);
+  count_type count_entries(bool ign_zero, bool ign_opt, bool ign_inf);
+  hsps::rational action_pre_cost(index_type i);
+  hsps::rational action_per_cost(index_type i);
+  bool compatible(index_type a, index_type b, bool opt_resources) const;
+  void compute_H1(const ACF& cost);
+  void compute_H1(const ACF& cost, const bool_vec& init);
+  void compute_H1max(const ACF& cost, const bool_vec& init);
+  void compute_H2(const ACF& cost);
+  void compute_H2(const ACF& cost, const bool_vec& init);
+  void compute_H3(const ACF& cost);
+  void compute_H2C(const ACF& cost, bool opt_resources);
+  void verify_H2C(const ACF& cost, bool opt_resources, bool opt_verbose);
+  void compute_action_cost();
+  void fill(index_type to_depth);
+  void clear();
+  void closure(const ACF& cost);
+  void closure(const ACF& cost, const index_set& nd);
+  void compute_hm_graph(const ACF& cost, const index_set& s,
+   index_set_graph& g);
+};
+class LinearScanH2Eval : public CostTable {
+  index_type n_pairs;
+  index_pair* pairs;
+  hsps::rational* values;
+  bool complete;
+ public:
+  LinearScanH2Eval(Instance& i, Statistics& s);
+  ~LinearScanH2Eval();
+  void compile_finite();
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH1 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH1(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH1();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH2 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH2(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH2();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+inline void sort2(index_type& i, index_type& j)
+{
+  if (i > j) {
+    index_type t = i;
+    i = j;
+    j = t;
+  }
+}
+inline void sort3(index_type& i, index_type& j, index_type& l)
+{
+  sort2(i, l);
+  sort2(i, j);
+  sort2(j, l);
+}
+inline CostNode::Value& CostNode::val(index_type p)
+{
+  return _store[p];
+}
+inline const CostNode::Value& CostNode::val(index_type p) const
+{
+  return _store[p];
+}
+inline CostNode::Value* CostNode::val_p(index_type p)
+{
+  return &(_store[p]);
+}
+inline CostNode& CostNode::next(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return *(_store[p].next);
+}
+inline CostNode* CostNode::next_p(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return _store[p].next;
+}
+inline CostTable::Entry& CostTable::Entry::operator=(const Entry& e)
+{
+  set = e.set;
+  val = e.val;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode::Value& v)
+{
+  s << std::resetiosflags(std::ios::scientific) << ((v.val).decimal());
+  if (v.opt) s << '*';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode& t)
+{
+  t.write(s);
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostTable::Entry& e)
+{
+  if (e.set.length() > 0) {
+    s << "{" << e.set[0];
+    for (index_type k = 1; k < e.set.length(); k++) s << ',' << e.set[k];
+    s << "}:" << e.val;
+  }
+  else {
+    s << "{}:" << e.val;
+  }
+  return s;
+}
+}
+namespace hsps {
+class Preprocessor {
+ public:
+  Instance& instance;
+  index_vec atom_map;
+  index_vec action_map;
+  index_vec inv_map;
+ protected:
+  Statistics& stats;
+  CostTable* inc_relation;
+  graph* inc_graph;
+  bool make_invariant(index_type init_atom,
+        index_set& inv_set,
+        bool& exact,
+        index_set& branch_set);
+  void analyze_branch_set(const index_set& branch_set,
+     const index_set& inv_set,
+     index_set& effective);
+  void dfs_find_invariants(index_type init_atom,
+      const index_set& base_set,
+      const index_set& branch_set,
+      index_type branch_depth,
+      index_type max_branch_depth);
+  void extend_LsC1_relevance(const index_set& check,
+        const graph& lmg,
+        const bool_vec& p_act,
+        const bool_vec& p_add,
+        bool_vec& rel_atms,
+        bool_vec& rel_acts);
+ public:
+  static int default_trace_level;
+  int trace_level;
+  Preprocessor(Instance& ins, Statistics& s);
+  ~Preprocessor();
+  void compute_reachability(bool_vec& reachable_atoms,
+       bool_vec& reachable_actions,
+       bool opt_H2 = false);
+  void compute_static_atoms(const bool_vec& reachable_actions,
+       bool_vec& static_atoms);
+  void compute_relevance(const index_set& check,
+    bool_vec& r_atm,
+    bool_vec& r_act);
+  void compute_relevance(const index_set& check,
+    index_type d_check,
+    index_vec& d_atm,
+    index_vec& d_act);
+  void between(index_type p,
+        index_type q,
+        const graph& lmg,
+        bool_vec& b_atm,
+        bool_vec& b_act);
+  void compute_L1C1_relevance(const index_set& check,
+         index_type d_check,
+         const graph& lmg,
+         index_vec& d_atm,
+         index_vec& d_act);
+  void compute_L1C1_relevance(const index_set& check,
+         const graph& lmg,
+         bool_vec& rel_atms,
+         bool_vec& rel_acts);
+  void compute_LsC1_relevance(const index_set& check,
+         const graph& lmg,
+         bool_vec& rel_atms,
+         bool_vec& rel_acts);
+  void compute_relaxed_relevance(const index_set& g,
+     index_vec& path,
+     const index_set& pre,
+     bool_vec& rel_acts);
+  void strictly_relevant_actions(index_type p,
+     Heuristic& h,
+     const ACF& f,
+     bool_vec& rel);
+  void strictly_relevant_actions(index_type p,
+     hsps::rational c,
+     Heuristic& h,
+     const ACF& f,
+     bool_vec& rel);
+  void relevant_at_cost(index_type p,
+   hsps::rational c,
+   Heuristic& h,
+   const ACF& f,
+   bool_vec& r_atoms,
+   bool_vec& r_actions);
+  void relevant_at_cost(const index_set& s,
+   hsps::rational c,
+   Heuristic& h,
+   const ACF& f,
+   bool_vec& r_atoms,
+   bool_vec& r_actions);
+  CostTable* inconsistency();
+  graph* inconsistency_graph();
+  bool inconsistent(index_type p, index_type q, Heuristic& inc);
+  bool consistent(index_type p, index_type q, Heuristic& inc);
+  bool inconsistent(const index_set& s, index_type p, Heuristic& inc);
+  bool consistent(const index_set& s, index_type p, Heuristic& inc);
+  bool inconsistent(index_type p, index_type q);
+  bool consistent(index_type p, index_type q);
+  bool inconsistent(const index_set& s);
+  bool consistent(const index_set& s);
+  bool inconsistent(const index_set& s, index_type p);
+  bool consistent(const index_set& s, index_type p);
+  bool inconsistent(const index_set& s0, const index_set& s1);
+  bool consistent(const index_set& s0, const index_set& s1);
+  bool implies(index_type p, index_type q, Heuristic& inc);
+  bool implies(const index_set& s, index_type q, Heuristic& inc);
+  bool implies(index_type p, index_type q);
+  bool implies(const index_set& s, index_type q);
+  void implied_atom_set(const index_set& s, index_set& is, Heuristic& inc);
+  bool landmark_test(const index_set& init,
+       const index_set& goal,
+       index_type p,
+       bool opt_H2 = false);
+  void compute_landmarks(const index_set& init,
+    const index_set& goal,
+    index_set& landmark_atoms);
+  void compute_landmarks(bool exclude_goal,
+    bool exclude_init,
+    bool_vec& landmark_atoms);
+  void compute_landmarks(bool exclude_goal,
+    bool exclude_init,
+    index_set& landmark_atoms);
+  void quick_landmark_graph(graph& g, bool opt_H2 = false);
+  void compute_landmark_graph(graph& g, bool opt_H2 = false);
+  void compute_hierarchy(index_set_graph& g);
+  void compute_hierarchy(graph& g0, index_set_graph& g);
+  void necessary_completions_for_safeness(index_set& atoms_missing_negation);
+  void compute_irrelevant_atoms();
+  void dfs_find_invariants(index_type max_branch_depth);
+  void bfs_find_invariants();
+  void find_inconsistent_set_invariants(graph& inc);
+  void find_maximal_inconsistent_set_invariants(graph& inc);
+  void find_binary_iff_invariants(bool opt_weak_verify);
+  bool verify_invariant(Instance::Constraint& inv, Heuristic& inc);
+  bool verify_invariants(Heuristic& inc);
+  void compute_ncw_sets(Heuristic& inc);
+  void compute_ncw_sets();
+  void preprocess(bool opt_H2 = false);
+  void remove_irrelevant_atoms();
+  void remove_unverified_invariants();
+  void remove_useless_actions();
+  void remove_useless_invariants();
+  void remove_redundant_preconditions();
+  void eliminate_strictly_determined_atoms();
+  void make_safe();
+  void apply_place_replication();
+  void write_heuristic_graph(std::ostream& s,
+        Heuristic& h,
+        const ACF& cost,
+        const bool_vec& atoms,
+        const bool_vec& actions);
+  void write_heuristic_graph(std::ostream& s,
+        Heuristic& h,
+        const ACF& cost);
+  void write_relevance_graph(std::ostream& s,
+        const index_vec& d_atm,
+        const index_vec& d_act,
+        const char* label);
+  void write_relevance_graph(std::ostream& s,
+        const index_vec& d_atm,
+        const index_vec& d_act,
+        const bool_vec& mark_atm,
+        const bool_vec& mark_act,
+        const char* label);
+  bool find_inverse_actions(const Instance::Action& act, Heuristic& inc,
+       index_set& inverses);
+};
+}
+#include <stdio.h>
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+#include <stdio.h>
+#include <stdlib.h>
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class PDDL_Name;
+class PDDL_Base {
+ public:
+  static bool use_default_function_value;
+  static hsps::rational default_function_value;
+  static bool use_strict_borrow_definition;
+  static bool use_extended_borrow_definition;
+  static bool del_before_add_semantics;
+  static bool compact_resource_effects;
+  static bool compile_away_disjunctive_preconditions;
+  static bool check_precondition_consistency;
+  static bool compile_away_conditional_effects;
+  static bool compile_away_plan_constraints;
+  static bool compile_away_object_functions;
+  static bool compile_for_validator;
+  static bool create_all_atoms;
+  static bool create_all_actions;
+  static bool number_multiple_action_instances;
+  static bool exclude_all_dkel_items;
+  static string_set excluded_dkel_tags;
+  static string_set required_dkel_tags;
+  static bool strict_set_export;
+  static bool best_effort;
+  static bool write_PDDL31;
+  static bool write_warnings;
+  static bool write_info;
+  static bool write_trace;
+  static bool trace_print_context;
+  static bool name_instance_by_problem_file;
+  static const char* instance_name_prefix;
+  enum symbol_class {
+    sym_object,
+    sym_typename,
+    sym_predicate,
+    sym_object_function,
+    sym_function,
+    sym_action,
+    sym_variable,
+    sym_misc,
+    sym_preference,
+    sym_set,
+    sym_meta_variable
+  };
+  enum metric_class {
+    metric_none,
+    metric_makespan,
+    metric_minimize,
+    metric_maximize
+  };
+  enum mode_keyword {
+    md_none,
+    md_start,
+    md_end,
+    md_all,
+    md_init,
+    md_pos_goal,
+    md_neg_goal
+  };
+  enum partial_value { p_false, p_true, p_unknown };
+  enum expression_class {
+    exp_fun,
+    exp_list,
+    exp_const,
+    exp_add,
+    exp_sub,
+    exp_mul,
+    exp_div,
+    exp_time,
+    exp_preference
+  };
+  enum relation_type {
+    rel_equal,
+    rel_greater,
+    rel_greater_equal,
+    rel_less,
+    rel_less_equal
+  };
+  enum formula_class { fc_false,
+         fc_true,
+         fc_atom,
+         fc_equality,
+         fc_negation,
+         fc_conjunction,
+         fc_disjunction,
+         fc_equivalence,
+         fc_implication,
+         fc_universal,
+         fc_existential,
+         fc_list
+  };
+  struct Symbol;
+  struct TypeSymbol;
+  struct Atom;
+  struct FTerm;
+  struct FChangeAtom;
+  struct SetOf;
+  struct ListExpression;
+  struct ActionSymbol;
+  struct Reference;
+  struct IrrelevantItem;
+  typedef lvector<TypeSymbol*> type_vec;
+  typedef lvector<Atom*> atom_vec;
+  typedef lvector<FChangeAtom*> ch_atom_vec;
+  typedef lvector<SetOf*> atom_set_vec;
+  typedef lvector<Reference*> ref_vec;
+  typedef lvector<IrrelevantItem*> irrelevant_vec;
+  struct TypeSet : public type_vec {
+    TypeSet() : type_vec(0, 0) { };
+    TypeSet(const TypeSet& s) : type_vec(s) { };
+    TypeSet(TypeSymbol* t) : type_vec(t, 1) { };
+    index_type n_elements() const;
+    Symbol* get_element(index_type n);
+    bool is_object() const;
+    bool subtype_or_equal(const TypeSet& s) const;
+    bool subtype_or_equal(TypeSymbol* t) const;
+    void print(std::ostream& s) const;
+    void write_type(std::ostream& s) const;
+  };
+  struct Symbol {
+    symbol_class sym_class;
+    char* print_name;
+    TypeSet sym_types;
+    bool defined_in_problem;
+    bool visible;
+    Symbol(symbol_class c, char* n)
+      : sym_class(c), print_name(n), defined_in_problem(false), visible(true) { };
+    Symbol(char* n)
+      : sym_class(sym_object), print_name(n), defined_in_problem(false), visible(true) { };
+    void print(std::ostream& s) const;
+  };
+  typedef zero_init_pair<Symbol*> symbol_pair;
+  typedef lvector<Symbol*> symbol_vec;
+  typedef svector<Symbol*> symbol_set;
+  typedef lvector<symbol_pair> symbol_pair_vec;
+  static bool extend_substitution(Symbol* out, Symbol* in, symbol_pair_vec& u);
+  static bool print_substitution(std::ostream& s, const symbol_pair_vec& u);
+  static bool print_inequality(std::ostream& s, const symbol_pair_vec& neq);
+  static bool substitution_violates_inequality(const symbol_pair_vec& neq,
+            const symbol_pair_vec& u);
+  static index_type find_matching_atom(Atom* a, atom_vec& v);
+  static index_type find_matching_atom(Atom* a, mode_keyword m, atom_vec& v);
+  static index_type find_matching_fluent_atom
+    (FChangeAtom* a, mode_keyword m, ch_atom_vec& v);
+  struct TypeSymbol : public Symbol {
+    symbol_vec elements;
+    bool is_base_type;
+    TypeSymbol(char* n) : Symbol(sym_typename, n), elements(0, 0),
+  is_base_type(false) { };
+    void add_element(Symbol* e);
+    bool is_object() const { return (strcmp(print_name, "object") == 0); };
+    bool subtype_or_equal(TypeSymbol* t) const;
+    bool subtype_or_equal(const TypeSet& t) const;
+    void print(std::ostream& s) const;
+  };
+  struct VariableSymbol : public Symbol {
+    Symbol* value;
+    FTerm* binding;
+    VariableSymbol(char* n) : Symbol(sym_variable, n), value(0), binding(0) {};
+    bool equality_type_check(Symbol* s);
+    void print(std::ostream& s);
+  };
+  typedef lvector<VariableSymbol*> variable_vec;
+  struct ParamSymbol : public Symbol {
+    variable_vec param;
+    ParamSymbol(symbol_class c, char* n) : Symbol(c, n), param(0, 0) { };
+  };
+  struct PredicateSymbol : public ParamSymbol {
+    bool pos_pre;
+    bool neg_pre;
+    bool added;
+    bool deleted;
+    bool locked;
+    bool modded;
+    ptr_table init;
+    ptr_table pos_goal;
+    ptr_table neg_goal;
+    ptr_table pos_prop;
+    ptr_table neg_prop;
+    irrelevant_vec irr_ins;
+    PredicateSymbol(char* n) : ParamSymbol(sym_predicate, n),
+  pos_pre(false), neg_pre(false), added(false), deleted(false),
+  locked(false), modded(false), irr_ins(0, 0) { };
+    bool is_static() const { return !modded; };
+    bool is_equality() const { return (strcmp(print_name, "=") == 0); };
+    void instantiate(Instance& ins);
+    void initialise_missing(const symbol_vec& p,
+       atom_vec* created,
+       index_type i = 0);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+  };
+  struct ObjectFunctionSymbol : public ParamSymbol {
+    bool modded;
+    ptr_table init;
+    ObjectFunctionSymbol(char* n)
+      : ParamSymbol(sym_object_function, n), modded(false) { };
+    bool is_static() const { return !modded; };
+    void print(std::ostream& s);
+  };
+  struct FunctionSymbol : public ParamSymbol {
+    bool modified;
+    bool integral;
+    bool linear;
+    bool conditioned;
+    bool increased;
+    bool decreased;
+    bool assigned;
+    bool borrowed;
+    ptr_table init;
+    FunctionSymbol(char* n) : ParamSymbol(sym_function, n),
+  modified(false), integral(true), linear(true), conditioned(false),
+  increased(false), decreased(false), assigned(false), borrowed(false)
+    { };
+    bool is_static() const
+    { return !modified; };
+    bool is_reusable() const
+    { return borrowed && !increased && !decreased && !assigned; };
+    bool is_consumable() const
+    { return !borrowed && !increased && decreased && !assigned; };
+    interval eval_init_bounds(ptr_table* p, index_type i, ListExpression* r);
+    void print(std::ostream& s);
+  };
+  struct AtomBase {
+    symbol_vec param;
+    mode_keyword at;
+    hsps::rational at_time;
+    AtomBase() : param(0, 0), at(md_none), at_time(0) { };
+    AtomBase(mode_keyword t) : param(0, 0), at(t), at_time(0) { };
+    AtomBase(AtomBase* b);
+    bool equals(AtomBase& b);
+    void free_variables(variable_vec& v);
+    bool occurs(Symbol* s);
+    void fill_in_args(AtomBase* b);
+    void collect_bound_variables(variable_vec& v);
+    void insert(ptr_table& t);
+    static bool print_bindings;
+    void print(std::ostream& s) const;
+    void print_instance(std::ostream& s);
+  };
+  typedef lvector<AtomBase*> atom_base_vec;
+  struct Atom : AtomBase {
+    PredicateSymbol* pred;
+    Atom(PredicateSymbol* p) : pred(p) { };
+    Atom(PredicateSymbol* p, mode_keyword t) : AtomBase(t), pred(p) { };
+    Atom(PredicateSymbol* p, variable_vec& a, bool as_value)
+      : pred(p)
+    {
+      param.set_length(a.length());
+      for (index_type k = 0; k < a.length(); k++)
+ param[k] = (as_value ? a[k]->value : a[k]);
+    };
+    Atom(PredicateSymbol* p, Symbol* a0)
+      : pred(p)
+    {
+      param.append(a0);
+    };
+    Atom(Atom* a) : AtomBase(a), pred(a->pred) { };
+    bool equals(Atom& a);
+    bool is_static() const {
+      return ((at == md_init) ||
+       (at == md_pos_goal) ||
+       (at == md_neg_goal) ||
+       pred->is_static());
+    };
+    bool check();
+    Instance::Atom* find_prop(Instance& ins, bool neg, bool create);
+    void build(Instance& ins, bool neg, index_type p);
+    Atom* instantiate_partially();
+    partial_value partial_eval(ptr_table* r, index_type p);
+    partial_value partial_eval();
+    bool initial_value();
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    void print(std::ostream& s, bool neg) const;
+    void print(std::ostream& s) const { print(s, false); };
+  };
+  struct CAtom : public Atom {
+    symbol_pair_vec neq;
+    CAtom(Atom* a) : Atom(a), neq(symbol_pair(0, 0), 0) { };
+    CAtom(CAtom* s) : Atom(s), neq(s->neq) { };
+    CAtom(const Atom* a, symbol_pair_vec& u);
+    CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool instance_of(CAtom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(CAtom* a, symbol_pair_vec& u);
+    void print(std::ostream& s);
+  };
+  typedef lvector<CAtom*> catom_vec;
+  struct FTerm : AtomBase {
+    ObjectFunctionSymbol* fun;
+    FTerm(ObjectFunctionSymbol* f) : fun(f) { };
+    bool equals(FTerm& a);
+    void print(std::ostream& s) const;
+  };
+  struct OInitAtom : AtomBase {
+    ObjectFunctionSymbol* fun;
+    Symbol* val;
+    OInitAtom(ObjectFunctionSymbol* f) : fun(f), val(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<OInitAtom*> obj_init_atom_vec;
+  struct FInitAtom : AtomBase {
+    FunctionSymbol* fun;
+    hsps::rational val;
+    Instance::resource_ref res;
+    FInitAtom(FunctionSymbol* f) : fun(f), val(0) { };
+    FInitAtom(FChangeAtom* a);
+    bool is_static() const { return fun->is_static(); };
+    void print(std::ostream& s);
+  };
+  typedef lvector<FInitAtom*> fun_init_atom_vec;
+  struct Expression;
+  typedef lvector<Expression*> exp_vec;
+  struct Expression {
+    expression_class exp_class;
+    Expression(expression_class c) : exp_class(c) { };
+    static bool print_nary;
+    bool is_static();
+    bool is_constant();
+    bool is_integral();
+    hsps::rational eval_static();
+    bool eval_partial(hsps::rational& val);
+    interval eval_bounds();
+    hsps::rational eval_init();
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    hsps::rational eval_delta(Symbol* preference, hsps::rational p_value, hsps::rational d_value);
+    Expression* copy();
+    Expression* simplify();
+    void collect_constants(exp_vec& c);
+    void mark_functions_in_condition();
+    hsps::rational integrify();
+    void substitute_for_time(Expression* e);
+    Expression* substitute_for_preference(Symbol* n, Expression* e);
+    bool equals(Expression* e);
+    void print_sum(std::ostream& s, bool grnd);
+    void print_product(std::ostream& s, bool grnd);
+    void print(std::ostream& s, bool grnd);
+  };
+  struct ListExpression : public Expression {
+    Symbol* sym;
+    ListExpression* rest;
+    ListExpression(Symbol* s, ListExpression* r) :
+      Expression(exp_list), sym(s), rest(r) { };
+    bool match(AtomBase* atom);
+  };
+  struct FunctionExpression : public Expression {
+    FunctionSymbol* fun;
+    ListExpression* args;
+    FunctionExpression(FunctionSymbol* f, ListExpression* a) :
+      Expression(exp_fun), fun(f), args(a) { };
+    bool match(FChangeAtom* atom);
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    FChangeAtom* make_atom_base();
+  };
+  struct ConstantExpression : public Expression {
+    hsps::rational val;
+    ConstantExpression(hsps::rational v) :
+      Expression(exp_const), val(v) { };
+  };
+  struct TimeExpression : public Expression {
+    Expression* time_exp;
+    TimeExpression() :
+      Expression(exp_time), time_exp(0) { };
+    TimeExpression(Expression* e) :
+      Expression(exp_time), time_exp(e) { };
+  };
+  struct BinaryExpression : public Expression {
+    Expression* first;
+    Expression* second;
+    BinaryExpression(expression_class c, Expression* e1, Expression* e2) :
+      Expression(c), first(e1), second(e2) { };
+  };
+  struct PreferenceExpression : public Expression {
+    Symbol* name;
+    PreferenceExpression(Symbol* n) :
+      Expression(exp_preference), name(n) { };
+  };
+  struct Relation {
+    relation_type rel;
+    mode_keyword at;
+    Expression* first;
+    Expression* second;
+    Relation(relation_type r, Expression* e1, Expression* e2) :
+      rel(r), at(md_none), first(e1), second(e2) { };
+    Relation(relation_type r, mode_keyword m, Expression* e1, Expression* e2) :
+      rel(r), at(m), first(e1), second(e2) { };
+    Expression* match_gteq_constant(FChangeAtom* atom);
+    FunctionExpression* match_lteq_fun(FChangeAtom* atom);
+    bool is_static();
+    partial_value partial_eval();
+    void print(std::ostream& s, bool grnd);
+  };
+  typedef lvector<Relation*> relation_vec;
+  struct FChangeAtom : AtomBase {
+    FunctionSymbol* fun;
+    Expression* val;
+    FChangeAtom(FunctionSymbol* f) :
+      fun(f), val(0) { };
+    FChangeAtom(FunctionSymbol* f, mode_keyword t) :
+      AtomBase(t), fun(f), val(0) { };
+    FChangeAtom(FChangeAtom* a, hsps::rational v) :
+      AtomBase(a), fun(a->fun), val(new ConstantExpression(v)) { };
+    bool equals(FChangeAtom& a);
+    bool fluent_equals(FChangeAtom& a);
+    bool fluent_and_mode_equals(FChangeAtom& a);
+    FChangeAtom* find_fluent_equals(ch_atom_vec& vec);
+    Instance::Resource* find_resource(Instance& ins);
+    void print(std::ostream& s);
+  };
+  struct Formula {
+    formula_class fc;
+    Formula(formula_class c) : fc(c) { };
+    void rename_variables_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_variables_2(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_2(PDDL_Base::symbol_pair_vec& sub);
+    Formula* simplify();
+    void write_otter(std::ostream& s) const;
+    void print(std::ostream& s) const;
+    void untype(PDDL_Base* base);
+  };
+  typedef lvector<Formula*> formula_vec;
+  struct AFormula : public Formula, public Atom {
+    AFormula(Atom* a) :
+      Formula(fc_atom), Atom(a) { };
+    AFormula(PredicateSymbol* p) :
+      Formula(fc_atom), Atom(p) { };
+    AFormula(PredicateSymbol* p, variable_vec& a) :
+      Formula(fc_atom), Atom(p, a, false) { };
+    void print(std::ostream& s) const;
+    void write_otter(std::ostream& s) const;
+  };
+  struct EqFormula : public Formula {
+    Symbol* t1;
+    Symbol* t2;
+    EqFormula(Symbol* s1, Symbol* s2) :
+      Formula(fc_equality), t1(s1), t2(s2) { };
+    void write_otter(std::ostream& s) const;
+  };
+  struct NFormula : public Formula {
+    Formula* f;
+    NFormula(Formula* g) : Formula(fc_negation), f(g) { };
+  };
+  struct BFormula : public Formula {
+    Formula* f1;
+    Formula* f2;
+    BFormula(formula_class c, Formula* g1, Formula* g2) :
+      Formula(c), f1(g1), f2(g2) { };
+  };
+  struct CFormula : public Formula {
+    formula_vec parts;
+    CFormula(formula_class c) : Formula(c), parts(0, 0) { };
+    CFormula(formula_class c, Formula* f1, Formula* f2) :
+      Formula(c), parts(0, 0)
+    {
+      parts.append(f1);
+      parts.append(f2);
+    };
+    void add(Formula* f) { parts.append(f); };
+    void add(formula_vec& f) { parts.append(f); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct QFormula : public Formula {
+    variable_vec vars;
+    Formula* f;
+    QFormula(formula_class c) : Formula(c), vars(0, 0), f(0) { };
+    QFormula(formula_class c, Formula* g) : Formula(c), vars(0, 0), f(g) { };
+    QFormula(formula_class c, variable_vec& v, Formula* g) :
+      Formula(c), vars(0, 0), f(g)
+    {
+      for (index_type k = 0; k < v.length(); k++) vars.append(v[k]);
+    };
+    void add(PDDL_Base::VariableSymbol* v) { vars.append(v); };
+    void add(PDDL_Base::variable_vec& v) { vars.append(v); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct TypeConstraint {
+    VariableSymbol* var;
+    TypeSymbol* typ;
+    TypeConstraint(VariableSymbol* v, TypeSymbol* t) : var(v), typ(t) { };
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+  };
+  typedef lvector<TypeConstraint*> type_constraint_vec;
+  struct Context {
+    variable_vec param;
+    atom_vec pos_con;
+    atom_vec neg_con;
+    type_constraint_vec type_con;
+    Context() : param(0, 0), pos_con(0, 0), neg_con(0, 0), type_con(0, 0) { };
+    Context(const Context* c) : param(c->param), pos_con(c->pos_con),
+  neg_con(c->neg_con), type_con(c->type_con) { };
+    bool context_is_static() const;
+    bool occurs_in_context(Symbol* s);
+    void clear_arguments();
+    void set_mode(mode_keyword m);
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+    void print_assignment(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct DKEL_Item : public Context {
+    char* item_name;
+    Symbol* name;
+    string_set item_tags;
+    bool defined_in_problem;
+    bool included;
+    DKEL_Item(char* name) : item_name(name), name(0),
+  defined_in_problem(false), included(true) { };
+    DKEL_Item(const DKEL_Item* i) : Context(i), item_name(i->item_name),
+  name(i->name), item_tags(i->item_tags),
+  defined_in_problem(i->defined_in_problem), included(i->included) { };
+    bool item_is_included(string_set& ex_tags, string_set& req_tags);
+    void print_begin(std::ostream& s);
+    void print_end(std::ostream& s);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SetOf : public Context {
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    SetOf() : pos_atoms(0, 0), neg_atoms(0, 0) { };
+    SetOf(const SetOf* s)
+      : Context(s), pos_atoms(s->pos_atoms), neg_atoms(s->neg_atoms)
+    { };
+    SetOf(Atom* a)
+    { pos_atoms.append(a); };
+    SetOf(Atom* a, bool n)
+    { if (n) neg_atoms.append(a); else pos_atoms.append(a); };
+    bool is_static() const;
+    void set_mode(mode_keyword m);
+    partial_value partial_eval(bool as_disjunction = false);
+    partial_value partial_eval(index_type p, bool as_disjunction = false);
+    void instantiate_as_set(Instance& ins, index_set& s);
+    void instantiate_as_effect(Instance& ins, index_set& s_add,
+          index_set& s_del);
+    void instantiate_conditional(Instance& ins, rule_set& s_pos,
+     rule_set& s_neg);
+    SetOf* instantiate_partially();
+    void compile(atom_vec& pos_ins, atom_vec& neg_ins, index_type p);
+    void compile_non_static(atom_set_vec& ins, index_type p);
+    void print(std::ostream& s);
+    void print_as_disjunction(std::ostream& s);
+    void build_set(Instance& ins, index_set& s, index_type p);
+    void build_effect(Instance& ins, index_set& s_add, index_set& s_del,
+        index_type p);
+    void build_conditional(Instance& ins, rule_set& s_pos, rule_set& s_neg,
+      index_type p);
+  };
+  struct QCNumericEffect : public Context {
+    FChangeAtom* atom;
+    QCNumericEffect() : atom(0) { };
+    QCNumericEffect(FChangeAtom* a) : atom(a) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<QCNumericEffect*> qc_numeric_effect_vec;
+  enum set_constraint_keyword { sc_at_least, sc_at_most, sc_exactly };
+  struct SetConstraint : public DKEL_Item {
+    set_constraint_keyword sc_type;
+    index_type sc_count;
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    atom_set_vec atom_sets;
+    SetConstraint() : DKEL_Item(":invariant"), sc_type(sc_at_least),
+  sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0), atom_sets(0, 0) { };
+    SetConstraint(const DKEL_Item* item) : DKEL_Item(item),
+  sc_type(sc_at_least), sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0),
+  atom_sets(0, 0) { };
+    void build(Instance& ins, index_type p);
+    void instantiate(Instance& ins);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InvariantFormula : public DKEL_Item {
+    Formula* f;
+    InvariantFormula(Formula* g)
+      : DKEL_Item(":invariant"), f(g) { };
+    InvariantFormula(const DKEL_Item* item, Formula* g)
+      : DKEL_Item(item), f(g) { };
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct Reference : public AtomBase {
+    Symbol* name;
+    bool neg;
+    bool has_args;
+    index_set index;
+    Reference(Symbol* n) : name(n), neg(false), has_args(true) { };
+    Reference(Symbol* n, bool ng, bool ha)
+      : name(n), neg(ng), has_args(ha) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    void* find_action();
+    void find(const name_vec& names, index_set& ind);
+    Reference* instantiate_partially();
+    void print(std::ostream& s);
+  };
+  struct IrrelevantItem : public DKEL_Item {
+    Reference* entity;
+    IrrelevantItem() : DKEL_Item(":irrelevant"), entity(0) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    IrrelevantItem* instantiate_partially();
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SequentialTaskNet : public Context {
+    ref_vec tasks;
+    ActionSymbol* abs_act;
+    SequentialTaskNet() : tasks(0, 0), abs_act(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<SequentialTaskNet*> task_net_vec;
+  struct SetSymbol : public Symbol {
+    ptr_table set_table;
+    lvector<index_set*> sets;
+    name_vec names;
+    SetSymbol(char* n) : Symbol(sym_set, n), sets(0, 0), names(0, 0) { };
+  };
+  struct SetName : public AtomBase {
+    SetSymbol* sym;
+    SetName(SetSymbol* s) : sym(s) { };
+    index_set* find();
+    SetName* instantiate_partially();
+    void print(std::ostream& s);
+    void print_instance(std::ostream& s);
+  };
+  struct ActionSymbol : public ParamSymbol {
+    atom_vec pos_pre;
+    atom_vec neg_pre;
+    atom_set_vec set_pre;
+    atom_set_vec dis_pre;
+    relation_vec num_pre;
+    atom_vec adds;
+    atom_vec dels;
+    atom_set_vec set_eff;
+    atom_vec cons;
+    atom_set_vec cond_eff;
+    atom_vec locks;
+    atom_vec enables;
+    ch_atom_vec reqs;
+    ch_atom_vec incs;
+    ch_atom_vec decs;
+    ch_atom_vec fass;
+    qc_numeric_effect_vec qc_incs;
+    qc_numeric_effect_vec qc_decs;
+    qc_numeric_effect_vec qc_fass;
+    Expression* dmin;
+    Expression* dmax;
+    irrelevant_vec irr_ins;
+    ref_vec refs;
+    task_net_vec exps;
+    ptr_table instances;
+    SetName* part;
+    const char* assoc;
+    ActionSymbol(char* n) : ParamSymbol(sym_action, n), pos_pre(0, 0),
+  neg_pre(0, 0), set_pre(0, 0), dis_pre(0, 0), num_pre(0, 0),
+  adds(0, 0), dels(0, 0), set_eff(0, 0), cons(0, 0), cond_eff(0, 0),
+  locks(0, 0), enables(0, 0), reqs(0, 0), incs(0, 0), decs(0, 0),
+  fass(0, 0), qc_incs(0, 0), qc_decs(0, 0), qc_fass(0, 0), dmin(0),
+  dmax(0), irr_ins(0, 0), refs(0, 0), exps(0, 0), part(0), assoc(0) { };
+    void build(Instance& ins, index_type p, Expression* cost_exp);
+    Instance::Action& build_action(Instance& ins,
+       PDDL_Name* name,
+       index_type& count,
+       const index_set& pre,
+       const index_set& add,
+       const index_set& del,
+       const index_set& lck,
+       const index_cost_vec& r_use,
+       const index_cost_vec& r_cons,
+       hsps::rational dmin,
+       hsps::rational dmax,
+       hsps::rational dur,
+       hsps::rational cost);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          index_vec& s,
+          index_type p);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc);
+    void build_actions_with_dc_and_ce(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          const rule_set& pce,
+          const rule_set& nce,
+          const bool_vec& ece);
+    index_type param_index(VariableSymbol* p);
+    void get_param_inequalities(symbol_pair_vec& neq);
+    void set_arguments(const symbol_vec& args);
+    void set_arguments(const ptr_table::key_vec& args);
+    void clear_arguments();
+    void* find_instance();
+    bool is_abstract();
+    void post_process();
+    void instantiate(Instance& ins, Expression* cost_exp);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InputPlanStep {
+    Reference* act;
+    hsps::rational start_time;
+    InputPlanStep() : act(0), start_time(0) { };
+    InputPlanStep(Reference* a, hsps::rational t) : act(a), start_time(t) { };
+  };
+  struct InputPlan {
+    Symbol* name;
+    bool is_opt;
+    lvector<InputPlanStep*> steps;
+    InputPlan() : name(0), is_opt(false), steps(0, 0) { };
+    bool export_to_instance(Instance& ins, const index_vec& map, Plan& p);
+    void print(std::ostream& s);
+  };
+  struct HTableEntry {
+    atom_vec atoms;
+    bool_vec neg;
+    hsps::rational cost;
+    bool opt;
+    HTableEntry() : atoms(0, 0), neg(false, 0), cost(0), opt(false) { };
+  };
+  struct SimpleReferenceSet : public Context {
+    Reference* ref;
+    SimpleReferenceSet(Reference* r) : ref(r) { };
+    bool build(const name_vec& names, index_set& set, index_type p);
+    void print(std::ostream& s);
+  };
+  typedef lvector<SimpleReferenceSet*> refs_vec;
+  struct ReferenceSet : public Context {
+    refs_vec refs;
+    Symbol* name;
+    ReferenceSet() : refs(0, 0), name(0) { };
+    void add(SimpleReferenceSet* ref) { refs.append(ref); };
+    void build(const name_vec& names, index_set_vec& sets, index_type p);
+    void print(std::ostream& s);
+  };
+  struct CPG {
+    atom_vec atoms;
+    index_vec atom_first_arg;
+    bool_vec neg;
+    symbol_vec args;
+    type_vec arg_types;
+    CPG() : atoms(0, 0), neg(false, 0), args(0, 0), arg_types(0, 0) { };
+    CPG(CPG& g, index_vec& s);
+    void make_key(ptr_table::key_vec& key);
+    void make_typed_key(ptr_table::key_vec& key);
+    void make_parameters(variable_vec& params);
+    ListExpression* make_argument_list(index_type first);
+    void add_asserting_effects(ActionSymbol* act,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          bool strict);
+    void add_destroying_effects(ActionSymbol* act,
+    ParamSymbol* pf,
+    PredicateSymbol* p,
+    bool p_val,
+    PredicateSymbol* g,
+    FunctionSymbol* f,
+    Expression* f_val,
+    bool strict);
+    bool initial_value();
+    void add_asserting_effects(index_type c_atom,
+          ActionSymbol* act,
+          index_type c_eff,
+          bool_vec& sat,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          symbol_pair_vec& eq,
+          symbol_pair_vec& neq,
+          bool strict);
+    void add_propositional_effect(ActionSymbol* act,
+      PredicateSymbol* p, bool p_val,
+      index_type c_atom, Atom* a_eff,
+      bool strict);
+    void add_fluent_effect(ActionSymbol* act,
+      FunctionSymbol* f, Expression* f_val,
+      index_type c_atom, Atom* a_eff);
+    void add_effect_conditions(Context* e, ParamSymbol* pf, bool_vec& sat,
+          symbol_vec& subs, symbol_pair_vec& eq,
+          symbol_pair_vec& neq);
+  };
+  enum goal_class { goal_pos_atom, goal_neg_atom, goal_relation, goal_task,
+      goal_conjunction, goal_disjunction, goal_forall,
+      goal_exists, goal_always, goal_sometime,
+      goal_at_most_once, goal_within, goal_always_within,
+      goal_sometime_before, goal_sometime_after };
+  struct Goal {
+    goal_class g_class;
+    Goal(goal_class c) : g_class(c) { };
+    bool is_state();
+    bool is_propositional();
+    bool is_singular();
+    bool makeCPG(CPG& g);
+    bool makeCPG(CPG& g, index_vec& s);
+    void instantiate(Instance& ins, hsps::rational deadline);
+    void instantiate(Instance& ins, index_set& set, Symbol* p, index_type i);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Goal*> goal_vec;
+  struct AtomicGoal : public Goal {
+    Atom* atom;
+    AtomicGoal(Atom* a, bool neg)
+      : Goal(neg ? goal_neg_atom : goal_pos_atom), atom(a) { };
+    void print(std::ostream& s);
+  };
+  struct NumericGoal : public Goal {
+    Relation* rel;
+    NumericGoal(Relation* r) : Goal(goal_relation), rel(r) { };
+    void print(std::ostream& s);
+  };
+  struct TaskGoal : public Goal {
+    Reference* task;
+    TaskGoal(Reference* r) : Goal(goal_task), task(r) { };
+    void print(std::ostream& s);
+  };
+  struct ConjunctiveGoal : public Goal {
+    goal_vec goals;
+    ConjunctiveGoal() : Goal(goal_conjunction), goals(0, 0) { };
+    ConjunctiveGoal(goal_class gc) : Goal(gc), goals(0, 0) { };
+    void print(std::ostream& s);
+  };
+  struct DisjunctiveGoal : public ConjunctiveGoal {
+    DisjunctiveGoal() : ConjunctiveGoal(goal_disjunction) { };
+    void print(std::ostream& s);
+  };
+  struct QuantifiedGoal : public Goal, public Context {
+    Goal* goal;
+    QuantifiedGoal() : Goal(goal_forall), goal(0) { };
+    QuantifiedGoal(goal_class gc) : Goal(gc), goal(0) { };
+    void print(std::ostream& s);
+  };
+  struct SimpleSequenceGoal : public Goal {
+    Goal* constraint;
+    SimpleSequenceGoal(goal_class c, Goal* g) : Goal(c), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredSequenceGoal : public Goal {
+    Goal* trigger;
+    Goal* constraint;
+    TriggeredSequenceGoal(goal_class c, Goal* t, Goal* g)
+      : Goal(c), trigger(t), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct DeadlineGoal : public Goal {
+    Goal* goal;
+    hsps::rational at;
+    DeadlineGoal(hsps::rational t, Goal* g) : Goal(goal_within), goal(g), at(t) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredDeadlineGoal : public Goal {
+    Goal* trigger;
+    Goal* goal;
+    hsps::rational delay;
+    TriggeredDeadlineGoal(Goal* t, hsps::rational d, Goal* g)
+      : Goal(goal_always_within), trigger(t), delay(d), goal(g) { };
+    void print(std::ostream& s);
+  };
+  struct Preference {
+    Symbol* name;
+    Goal* goal;
+    Preference() : name(0), goal(0) { };
+    Preference(Symbol* n) : name(n), goal(0) { };
+    Preference(Symbol* n, Goal* g) : name(n), goal(g) { };
+    bool is_state() { return goal->is_state(); };
+    bool is_propositional() { return goal->is_propositional(); };
+    hsps::rational value(metric_class metric_type, Expression* m);
+    void instantiate(SoftInstance& ins,
+       metric_class metric_type,
+       Expression* m);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Preference*> preference_vec;
+  char* domain_name;
+  char* problem_name;
+  char* domain_file;
+  char* problem_file;
+  bool ready_to_instantiate;
+  char* problem_file_basename();
+  char* enum_problem_filename(const char* s, index_type i);
+  StringTable& tab;
+  type_vec dom_types;
+  type_vec dom_base_types;
+  TypeSymbol* dom_top_type;
+  symbol_vec dom_constants;
+  PredicateSymbol* dom_eq_pred;
+  PredicateSymbol* dom_assign_pred;
+  Symbol* dom_undefined_obj;
+  static PredicateSymbol* current_eq_predicate;
+  lvector<PredicateSymbol*> dom_predicates;
+  lvector<ObjectFunctionSymbol*> dom_object_functions;
+  lvector<FunctionSymbol*> dom_functions;
+  lvector<ActionSymbol*> dom_actions;
+  lvector<SetConstraint*> dom_sc_invariants;
+  lvector<InvariantFormula*> dom_f_invariants;
+  lvector<IrrelevantItem*> dom_irrelevant;
+  atom_vec dom_init;
+  obj_init_atom_vec dom_obj_init;
+  fun_init_atom_vec dom_fun_init;
+  goal_vec dom_goals;
+  preference_vec dom_preferences;
+  ref_vec goal_tasks;
+  metric_class metric_type;
+  Expression* metric;
+  hsps::rational serial_length;
+  hsps::rational parallel_length;
+  lvector<InputPlan*> input_plans;
+  lvector<HTableEntry*> h_table;
+  lvector<ReferenceSet*> input_sets;
+  lvector<SetSymbol*> partitions;
+  static ActionSymbol* src_action_symbol(ptr_pair* p);
+  TypeSymbol* find_type(const char* name);
+  PredicateSymbol* find_predicate(const char* name);
+  FunctionSymbol* find_function(const char* name);
+  bool find_initial_fact(const char* pname, const symbol_vec& arg);
+  hsps::rational find_function_value(const char* fname, const symbol_vec& arg);
+  index_type find_element_satisfying(const symbol_vec& elements,
+         const char* pname,
+         symbol_vec& arg,
+         index_type element_arg_p);
+  void find_elements_satisfying(const symbol_vec& elements,
+    const char* pname,
+    symbol_vec& arg,
+    index_type element_arg_p,
+    index_set& sats);
+  Atom* goal_to_atom(Goal* g);
+  bool goal_to_atom_vec(Goal* g, atom_vec& av);
+  PDDL_Base(StringTable& t);
+  ~PDDL_Base();
+  void set_variable_type(variable_vec& vec, TypeSymbol* t);
+  void set_variable_type(variable_vec& vec, const TypeSet& t);
+  void set_type_type(type_vec& vec, TypeSymbol* t);
+  void set_constant_type(symbol_vec& vec, TypeSymbol* t);
+  void clear_context(variable_vec& vec);
+  void clear_context(variable_vec& vec, index_type n_min, index_type n_max);
+  bool merge_type_vectors(type_vec& v0, type_vec& v1);
+  void make_parameters(type_vec& t, const char* prefix, variable_vec& v);
+  Atom* make_atom_from_prop(ptr_pair& src, bool& neg);
+  Symbol* gensym(symbol_class c, const char* p, const TypeSet& t);
+  Symbol* gensym(symbol_class c, const char* p, TypeSymbol* t);
+  Symbol* gensym_i(symbol_class c, const char* p, index_type i, TypeSymbol* t);
+  Symbol* gensym_s(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t);
+  Symbol* gensym_n(symbol_class c, const char* p, const Name* n, TypeSymbol* t);
+  void new_variable_substitution(Atom* a,
+     symbol_pair_vec& u,
+     symbol_pair_vec& new_u);
+  Atom* new_meta_atom(PredicateSymbol* p);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& u);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+  void extend_cc(CAtom* l, catom_vec& m, catom_vec& nm,
+   lvector< swapable_pair<catom_vec> >& x,
+   index_type d);
+  void find_cc();
+  void post_process();
+  void instantiate(Instance& ins);
+  void instantiate_soft(SoftInstance& ins);
+  void instantiate_atom_set(Instance& ins, atom_vec& a, index_set& s);
+  index_type n_plans() const { return input_plans.length(); };
+  bool export_plan(index_type i, Instance& ins, const index_vec& map, Plan& p);
+  bool export_plan(index_type i, Instance& ins, Plan& p);
+  void export_heuristic(Instance& ins,
+   const index_vec& map,
+   bool opt_maximize,
+   Heuristic& h);
+  void export_sets(const name_vec& names, index_set_vec& sets);
+  void export_action_partitions(name_vec& names, index_set_vec& sets);
+  void lift_DKEL_Items(const Instance& ins);
+  PredicateSymbol* find_type_predicate(Symbol* type_sym);
+  void untype();
+  void compile_preferences();
+  void compile_constraints_1();
+  void compile_constraints_2();
+  void select_preferences(const bool_vec& sel);
+  void metric_to_goal(hsps::rational bound);
+  void compile_set_conditions_and_effects();
+  void compile_object_functions();
+  Expression* replace_violations_1(Expression* exp,
+       CPG* cpg[],
+       FunctionSymbol* f_violated[]);
+  Goal* compile_constraint_1(Goal* g, index_type i, const Symbol* n,
+        symbol_vec& aut_states, index_type n_ra);
+  AtomicGoal* make_automaton_type_a(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_e(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_o(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sb(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sa(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  void make_automaton_transition(Symbol* s_from,
+     Symbol* s_to,
+     bool is_accept,
+     CPG* f, bool neg_f,
+     CPG* g, bool neg_g,
+     PredicateSymbol* p_state,
+     PredicateSymbol* p_accept,
+     PredicateSymbol* p_synch);
+  void add_precondition_formula(ActionSymbol* a, CPG* f, bool is_neg);
+  Goal* compile_constraint_2(Goal* g, const Symbol* n);
+  Goal* compile_always_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_sometime_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_at_most_once_constraint(SimpleSequenceGoal* g,
+     const Symbol* n);
+  Goal* compile_sometime_before_constraint(TriggeredSequenceGoal* g,
+        const Symbol* n);
+  void compile_set_conditions_and_effects(ActionSymbol* act);
+  void compile_set_conditions_and_effects(ActionSymbol* act,
+       variable_vec& i_param,
+       variable_vec& d_param,
+       index_type p);
+  Atom* make_binding_atom(VariableSymbol* v);
+  void compile_object_functions(ActionSymbol* act, Symbol* undefined_value);
+  void compile_object_functions_for_validator(ActionSymbol* act);
+  Goal* compile_object_functions(Goal* g);
+  void write_declarations(std::ostream& s);
+  void write_action(std::ostream& s, ActionSymbol* act);
+  void write_set_precondition(std::ostream& s, SetOf* set);
+  void write_disjunctive_set_precondition(std::ostream& s, SetOf* set);
+  void write_set_effect(std::ostream& s, SetOf* set);
+  void write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn);
+  void write_objects(std::ostream& s, bool defined_in_problem);
+  void write_init(std::ostream& s);
+  void write_goal(std::ostream& s);
+  void write_metric(std::ostream& s);
+  void write_dkel_items(std::ostream& s, bool defined_in_problem);
+  void write_domain_begin(std::ostream& s);
+  void write_problem_begin(std::ostream& s);
+  void write_end(std::ostream& s);
+  void write_dkel_domain(std::ostream& s, bool leave_open);
+  void write_dkel_problem(std::ostream& s, bool leave_open);
+  void write_plans(std::ostream& s);
+  void write_heuristic_table(std::ostream& s);
+  void write_sets(std::ostream& s);
+  void print(std::ostream& s);
+};
+class InstanceName : public Name {
+  char* domain_name;
+  char* problem_name;
+ public:
+  InstanceName(char* d, char* p) : domain_name(d), problem_name(p) { };
+  virtual ~InstanceName() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class PDDL_Name : public Name {
+ protected:
+  bool neg;
+  PDDL_Base::Symbol* sym;
+  PDDL_Base::symbol_vec arg;
+  bool vis;
+  bool_vec avis;
+ public:
+  static char catc;
+  static bool obscure_symbol_names;
+  PDDL_Name(PDDL_Base::Symbol* s)
+    : neg(false), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, bool n)
+    : neg(n), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::symbol_vec a, bool n)
+    : neg(n), sym(s), arg(a), vis(true), avis(true, a.length()) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n);
+  void add(PDDL_Base::Symbol* s);
+  void add(PDDL_Base::Symbol* s, bool v);
+  PDDL_Base::Symbol* symbol() { return sym; };
+  PDDL_Base::symbol_vec& args() { return arg; };
+  index_type argc() { return arg.length(); };
+  bool is_neg() { return neg; };
+  virtual ~PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class Numbered_PDDL_Name : public PDDL_Name {
+  index_type copy;
+ public:
+  Numbered_PDDL_Name(PDDL_Base::Symbol* sym, index_type c)
+    : PDDL_Name(sym), copy(c) { };
+  Numbered_PDDL_Name(PDDL_Name* n, index_type c);
+  virtual ~Numbered_PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+};
+}
+#include <sstream>
+typedef union {
+  hsps::StringTable::Cell* sym;
+  hsps::PDDL_Base::Expression* exp;
+  hsps::PDDL_Base::ListExpression* lst;
+  hsps::PDDL_Base::Relation* rel;
+  hsps::PDDL_Base::Goal* goal;
+  hsps::PDDL_Base::Formula* ff;
+  hsps::PDDL_Base::mode_keyword tkw;
+  hsps::PDDL_Base::relation_type rkw;
+  hsps::PDDL_Base::set_constraint_keyword sckw;
+  hsps::rational::XR rval;
+  int ival;
+  char* sval;
+} yy_PDDL_Parser_stype;
+class PDDL_Parser : public hsps::PDDL_Base
+{
+public:
+enum YY_PDDL_Parser_ENUM_TOKEN { YY_PDDL_Parser_NULL_TOKEN=0
+ ,TK_OPEN=258
+ ,TK_CLOSE=259
+ ,TK_OPEN_SQ=260
+ ,TK_CLOSE_SQ=261
+ ,TK_GREATER=262
+ ,TK_GREATEQ=263
+ ,TK_LESS=264
+ ,TK_LESSEQ=265
+ ,TK_COLON=266
+ ,TK_HASHT=267
+ ,TK_EQ=268
+ ,TK_HYPHEN=269
+ ,TK_PLUS=270
+ ,TK_MUL=271
+ ,TK_DIV=272
+ ,TK_UMINUS=273
+ ,TK_NEW_SYMBOL=274
+ ,TK_OBJ_SYMBOL=275
+ ,TK_TYPE_SYMBOL=276
+ ,TK_PRED_SYMBOL=277
+ ,TK_OBJFUN_SYMBOL=278
+ ,TK_FUN_SYMBOL=279
+ ,TK_VAR_SYMBOL=280
+ ,TK_ACTION_SYMBOL=281
+ ,TK_MISC_SYMBOL=282
+ ,TK_KEYWORD=283
+ ,TK_NEW_VAR_SYMBOL=284
+ ,TK_PREFERENCE_SYMBOL=285
+ ,TK_SET_SYMBOL=286
+ ,TK_FLOAT=287
+ ,TK_INT=288
+ ,TK_STRING=289
+ ,KW_REQS=290
+ ,KW_CONSTANTS=291
+ ,KW_PREDS=292
+ ,KW_FUNS=293
+ ,KW_TYPES=294
+ ,KW_DEFINE=295
+ ,KW_DOMAIN=296
+ ,KW_ACTION=297
+ ,KW_PROCESS=298
+ ,KW_EVENT=299
+ ,KW_ARGS=300
+ ,KW_PRE=301
+ ,KW_COND=302
+ ,KW_AT_START=303
+ ,KW_AT_END=304
+ ,KW_OVER_ALL=305
+ ,KW_EFFECT=306
+ ,KW_INVARIANT=307
+ ,KW_DURATION=308
+ ,KW_AND=309
+ ,KW_OR=310
+ ,KW_EXISTS=311
+ ,KW_FORALL=312
+ ,KW_IMPLY=313
+ ,KW_NOT=314
+ ,KW_WHEN=315
+ ,KW_EITHER=316
+ ,KW_PROBLEM=317
+ ,KW_FORDOMAIN=318
+ ,KW_OBJECTS=319
+ ,KW_INIT=320
+ ,KW_GOAL=321
+ ,KW_LENGTH=322
+ ,KW_SERIAL=323
+ ,KW_PARALLEL=324
+ ,KW_METRIC=325
+ ,KW_MINIMIZE=326
+ ,KW_MAXIMIZE=327
+ ,KW_DURATION_VAR=328
+ ,KW_TOTAL_TIME=329
+ ,KW_INCREASE=330
+ ,KW_DECREASE=331
+ ,KW_SCALE_UP=332
+ ,KW_SCALE_DOWN=333
+ ,KW_ASSIGN=334
+ ,KW_TAG=335
+ ,KW_NAME=336
+ ,KW_VARS=337
+ ,KW_SET_CONSTRAINT=338
+ ,KW_SETOF=339
+ ,KW_AT_LEAST_N=340
+ ,KW_AT_MOST_N=341
+ ,KW_EXACTLY_N=342
+ ,KW_CONTEXT=343
+ ,KW_FORMULA=344
+ ,KW_IRRELEVANT=345
+ ,KW_PLAN=346
+ ,KW_HEURISTIC=347
+ ,KW_OPT=348
+ ,KW_INF=349
+ ,KW_FACT=350
+ ,KW_SET=351
+ ,KW_EXPANSION=352
+ ,KW_TASKS=353
+ ,KW_PREFERENCE=354
+ ,KW_VIOLATED=355
+ ,KW_WITHIN=356
+ ,KW_ASSOC=357
+ ,KW_CONSTRAINTS=358
+ ,KW_ALWAYS=359
+ ,KW_SOMETIME=360
+ ,KW_AT_MOST_ONCE=361
+ ,KW_SOMETIME_BEFORE=362
+ ,KW_SOMETIME_AFTER=363
+ ,KW_ALWAYS_WITHIN=364
+ ,KW_IFF=365
+ ,KW_FALSE=366
+ ,KW_TRUE=367
+ ,KW_NUMBER=368
+ ,KW_UNDEFINED=369
+     };
+public:
+ int yyparse(void);
+ virtual void log_error(char *msg) = 0;
+ virtual int next_token() = 0;
+ yy_PDDL_Parser_stype yylval;
+ int yynerrs;
+ int yychar;
+public:
+ int yydebug;
+public:
+ PDDL_Parser(hsps::StringTable& t);
+public:
+ public: virtual std::ostream& at_position(std::ostream& s) = 0; virtual char* current_file() = 0; bool error_flag; private: hsps::PDDL_Base::variable_vec current_param; hsps::index_vec stored_n_param; hsps::PDDL_Base::TypeSet current_type_set; hsps::index_type last_n_functions; hsps::PDDL_Base::AtomBase* current_atom; hsps::PDDL_Base::atom_base_vec current_atom_stack; hsps::PDDL_Base::Context* current_context; hsps::lvector<Context*> stored_context; hsps::PDDL_Base::DKEL_Item* current_item; hsps::lvector<ConjunctiveGoal*> current_goal; hsps::PDDL_Base::Symbol* current_preference_name; hsps::PDDL_Base::HTableEntry* current_entry; char* current_plan_file; hsps::index_type n_plans_in_current_file;
+};
+typedef struct yy_buffer_state *YY_BUFFER_STATE;
+class PDDL_Scanner
+{
+ private:
+ char *yy_c_buf_p;
+ char yy_hold_char;
+ int yy_n_chars;
+ int yy_init;
+ int yy_start;
+ int yy_did_buffer_switch_on_eof;
+ private:
+ void yy_initialize();
+ int input();
+ int yyinput() {return input();};
+ int yy_get_next_buffer();
+ void yyunput( char c, char *buf_ptr );
+ long yy_get_previous_state_ ( void );
+ long yy_try_NUL_trans_ ( long current_state_ );
+ protected:
+ YY_BUFFER_STATE YY_CURRENT_BUFFER;
+ void yyrestart ( FILE *input_file );
+ void yy_switch_to_buffer( YY_BUFFER_STATE new_buffer );
+ void yy_load_buffer_state( void );
+ YY_BUFFER_STATE yy_create_buffer( FILE *file, int size );
+ void yy_delete_buffer( YY_BUFFER_STATE b );
+ void yy_init_buffer( YY_BUFFER_STATE b, FILE *file );
+ protected:
+ virtual void yy_echo()
+  ;
+ virtual int yy_input(char *buf,int &result,int max_size)
+  ;
+ virtual void yy_fatal_error(char *msg)
+  ;
+ virtual int yy_wrap()
+  ;
+ public:
+ char *yytext;
+ int yyleng;
+ FILE *yyin;
+ FILE *yyout;
+ int next_token ( yy_PDDL_Parser_stype& val);
+ PDDL_Scanner(hsps::StringTable& t) ;
+ virtual ~PDDL_Scanner() ;
+ int yy_flex_debug;
+ public:
+ private: hsps::StringTable& _tab; bool _reset; char* _filename; int _line_no; bool _trace_line; public: void open_file(char* fname, bool trace); void close_file(); char* current_file() const { return _filename; }; int current_line() const { return _line_no; };
+};
+namespace hsps {
+class Parser : public PDDL_Parser {
+  PDDL_Scanner scanner;
+ public:
+  Parser(StringTable& t) : PDDL_Parser(t), scanner(t) { };
+  void read(char *name, bool trace);
+  virtual int next_token();
+  virtual void log_error(char* msg);
+  virtual std::ostream& at_position(std::ostream& s);
+  virtual char* current_file();
+};
+}
+namespace hsps {
+class AH : public Heuristic {
+  void max_cost_mset(index_type m, const index_set& g, index_set& s);
+  void goal_relevant_remaining_actions(const index_set& g,
+           index_set& a,
+           bool_vec& rem);
+ protected:
+  CostTable* Hmax;
+  lvector<CostTable*> H_vec;
+  Statistics& stats;
+ public:
+  static count_type Hmax_wins;
+  static count_type Hsum_wins;
+  static count_type draws;
+  static bool use_linear_scan_eval;
+  AH(Instance& i, Statistics& s);
+  virtual ~AH();
+  index_type n_additive_components() { return H_vec.length(); };
+  CostTable* additive_component(index_type i) { return H_vec[i]; };
+  CostTable* max_component() { return Hmax; };
+  void compute_additive(const ACF& cost, const index_set_vec& p, bool useH2);
+  void compute_fractional(const ACF& cost, index_set_vec& p, bool useH2);
+  void compute_max(const ACF& cost, bool useH2);
+  void disable_max();
+  void compute_with_relevance_partitioning
+    (const ACF& cost, const index_set& g);
+  void compute_with_iterative_assignment
+    (const ACF& cost, const index_set& g, index_set_vec& app,
+     bool useH2, bool fractional, const index_set& g_limit);
+  void compute_with_iterative_assignment_1
+    (const ACF& cost, const index_set& g,
+     bool useH2, bool fractional, bool optimal,
+     const index_set& g_limit);
+  void compute_with_iterative_assignment_2
+    (const ACF& cost, const index_set& g, bool useH2, bool fractional,
+     const index_set& g_limit);
+  void compute_with_layered_partitioning
+    (const ACF& cost, const index_set& g);
+  void compute_layered_action_partition
+    (index_type m, const index_set& g, index_set_vec& p, index_type pg,
+     bool_vec& rem);
+  void compute_with_new_decomposition
+    (const ACF& cost, const index_set& g, bool useH2);
+  void compute_bottom_up_2
+    (const ACF& cost, const index_set& g, index_type p_max, bool useH2);
+  void compute_bottom_up
+    (const ACF& cost, const index_set& g, bool do_glue, bool useH2);
+  void compute_with_k_cuts
+    (const ACF& cost, const index_set& g, index_type k, bool useH2);
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual void write_eval(const index_set& s, std::ostream& st,
+     char* p = 0, bool e = true);
+  virtual void write_eval(const bool_vec& s, std::ostream& st,
+     char* p = 0, bool e = true);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+};
+}
+namespace hsps {
+class AtomSet {
+ protected:
+  Instance& instance;
+  bool_vec set;
+  index_type size;
+  index_type count();
+ private:
+  hsps::rational split(index_set g, index_type p, index_type n_out, index_type limit,
+       StateFactory& f, State* sp, Search& s, hsps::rational bound);
+  hsps::rational split_random(index_set g, index_type p, index_type n_out,
+       index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+ public:
+  static index_type max_set_size_encountered;
+  AtomSet(Instance& i);
+  AtomSet(Instance& i, const index_set& g);
+  AtomSet(Instance& i, const bool_vec& g);
+  AtomSet(const AtomSet& s);
+  ~AtomSet();
+  index_type atom_set_size() { return size; };
+  void add(const index_set& s);
+  void add(const bool_vec& s);
+  void del(const index_set& s);
+  void del(const bool_vec& s);
+  bool is_init_all();
+  bool is_init_some();
+  bool is_goal_all();
+  bool is_goal_some();
+  index_vec& copy_to(index_vec& s);
+  bool_vec& copy_to(bool_vec& s);
+  hsps::rational split(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound);
+  hsps::rational split_random(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+  int compare(const AtomSet& s);
+  index_type hash();
+};
+class AtomSetState : public AtomSet, public State {
+ protected:
+  Heuristic& heuristic;
+  hsps::rational est;
+  hsps::rational eval();
+  hsps::rational eval(hsps::rational b_est);
+  hsps::rational eval_with_trace_level(int level);
+  void apply_path_max();
+ public:
+  AtomSetState(Instance& i, Heuristic& h);
+  AtomSetState(Instance& i, Heuristic& h, const index_set& g);
+  AtomSetState(Instance& i, Heuristic& h, const bool_vec& g);
+  AtomSetState(const AtomSetState& s);
+  virtual ~AtomSetState();
+  index_type atom_set_size() { return size; };
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual void write(std::ostream& s);
+  virtual void write_eval(std::ostream& s, char* p = 0, bool e = true);
+};
+}
+namespace hsps {
+class SeqRegState : public AtomSetState, public StateFactory {
+ protected:
+  const ACF& cost;
+  index_type act;
+  RegressionResourceState* res;
+  bool relevant(Instance::Action& a);
+  bool applicable(Instance::Action& a);
+  SeqRegState* apply(Instance::Action& a);
+ public:
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c)
+    : AtomSetState(i, h), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c,
+       RegressionResourceState* r)
+    : AtomSetState(i, h), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+       RegressionResourceState* r)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+       RegressionResourceState* r)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(const SeqRegState& s);
+  virtual ~SeqRegState();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void set_predecessor(State* p);
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write_plan(std::ostream& s);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual void write(std::ostream& s);
+};
+class ApxSeqRegState : public SeqRegState {
+ protected:
+  index_type limit;
+ public:
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, index_type l)
+    : SeqRegState(i, h, c), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+   index_type l)
+    : SeqRegState(i, h, c, g), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+   index_type l)
+    : SeqRegState(i, h, c, g), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, r), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, g, r), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, g, r), limit(l) { };
+  ApxSeqRegState(const ApxSeqRegState& s)
+    : SeqRegState(s), limit(s.limit) { };
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+};
+class SeqCRegState : public SeqRegState {
+ public:
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c)
+    : SeqRegState(i, h, c) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g)
+    : SeqRegState(i, h, c, g) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g)
+    : SeqRegState(i, h, c, g) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, r) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, g, r) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, g, r) { };
+  SeqCRegState(const SeqRegState& s)
+    : SeqRegState(s) { };
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual int compare(const State& s);
+  index_type hash();
+  virtual void write(std::ostream& s);
+};
+class LDSeqRegState : public SeqRegState {
+  const index_vec& plan;
+  static bool copy_as_ld;
+ public:
+  LDSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+  const index_set& g, const index_vec& p)
+    : SeqRegState(i, h, c, g), plan(p) { };
+  LDSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+  const index_vec& p, const bool_vec& g)
+    : SeqRegState(i, h, c, g), plan(p) { };
+  LDSeqRegState(const LDSeqRegState& s);
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* copy();
+  virtual int compare(const State& s);
+  virtual void write(std::ostream& s);
+};
+}
+namespace hsps {
+class ActionSequence : public index_vec, public Plan {
+ public:
+  ActionSequence() : index_vec(no_such_index, 0) { };
+  ActionSequence(const index_vec& vec) : index_vec(vec) { };
+  ActionSequence(const ActionSequence& seq) : index_vec(seq) { };
+  virtual ~ActionSequence() { };
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  virtual void output(Plan& to);
+};
+class ActionSequenceSet : public lvector<ActionSequence>, public PlanSet {
+ public:
+  ActionSequenceSet() : lvector<ActionSequence>() { };
+  virtual ~ActionSequenceSet() { };
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+};
+class CountActions
+: public lvector<count_type>, public Plan, public PlanSet
+{
+ public:
+  CountActions() : lvector<count_type>(0, 0) { };
+  CountActions(index_type n) : lvector<count_type>(0, n) { };
+  virtual ~CountActions() { };
+  void reset() { assign_value(0, length()); };
+  void reset(index_type n) { assign_value(0, n); };
+  count_type sum();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class ApxResult : public Result {
+  bool min_sol;
+  index_type sol_depth;
+ public:
+  ApxResult() : min_sol(false), sol_depth(0) { };
+  virtual ~ApxResult() { };
+  bool min_solution() { return min_sol; };
+  index_type solution_depth() { return sol_depth; };
+  virtual void solution(State& s, hsps::rational cost);
+  virtual bool more();
+};
+class Print : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  hsps::rational current_t;
+  amt_vec peak_use;
+  amt_vec res_cons;
+  count_type n_actions;
+  count_type n_plans;
+  hsps::rational sum_cost;
+ public:
+  static bool print_noops;
+  static bool decimal_time;
+  Print(Instance& i, ::std::ostream& s);
+  virtual ~Print();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintActions : public Plan, public PlanSet {
+ protected:
+  Instance& instance;
+  ::std::ostream& to;
+  char action_sep;
+  bool first_action;
+  char plan_sep;
+  bool first_plan;
+ public:
+  PrintActions(Instance& i, ::std::ostream& s);
+  PrintActions(Instance& i, ::std::ostream& s, char as);
+  PrintActions(Instance& i, ::std::ostream& s, char as, char ps);
+  virtual ~PrintActions();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintActionSetNames : public PrintActions {
+ public:
+  PrintActionSetNames(Instance& i, ::std::ostream& s)
+    : PrintActions(i, s) { };
+  PrintActionSetNames(Instance& i, ::std::ostream& s, char p)
+    : PrintActions(i, s, p) { };
+  virtual ~PrintActionSetNames() { };
+  virtual void insert(index_type act);
+};
+class PrintPDDL : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  hsps::rational start_t;
+ public:
+  PrintPDDL(Instance& i, ::std::ostream& s);
+  virtual ~PrintPDDL();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintIPC : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  bool temporal;
+  hsps::rational epsilon;
+  bool included_epsilon;
+  bool strict_separation;
+  hsps::rational start_t;
+  bool occ_current_t;
+ public:
+  PrintIPC(Instance& i, ::std::ostream& s);
+  virtual ~PrintIPC();
+  void set_epsilon(hsps::rational e, bool included, bool strict);
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintAssoc : public Plan {
+  Instance& instance;
+  ::std::ostream& to;
+ public:
+  PrintAssoc(Instance& i, ::std::ostream& s);
+  virtual ~PrintAssoc();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class Store : public Result, public ScheduleSet {
+  state_vec solutions;
+ public:
+  Store(Instance& i);
+  virtual ~Store();
+  void reset();
+  void clear();
+  virtual void solution(State& s, hsps::rational cost);
+  index_type n_solutions() { return solutions.length(); };
+  State* solution(index_type k);
+  index_type n_plans() { return length(); };
+  Schedule* plan(index_type k);
+  virtual void output(PlanSet& to);
+  virtual void output(Result& to);
+};
+class StoreFilter : public SearchResult {
+ protected:
+  Store& store;
+ public:
+  StoreFilter(Store& s) : store(s) { };
+  virtual ~StoreFilter() { };
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class StoreMinCost : public StoreFilter {
+ public:
+  StoreMinCost(Store& s) : StoreFilter(s) { };
+  virtual ~StoreMinCost() { };
+  virtual void solution(State& s, hsps::rational cost);
+};
+class StoreDistinct : public StoreFilter {
+  Instance& instance;
+ public:
+  static count_type n_discarded;
+  StoreDistinct(Instance& i, Store& s) : StoreFilter(s), instance(i) { };
+  virtual ~StoreDistinct() { };
+  virtual void solution(State& s, hsps::rational cost);
+};
+class Conflicts : public Result {
+  Instance& instance;
+  index_set nec_del;
+  index_set pos_del;
+  amt_vec min_peak;
+  amt_vec max_peak;
+  bool first;
+  bool need_to_clear;
+ public:
+  Conflicts(Instance& ins);
+  virtual ~Conflicts();
+  const index_set& nec_deleted() const { return nec_del; };
+  const index_set& pos_deleted() const { return pos_del; };
+  const amt_vec& min_peak_resource_use() const { return min_peak; };
+  const amt_vec& max_peak_resource_use() const { return max_peak; };
+  void clear();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions();
+};
+}
+namespace hsps {
+class HashTable {
+ public:
+  struct Entry {
+    State* state;
+    index_type depth;
+    hsps::rational cost;
+  };
+ private:
+  index_type size;
+  index_type nocc;
+  Entry* tab;
+  count_type hits;
+  count_type cols;
+  count_type miss;
+ public:
+  HashTable(index_type s);
+  ~HashTable();
+  void inc_occ_count() { nocc += 1; };
+  Entry& operator[](index_type i);
+  index_type index(State& s);
+  Entry* find(State& s);
+  void insert(State& s, hsps::rational v, index_type d);
+  void insert(State& s, hsps::rational v);
+  void clear();
+  double hit_ratio();
+  double HCF();
+  double TUF();
+};
+}
+namespace hsps {
+class IDA : public MultiSearchAlgorithm {
+  HashTable* ttab;
+  bool cycle_check;
+  hsps::rational current_bound;
+  count_type iteration_limit;
+  count_type iteration_count;
+  static const count_type TRACE_LEVEL_2_NOTIFY = 100000;
+ public:
+  IDA(Statistics& s, SearchResult& r);
+  IDA(Statistics& s, SearchResult& r, HashTable* t);
+  virtual ~IDA();
+  void set_iteration_limit(count_type i_max) { iteration_limit = i_max; };
+  void increase_iteration_limit(count_type i) { iteration_limit += i; };
+  count_type get_iteration_limit() { return iteration_limit; };
+  void set_cycle_check(bool cc) { cycle_check = cc; };
+  hsps::rational main(State& s, hsps::rational bound);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+  virtual hsps::rational cost() const;
+  virtual hsps::rational resume(State& s, hsps::rational b);
+};
+}
+namespace hsps {
+class Node;
+typedef Node* nodep;
+typedef lvector<nodep> node_vec;
+struct Link {
+  Node* node;
+  hsps::rational delta;
+  Link() : node(0), delta(0) { };
+  Link(Node* s, hsps::rational d) : node(s), delta(d) { };
+  Link& operator=(const Link& l);
+  bool operator==(const Link& l);
+  bool operator<(const Link& l);
+  bool operator>(const Link& l);
+  bool operator<=(const Link& l);
+  bool operator>=(const Link& l);
+};
+typedef svector<Link> link_vec;
+class Node {
+ public:
+  index_type id;
+  State* state;
+  link_vec succ;
+  bool closed;
+  hsps::rational acc;
+  hsps::rational est;
+  hsps::rational val;
+  hsps::rational opt;
+  index_type pos;
+  count_type exp;
+  Node* bp_pre;
+  hsps::rational bp_delta;
+  link_vec* all_pre;
+  Node() :
+    id(0), state(0), closed(false), acc(0), est(0), val(0), opt(POS_INF),
+    pos(no_such_index), exp(0), bp_pre(0), bp_delta(0), all_pre(0) { };
+  ~Node();
+  hsps::rational min_delta_to(Node* n);
+  bool solved() { return (opt).finite(); };
+  bool back_path_contains(Node* n);
+  void add_predecessor(Node* n, hsps::rational d);
+  void backup_costs(node_vec& p);
+  void write(std::ostream& s, const Name* p = 0);
+  void write_short(std::ostream& s, const Name* p = 0);
+  void write_graph_node(std::ostream& s);
+  void write_graph_edges(std::ostream& s);
+};
+class NodeQueue : public node_vec {
+  const node_vec::order& before;
+ public:
+  NodeQueue(const node_vec::order& b);
+  ~NodeQueue();
+  void check_queue();
+  Node* peek();
+  void enqueue(Node*);
+  Node* dequeue();
+  void shift_up(index_type i);
+  void shift_down(index_type i);
+};
+class NodeSet {
+ protected:
+  static index_type next_id;
+  node_vec roots;
+ public:
+  static bool write_state_in_graph_node;
+  virtual ~NodeSet();
+  virtual Node* insert_node(State& s) = 0;
+  virtual Node* find_node(State& s) = 0;
+  virtual void clear() = 0;
+  virtual void collect_nodes(node_vec& ns) = 0;
+  Node* insert_root_node(State& s);
+  void make_root(Node* n);
+  node_vec& root_nodes();
+  void compute_reverse_links(node_vec& v);
+  void compute_reverse_links();
+  void mark_solved_apsp();
+  void mark_solved();
+  void backup_costs();
+  void set_back_path_solution_cost(Node* n, hsps::rational c_sol);
+  void cache_pg(hsps::rational c_sol);
+  void back_path_to_sequence(Node* n, node_vec& ns);
+  State* build_path(node_vec& ns);
+  State* build_path(Node* tn);
+  void write_short(std::ostream& s, const Name* p = 0);
+  void write_graph(std::ostream& s);
+};
+class NodeSetSearchState : public State {
+  Node* node;
+  hsps::rational delta;
+  State* path;
+ public:
+  NodeSetSearchState(Node* n);
+  NodeSetSearchState(NodeSetSearchState* p, Link& l, State* s);
+  NodeSetSearchState(const NodeSetSearchState& s);
+  virtual ~NodeSetSearchState();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write(std::ostream& s);
+  virtual void write_plan(std::ostream& s);
+};
+class TreeNodeSet : public Node, public NodeSet {
+  TreeNodeSet* left;
+  TreeNodeSet* right;
+ public:
+  TreeNodeSet();
+  virtual ~TreeNodeSet();
+  virtual Node* insert_node(State& s);
+  virtual Node* find_node(State& s);
+  virtual void clear();
+  virtual void collect_nodes(node_vec& ns);
+};
+class HashNodeSet : public NodeSet {
+  index_type size;
+  TreeNodeSet** tab;
+ public:
+  HashNodeSet(index_type s);
+  virtual ~HashNodeSet();
+  virtual Node* insert_node(State& s);
+  virtual Node* find_node(State& s);
+  virtual void clear();
+  virtual void collect_nodes(node_vec& ns);
+};
+inline Link& Link::operator=(const Link& l)
+{
+  node = l.node;
+  delta = l.delta;
+  return *this;
+}
+inline bool Link::operator==(const Link& l)
+{
+  return ((node == l.node) && (delta == l.delta));
+}
+inline bool Link::operator<(const Link& l)
+{
+  return ((node < l.node) || ((node == l.node) && (delta < l.delta)));
+}
+inline bool Link::operator>(const Link& l)
+{
+  return ((node > l.node) || ((node == l.node) && (delta > l.delta)));
+}
+inline bool Link::operator<=(const Link& l)
+{
+  return ((node <= l.node) || ((node == l.node) && (delta <= l.delta)));
+}
+inline bool Link::operator>=(const Link& l)
+{
+  return ((node >= l.node) || ((node == l.node) && (delta >= l.delta)));
+}
+}
+namespace hsps {
+class NodeOrderForBFS : public node_vec::order {
+ public:
+  NodeOrderForBFS() { };
+  virtual bool operator()(const nodep& v0, const nodep& v1) const;
+};
+class BFS : public SingleSearchAlgorithm {
+  static NodeOrderForBFS b_op;
+ protected:
+  static const count_type TRACE_LEVEL_2_NOTIFY = 10000;
+  HashNodeSet graph;
+  NodeQueue queue;
+  Node* current_node;
+  hsps::rational best_node_cost;
+  count_type acc_succ;
+  count_type new_succ;
+  void update_cost(Node* n, Node* p, hsps::rational d);
+ public:
+  NodeSet& state_space() { return graph; };
+  BFS(Statistics& s, SearchResult& r);
+  BFS(Statistics& s, SearchResult& r, index_type nt_size);
+  virtual ~BFS();
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+  virtual hsps::rational resume();
+  virtual hsps::rational main();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual hsps::rational cost() const;
+  virtual bool done() const;
+};
+class BFS_PX : public BFS {
+  hsps::rational threshold;
+ public:
+  BFS_PX(Statistics& s, SearchResult& r, hsps::rational thresh)
+    : BFS(s, r), threshold(thresh) { };
+  BFS_PX(Statistics& s, SearchResult& r, index_type nt_size, hsps::rational thresh)
+    : BFS(s, r, nt_size), threshold(thresh) { };
+  virtual ~BFS_PX() { };
+  virtual hsps::rational main();
+};
+}
+#include <sstream>
+#include <fstream>
+int main(int argc, char *argv[]) {
+  hsps::StringTable symbols(50, hsps::lowercase_map);
+  hsps::index_type opt_q_val = 0;
+  hsps::rational opt_d_val = 0;
+  bool opt_round = false;
+  bool opt_round_up = false;
+  bool opt_round_down = false;
+  bool opt_unlimited = false;
+  bool opt_unit = false;
+  bool opt_H0 = false;
+  bool opt_H1 = false;
+  bool opt_H3 = false;
+  bool opt_AH = false;
+  bool opt_AH_max = true;
+  bool opt_structured = false;
+  bool opt_AHRC = false;
+  hsps::rational alpha_AHRC = (hsps::rational(5,10).reduce());
+  bool opt_load_partition = false;
+  bool opt_rnd_relevance_partition = false;
+  bool opt_ia1_partition = false;
+  bool opt_ia2_partition = false;
+  bool opt_iaa_partition = false;
+  bool opt_fpia = false;
+  bool opt_layered_partition = false;
+  bool opt_new_decomposition = false;
+  bool opt_bu_partition = false;
+  bool opt_bu_glue = false;
+  bool opt_bu2_partition = false;
+  hsps::rational bu2_ratio = (hsps::rational(1,4).reduce());
+  bool opt_load_h = false;
+  bool opt_load_compare = false;
+  bool opt_compare_max = false;
+  bool opt_all_pairs = false;
+  bool opt_pdb_1 = false;
+  bool opt_pdb_load = false;
+  bool opt_pdb_ai = false;
+  bool opt_pdb_ai_all = false;
+  bool opt_pdb_ind_pair = false;
+  bool opt_pdb_ind_bin = false;
+  bool opt_pdb_wbin = false;
+  bool opt_pdb_windbin = false;
+  bool opt_pdb_collapse = true;
+  bool opt_pdb_bin = false;
+  bool opt_pdb_random_bin = false;
+  bool opt_pdb_independent_random_bin = false;
+  bool opt_pdb_spanning_subset = true;
+  hsps::index_type opt_pdb_random_bin_swaps = 10000;
+  hsps::index_type opt_pdb_random_bin_k = 0;
+  bool opt_pdb_cg = false;
+  bool opt_pdb_int = false;
+  hsps::index_type opt_pdb_size = 20000;
+  bool opt_pdb_add = true;
+  bool opt_pdb_ext_add = false;
+  hsps::rational ext_add_threshold = 0;
+  bool opt_pdb_add_all = false;
+  bool opt_pdb_reduced = false;
+  bool opt_pdb_inc = true;
+  bool opt_optimal = false;
+  bool opt_maximal_add = true;
+  bool opt_sas = false;
+  bool opt_sas_min = false;
+  bool opt_sas_select = false;
+  bool opt_apply_invariants = false;
+  bool opt_eval_cache = false;
+  bool opt_sequential = false;
+  bool opt_temporal = false;
+  bool opt_resource = false;
+  bool opt_compose = false;
+  hsps::index_type composite_resource_size = 2;
+  bool opt_R0 = false;
+  bool opt_R2 = false;
+  bool opt_RAH = false;
+  bool opt_rpdb = false;
+  bool opt_cost = false;
+  bool opt_deadline = false;
+  bool opt_apply_cuts = true;
+  bool opt_ncw = false;
+  bool opt_preprocess = true;
+  bool opt_rm_irrelevant = false;
+  bool opt_quick_find_invariants = false;
+  bool opt_find_invariants = false;
+  bool opt_negation_invariants = true;
+  bool opt_verify_invariants = false;
+  bool opt_extend_goal = false;
+  bool opt_find_all = false;
+  bool opt_all_different = false;
+  bool opt_exhaustive = false;
+  bool opt_find_n = false;
+  hsps::count_type n_to_find = 0;
+  bool opt_post_op = false;
+  bool opt_print_plan = true;
+  bool opt_validate = false;
+  bool opt_pop = false;
+  bool opt_path = false;
+  bool opt_write_graphs = false;
+  bool opt_pddl = false;
+  bool opt_gantt = false;
+  bool opt_ipc = false;
+  bool opt_strict_ipc = false;
+  hsps::rational epsilon = hsps::rational(1,100);
+  bool opt_cc = false;
+  bool opt_tt = false;
+  hsps::index_type opt_tt_size = 31337;
+  bool opt_bfs = false;
+  bool opt_bfs_px = false;
+  hsps::rational px_threshold = 0;
+  bool opt_dfs = false;
+  bool opt_bb = false;
+  bool opt_lds = false;
+  bool opt_bfida = false;
+  bool opt_idao = false;
+  bool opt_explore_to_depth = false;
+  bool opt_explore_to_bound = false;
+  hsps::index_type depth_limit = 0;
+  bool opt_print_solution_only = false;
+  bool opt_no_print_solution = false;
+  bool opt_apx = false;
+  hsps::index_type apx_limit = 0;
+  double time_limit = 0;
+  unsigned long memory_limit = 0;
+  unsigned long stack_limit = 0;
+  hsps::index_type iteration_limit = 0;
+  hsps::count_type node_limit = 0;
+  hsps::rational cost_limit = POS_INF;
+  bool opt_limit_to_length = false;
+  bool opt_save = false;
+  bool opt_look_ahead = false;
+  hsps::index_type look_ahead_depth = 1;
+  unsigned long rnd_seed = 0;
+  int verbose_level = 1;
+  bool opt_bfs_write_graph = false;
+  bool opt_bfs_write_stats = false;
+  hsps::Statistics parse_stats;
+  hsps::Parser* reader = new hsps::Parser(symbols);
+  for (int k = 1; k < argc; k++) {
+    if ((strcmp(argv[k],"-v") == 0) && (k < argc - 1)) {
+      verbose_level = atoi(argv[++k]);
+      if (verbose_level < 1) opt_print_plan = false;
+      if (verbose_level <= 0) hsps::PDDL_Base::write_warnings = false;
+      if (verbose_level > 1) hsps::PDDL_Base::write_info = true;
+    }
+    else if (strcmp(argv[k],"-no-warnings") == 0) {
+      hsps::PDDL_Base::write_warnings = false;
+    }
+    else if (strcmp(argv[k],"-no-info") == 0) {
+      hsps::PDDL_Base::write_info = false;
+    }
+    else if (strcmp(argv[k],"-name-by-file") == 0) {
+      hsps::PDDL_Base::name_instance_by_problem_file = true;
+    }
+    else if ((strcmp(argv[k],"-q") == 0) && (k < argc - 1)) {
+      opt_q_val = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-d") == 0) && (k < argc - 1)) {
+      opt_d_val = hsps::rational::ator(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-round") == 0) {
+      opt_round = true;
+      opt_round_up = false;
+      opt_round_down = false;
+    }
+    else if (strcmp(argv[k],"-round-up") == 0) {
+      opt_round_up = true;
+      opt_round = false;
+      opt_round_down = false;
+    }
+    else if (strcmp(argv[k],"-round-down") == 0) {
+      opt_round_down = true;
+      opt_round_up = false;
+      opt_round = false;
+    }
+    else if (strcmp(argv[k],"-u") == 0) {
+      opt_unlimited = true;
+    }
+    else if (strcmp(argv[k],"-unit") == 0) {
+      opt_unit = true;
+    }
+    else if (strcmp(argv[k],"-dba-semantics") == 0) {
+      hsps::PDDL_Base::del_before_add_semantics = true;
+    }
+    else if (strcmp(argv[k],"-use-strict-borrow") == 0) {
+      hsps::PDDL_Base::use_strict_borrow_definition = true;
+    }
+    else if (strcmp(argv[k],"-use-extended-borrow") == 0) {
+      hsps::PDDL_Base::use_extended_borrow_definition = true;
+    }
+    else if (strcmp(argv[k],"-no-compile") == 0) {
+      hsps::PDDL_Base::compile_away_disjunctive_preconditions = false;
+      hsps::PDDL_Base::compile_away_conditional_effects = false;
+    }
+    else if (strcmp(argv[k],"-no-compact") == 0) {
+      hsps::PDDL_Base::compact_resource_effects = false;
+    }
+    else if (strcmp(argv[k],"-non-strict-set-export") == 0) {
+      hsps::PDDL_Base::strict_set_export = false;
+    }
+    else if (strcmp(argv[k],"-seq") == 0) {
+      opt_sequential = true;
+    }
+    else if (strcmp(argv[k],"-time") == 0) {
+      opt_temporal = true;
+      opt_ncw = true;
+    }
+    else if (strcmp(argv[k],"-deadline") == 0) {
+      opt_deadline = true;
+      opt_temporal = true;
+      opt_ncw = true;
+    }
+    else if (strcmp(argv[k],"-res") == 0) {
+      opt_resource = true;
+    }
+    else if (strcmp(argv[k],"-cost") == 0) {
+      opt_cost = true;
+    }
+    else if (strcmp(argv[k],"-cut") == 0) {
+      opt_apply_cuts = true;
+    }
+    else if (strcmp(argv[k],"-no-cut") == 0) {
+      opt_apply_cuts = false;
+    }
+    else if (strcmp(argv[k],"-ncw") == 0) {
+      opt_ncw = true;
+    }
+    else if (strcmp(argv[k],"-no-ncw") == 0) {
+      opt_ncw = false;
+    }
+    else if (strcmp(argv[k],"-inv") == 0) {
+      opt_apply_invariants = true;
+    }
+    else if (strcmp(argv[k],"-eac") == 0) {
+      opt_eval_cache = true;
+    }
+    else if (strcmp(argv[k],"-prep") == 0) {
+      opt_preprocess = true;
+    }
+    else if (strcmp(argv[k],"-no-prep") == 0) {
+      opt_preprocess = false;
+    }
+    else if (strcmp(argv[k],"-rm") == 0) {
+      opt_rm_irrelevant = true;
+    }
+    else if (strcmp(argv[k],"-quick-find") == 0) {
+      opt_quick_find_invariants = true;
+    }
+    else if (strcmp(argv[k],"-find") == 0) {
+      opt_find_invariants = true;
+    }
+    else if (strcmp(argv[k],"-no-find") == 0) {
+      opt_find_invariants = false;
+    }
+    else if (strcmp(argv[k],"-no-neg") == 0) {
+      opt_negation_invariants = false;
+    }
+    else if (strcmp(argv[k],"-verify") == 0) {
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-no-verify") == 0) {
+      opt_verify_invariants = false;
+    }
+    else if (strcmp(argv[k],"-extend") == 0) {
+      opt_extend_goal = true;
+    }
+    else if (strcmp(argv[k],"-no-extend") == 0) {
+      opt_extend_goal = false;
+    }
+    else if ((strcmp(argv[k],"-compose") == 0) && (k < argc - 1)) {
+      opt_compose = true;
+      composite_resource_size = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-l") == 0) || (strcmp(argv[k],"-load") == 0)) {
+      opt_load_h = true;
+    }
+    else if (strcmp(argv[k],"-compare") == 0) {
+      opt_load_compare = true;
+    }
+    else if (strcmp(argv[k],"-compare-max") == 0) {
+      opt_load_compare = true;
+      opt_compare_max = true;
+    }
+    else if (strcmp(argv[k],"-1") == 0) {
+      opt_H1 = true;
+    }
+    else if (strcmp(argv[k],"-0") == 0) {
+      opt_H0 = true;
+    }
+    else if (strcmp(argv[k],"-3") == 0) {
+      opt_H3 = true;
+    }
+    else if (strcmp(argv[k],"-R0") == 0) {
+      opt_R0 = true;
+    }
+    else if (strcmp(argv[k],"-R2") == 0) {
+      opt_R2 = true;
+    }
+    else if (strcmp(argv[k],"-RAH") == 0) {
+      opt_RAH = true;
+    }
+    else if (strcmp(argv[k],"-rpdb") == 0) {
+      opt_rpdb = true;
+      opt_sas = true;
+      opt_optimal = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-AH") == 0) {
+      opt_AH = true;
+    }
+    else if (strcmp(argv[k],"-use-lse") == 0) {
+      hsps::AH::use_linear_scan_eval = true;
+    }
+    else if ((strcmp(argv[k],"-AHRC") == 0) && (k < argc - 1)) {
+      opt_AH = true;
+      opt_AHRC = true;
+      opt_AH_max = false;
+      alpha_AHRC = hsps::rational::ator(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-AHX") == 0) {
+      opt_AH = true;
+      opt_structured = true;
+    }
+    else if (strcmp(argv[k],"-no-max") == 0) {
+      opt_AH_max = false;
+    }
+    else if (strcmp(argv[k],"-load-p") == 0) {
+      opt_load_partition = true;
+    }
+    else if (strcmp(argv[k],"-prr") == 0) {
+      opt_rnd_relevance_partition = true;
+    }
+    else if (strcmp(argv[k],"-pia") == 0) {
+      opt_ia2_partition = true;
+    }
+    else if (strcmp(argv[k],"-pia2a") == 0) {
+      opt_ia2_partition = true;
+      opt_iaa_partition = true;
+    }
+    else if (strcmp(argv[k],"-fpia") == 0) {
+      opt_ia2_partition = true;
+      opt_fpia = true;
+    }
+    else if (strcmp(argv[k],"-pia1") == 0) {
+      opt_ia1_partition = true;
+      opt_optimal = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pia1a") == 0) {
+      opt_ia1_partition = true;
+      opt_iaa_partition = true;
+      opt_optimal = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-fpia1") == 0) {
+      opt_ia1_partition = true;
+      opt_fpia = true;
+      opt_optimal = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pbu") == 0) {
+      opt_bu_partition = true;
+    }
+    else if (strcmp(argv[k],"-pbug") == 0) {
+      opt_bu_partition = true;
+      opt_bu_glue = true;
+    }
+    else if ((strcmp(argv[k],"-pbu2") == 0) && (k < argc - 1)) {
+      opt_bu2_partition = true;
+      bu2_ratio = hsps::rational::ator(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-cnd") == 0) {
+      opt_new_decomposition = true;
+      opt_optimal = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pl") == 0) {
+      opt_layered_partition = true;
+    }
+    else if (strcmp(argv[k],"-pdb-ap") == 0) {
+      opt_all_pairs = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-load") == 0) {
+      opt_pdb_load = true;
+    }
+    else if (strcmp(argv[k],"-pdb-ai") == 0) {
+      opt_pdb_ai = true;
+      opt_optimal = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-ai-all") == 0) {
+      opt_pdb_ai_all = true;
+      opt_optimal = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-strict-ai") == 0) {
+      opt_pdb_ai = true;
+      opt_optimal = true;
+      opt_pdb_collapse = false;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-strict-ai-all") == 0) {
+      opt_pdb_ai_all = true;
+      opt_optimal = true;
+      opt_pdb_collapse = false;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-cg") == 0) {
+      opt_pdb_cg = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-int") == 0) {
+      opt_pdb_int = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-bin") == 0) {
+      opt_pdb_bin = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-rbin") == 0) {
+      opt_pdb_random_bin = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-rib") == 0) {
+      opt_pdb_independent_random_bin = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-strict-rib") == 0) {
+      opt_pdb_independent_random_bin = true;
+      opt_pdb_collapse = false;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if ((strcmp(argv[k],"-rbin-k") == 0) && (k < argc - 1)) {
+      opt_pdb_random_bin_k = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-rbin-swaps") == 0) && (k < argc - 1)) {
+      opt_pdb_random_bin_swaps = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-pdb-no-span") == 0) {
+      opt_pdb_spanning_subset = false;
+    }
+    else if (strcmp(argv[k],"-pdb-1") == 0) {
+      opt_pdb_1 = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-ip") == 0) {
+      opt_pdb_ind_pair = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-ibin") == 0) {
+      opt_pdb_ind_bin = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-wbin") == 0) {
+      opt_pdb_wbin = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-windbin") == 0) {
+      opt_pdb_windbin = true;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pdb-strict-windbin") == 0) {
+      opt_pdb_windbin = true;
+      opt_pdb_collapse = false;
+      opt_find_invariants = true;
+      opt_verify_invariants = true;
+    }
+    else if ((strcmp(argv[k],"-pdb-size") == 0) && (k < argc - 1)) {
+      opt_pdb_size = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-add") == 0) {
+      opt_pdb_add = true;
+    }
+    else if (strcmp(argv[k],"-no-add") == 0) {
+      opt_pdb_add = false;
+    }
+    else if (strcmp(argv[k],"-apx-add") == 0) {
+      opt_pdb_add = true;
+      opt_maximal_add = false;
+    }
+    else if ((strcmp(argv[k],"-xadd") == 0) && (k < argc - 1)) {
+      opt_pdb_add = true;
+      opt_pdb_ext_add = true;
+      ext_add_threshold = hsps::rational::ator(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-add-all") == 0) {
+      opt_pdb_add = true;
+      opt_pdb_add_all = true;
+    }
+    else if (strcmp(argv[k],"-red") == 0) {
+      opt_pdb_reduced = true;
+    }
+    else if (strcmp(argv[k],"-inc") == 0) {
+      opt_pdb_inc = true;
+    }
+    else if (strcmp(argv[k],"-no-inc") == 0) {
+      opt_pdb_inc = false;
+    }
+    else if (strcmp(argv[k],"-o") == 0) {
+      opt_optimal = true;
+    }
+    else if (strcmp(argv[k],"-non-optimal") == 0) {
+      opt_optimal = false;
+    }
+    else if (strcmp(argv[k],"-ac") == 0) {
+      opt_optimal = false;
+    }
+    else if ((strcmp(argv[k],"-look") == 0) && (k < argc - 1)) {
+      opt_look_ahead = true;
+      look_ahead_depth = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-bfs") == 0) {
+      opt_bfs = true;
+      opt_apply_cuts = false;
+    }
+    else if ((strcmp(argv[k],"-px") == 0) && (k < argc - 1)) {
+      opt_bfs_px = true;
+      px_threshold = hsps::rational::ator(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-bfs-write-stats") == 0) {
+      opt_bfs_write_stats = true;
+    }
+    else if (strcmp(argv[k],"-bfs-write-graph") == 0) {
+      opt_bfs_write_graph = true;
+    }
+    else if (strcmp(argv[k],"-bfs-write-graph-compact") == 0) {
+      opt_bfs_write_graph = true;
+      hsps::NodeSet::write_state_in_graph_node = false;
+    }
+    else if (strcmp(argv[k],"-bb") == 0) {
+      opt_bb = true;
+      opt_find_all = true;
+    }
+    else if (strcmp(argv[k],"-dfs") == 0) {
+      opt_dfs = true;
+    }
+    else if (strcmp(argv[k],"-lds") == 0) {
+      opt_lds = true;
+      opt_sequential = true;
+      opt_bb = true;
+      opt_find_all = true;
+    }
+    else if (strcmp(argv[k],"-bfida") == 0) {
+      opt_bfida = true;
+      opt_apply_cuts = false;
+    }
+    else if (strcmp(argv[k],"-cc") == 0) {
+      opt_cc = true;
+    }
+    else if (strcmp(argv[k],"-tt") == 0) {
+      opt_tt = true;
+    }
+    else if ((strcmp(argv[k],"-tt-size") == 0) && (k < argc - 1)) {
+      opt_tt_size = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-idao") == 0) {
+      opt_idao = true;
+    }
+    else if (strcmp(argv[k],"-post") == 0) {
+      opt_round_up = true;
+      opt_round = false;
+      opt_round_down = false;
+      opt_post_op = true;
+    }
+    else if (strcmp(argv[k],"-all") == 0) {
+      opt_find_all = true;
+    }
+    else if (strcmp(argv[k],"-all-different") == 0) {
+      if (!opt_exhaustive) opt_find_all = true;
+      opt_all_different = true;
+    }
+    else if (strcmp(argv[k],"-ex") == 0) {
+      opt_find_all = false;
+      opt_exhaustive = true;
+    }
+    else if ((strcmp(argv[k],"-k") == 0) && (k < argc - 1)) {
+      opt_find_n = true;
+      n_to_find = atoi(argv[++k]);
+    }
+    else if (((strcmp(argv[k],"-e") == 0) ||
+       (strcmp(argv[k],"-ed") == 0)) &&
+      (k < argc - 1)) {
+      opt_explore_to_depth = true;
+      depth_limit = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-eb") == 0) && (k < argc - 1)) {
+      opt_explore_to_bound = true;
+      cost_limit = hsps::rational::ator(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-print-solution-only") == 0) {
+      opt_print_solution_only = true;
+    }
+    else if (strcmp(argv[k],"-no-print-solution") == 0) {
+      opt_no_print_solution = true;
+    }
+    else if ((strcmp(argv[k],"-apx") == 0) && (k < argc - 1)) {
+      opt_apx = true;
+      apx_limit = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-t") == 0) && (k < argc - 1)) {
+      time_limit = atof(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-y") == 0) && (k < argc - 1)) {
+      memory_limit = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-s") == 0) && (k < argc - 1)) {
+      stack_limit = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-i") == 0) && (k < argc - 1)) {
+      iteration_limit = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-c") == 0) && (k < argc - 1)) {
+      cost_limit = hsps::rational::ator(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-ll") == 0) {
+      opt_limit_to_length = true;
+    }
+    else if ((strcmp(argv[k],"-n") == 0) && (k < argc - 1)) {
+      node_limit = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-val") == 0) {
+      opt_validate = true;
+    }
+    else if (strcmp(argv[k],"-no-plan") == 0) {
+      opt_print_plan = false;
+    }
+    else if (strcmp(argv[k],"-plan") == 0) {
+      opt_print_plan = true;
+    }
+    else if (strcmp(argv[k],"-pop") == 0) {
+      opt_print_plan = true;
+      opt_pop = true;
+    }
+    else if (strcmp(argv[k],"-path") == 0) {
+      opt_print_plan = true;
+      opt_path = true;
+    }
+    else if (strcmp(argv[k],"-g") == 0) {
+      opt_write_graphs = true;
+    }
+    else if (strcmp(argv[k],"-gantt") == 0) {
+      opt_gantt = true;
+      hsps::Schedule::GANTT_ACTION_NAMES_ON_CHART = false;
+    }
+    else if (strcmp(argv[k],"-pddl") == 0) {
+      opt_print_plan = true;
+      opt_pddl = true;
+      opt_ipc = false;
+    }
+    else if (strcmp(argv[k],"-ipc") == 0) {
+      opt_print_plan = true;
+      opt_ipc = true;
+      opt_pddl = false;
+    }
+    else if (strcmp(argv[k],"-strict-ipc") == 0) {
+      opt_print_plan = true;
+      opt_ipc = true;
+      opt_strict_ipc = true;
+      opt_pddl = false;
+    }
+    else if ((strcmp(argv[k],"-epsilon") == 0) && (k < argc - 1)) {
+      epsilon = hsps::rational::ator(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-nsn") == 0) {
+      hsps::Instance::write_atom_set_with_symbolic_names = false;
+      hsps::Instance::write_action_set_with_symbolic_names = false;
+    }
+    else if (strcmp(argv[k],"-print-rational") == 0) {
+      hsps::Print::decimal_time = false;
+    }
+    else if (strcmp(argv[k],"-save") == 0) {
+      opt_save = true;
+    }
+    else if (strcmp(argv[k],"-sas-min") == 0) {
+      opt_sas_min = true;
+    }
+    else if (strcmp(argv[k],"-sas-select") == 0) {
+      opt_sas_select = true;
+    }
+    else if (((strcmp(argv[k],"-rnd") == 0) ||
+       (strcmp(argv[k],"-r") == 0)) &&
+      (k < argc - 1)) {
+      rnd_seed = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-exclude") == 0) && (k < argc - 1)) {
+      char* tag = argv[++k];
+      if (strcmp(tag, "all") == 0) {
+ hsps::PDDL_Base::exclude_all_dkel_items = true;
+      }
+      else {
+ const hsps::StringTable::Cell* c = symbols.find(tag);
+ if (c) hsps::PDDL_Base::excluded_dkel_tags.insert(c->text);
+      }
+    }
+    else if ((strcmp(argv[k],"-require") == 0) && (k < argc - 1)) {
+      const hsps::StringTable::Cell* c = symbols.find(argv[++k]);
+      if (c) hsps::PDDL_Base::required_dkel_tags.insert(c->text);
+    }
+    else if (strcmp(argv[k],"-strict") == 0) {
+      hsps::PDDL_Base::best_effort = false;
+    }
+    else if (*argv[k] != '-') {
+      parse_stats.start();
+      reader->read(argv[k], false);
+      parse_stats.stop();
+    }
+  }
+  hsps::SearchAlgorithm::default_trace_level = verbose_level;
+  hsps::Heuristic::default_trace_level = verbose_level - 1;
+  hsps::Instance::default_trace_level = verbose_level - 1;
+  hsps::Preprocessor::default_trace_level = verbose_level - 1;
+  bool opt_pdb = (opt_pdb_load || opt_pdb_bin || opt_pdb_random_bin ||
+    (opt_pdb_independent_random_bin &&
+     (opt_pdb_random_bin_k == 0)) ||
+    opt_pdb_cg || opt_pdb_int || opt_pdb_1 ||
+    opt_pdb_ind_pair || opt_pdb_ind_bin || opt_pdb_wbin ||
+    opt_pdb_windbin);
+  if (opt_pdb || opt_all_pairs || opt_pdb_ai ||
+      opt_pdb_ai_all || (opt_pdb_random_bin_k > 0))
+    opt_sas = true;
+  hsps::Instance instance;
+  hsps::cost_vec saved_dur;
+  hsps::cost_vec saved_res;
+  hsps::Statistics stats;
+  hsps::rational root_est_cost = 0;
+  bool solved = false;
+  bool optimally = false;
+  hsps::rational solution_cost = 0;
+  hsps::Store store(instance);
+  hsps::Statistics look_ahead_stats;
+  hsps::HashTable* tt = 0;
+  hsps::LC_RNG rnd_source;
+  if (rnd_seed > 0) rnd_source.seed(rnd_seed);
+  stats.enable_interrupt(false);
+  if (time_limit > 0) stats.enable_time_out(time_limit, false);
+  if (memory_limit > 0) stats.enable_memory_limit(memory_limit, false);
+  if (stack_limit > 0) stats.enable_stack_limit(stack_limit, false);
+  stats.start();
+  std::cerr << "instantiating..." << std::endl;
+  reader->instantiate(instance);
+  if (opt_resource && opt_compose && (instance.n_resources() > 1)) {
+    hsps::mSubsetEnumerator crs(instance.n_resources(),
+    composite_resource_size);
+    bool more = crs.first();
+    while (more) {
+      hsps::index_set s;
+      crs.current_set(s);
+      instance.create_composite_resource(s);
+      more = crs.next();
+    }
+  }
+  hsps::Preprocessor prep(instance, stats);
+  if (opt_preprocess) {
+    std::cerr << "preprocessing..." << std::endl;
+    prep.preprocess();
+    if (opt_rm_irrelevant) {
+      prep.compute_irrelevant_atoms();
+      prep.remove_irrelevant_atoms();
+      if (!instance.cross_referenced()) {
+ std::cerr << "re-cross referencing..." << std::endl;
+ instance.cross_reference();
+      }
+    }
+  }
+  else {
+    std::cerr << "cross referencing..." << std::endl;
+    instance.cross_reference();
+  }
+  if (opt_quick_find_invariants) {
+    hsps::graph* g_inc = prep.inconsistency_graph();
+    prep.find_inconsistent_set_invariants(*g_inc);
+    instance.add_missing_negation_invariants();
+  }
+  else if (opt_find_invariants) {
+    prep.bfs_find_invariants();
+  }
+  if (opt_negation_invariants) {
+    instance.add_missing_negation_invariants();
+  }
+  if (opt_verify_invariants) {
+    prep.verify_invariants(*(prep.inconsistency()));
+    prep.remove_unverified_invariants();
+  }
+  if (opt_extend_goal) {
+    hsps::index_set new_goals;
+    prep.implied_atom_set(instance.goal_atoms,new_goals,*prep.inconsistency());
+    std::cerr << new_goals.length() << " implied goals found" << std::endl;
+    if (new_goals.length() > 0) {
+      hsps::index_set new_goal(instance.goal_atoms);
+      new_goal.insert(new_goals);
+      instance.set_goal(new_goal);
+    }
+  }
+  instance.save_durations(saved_dur);
+  if (opt_unit) {
+    for (hsps::index_type k = 0; k < instance.n_actions(); k++) {
+      instance.actions[k].cost = 1;
+      instance.actions[k].dmin = 1;
+      instance.actions[k].dmax = 1;
+      instance.actions[k].dur = 1;
+    }
+  }
+  else if (opt_d_val > 0) instance.discretize_durations(opt_d_val);
+  else if (opt_q_val > 0) instance.quantize_durations(opt_q_val);
+  else if (opt_round_up) instance.round_durations_up();
+  else if (opt_round_down) instance.round_durations_down();
+  else if (opt_round) instance.round_durations();
+  if (opt_unlimited) instance.assign_unlimited_resources(saved_res);
+  stats.stop();
+  std::cerr << "instance " << instance.name << " built in "
+     << stats.time() << " seconds" << std::endl;
+  std::cerr << instance.n_atoms() << " atoms ("
+     << instance.goal_atoms.length() << " goals), "
+     << instance.n_resources() << " resources ("
+     << instance.n_reusable_resources() << " reusable, "
+     << instance.n_consumable_resources() << " consumable), "
+     << instance.n_actions() << " actions, "
+     << instance.n_invariants() << " invariants"
+     << std::endl;
+  if (verbose_level > 2) {
+    instance.print(std::cerr);
+  }
+  if (!stats.break_signal_raised()) {
+    stats.start();
+    hsps::Heuristic* cost_est = 0;
+    hsps::estimator_vec resource_est(0, instance.n_resources());
+    if (opt_load_h) {
+      hsps::CostTable* cost_tab = new hsps::CostTable(instance, stats);
+      std::cerr << "loading heuristic table (" << reader->h_table.length()
+  << " entries)..." << std::endl;
+      reader->export_heuristic(instance, prep.atom_map, true, *cost_tab);
+      cost_est = cost_tab;
+    }
+    else if (opt_AH) {
+      std::cerr << "computing AH heuristic..." << std::endl;
+      hsps::AH* h = new hsps::AH(instance, stats);
+      if (opt_load_partition) {
+ stats.start();
+ hsps::name_vec pnames(0, 0);
+ hsps::index_set_vec partition;
+ reader->export_action_partitions(pnames, partition);
+ if (partition.length() == 0) {
+   std::cerr << "warning: action partitioning not defined by domain"
+      << " - trying alternate load method..." << std::endl;
+   hsps::name_vec anames(0, 0);
+   instance.action_names(anames);
+   reader->export_sets(anames, partition);
+ }
+ if (partition.length() == 0) {
+   std::cerr << "warning: no action partitioning loaded" << std::endl;
+ }
+ instance.remap_sets(partition, prep.action_map);
+ if (opt_cost) {
+   h->compute_additive(hsps::CostACF(instance), partition, !opt_H1);
+   if (opt_AH_max) h->compute_max(hsps::CostACF(instance), true);
+ }
+ else {
+   h->compute_additive(hsps::UnitACF(), partition, !opt_H1);
+   if (opt_AH_max) h->compute_max(hsps::UnitACF(), true);
+ }
+ stats.stop();
+      }
+      else if (opt_ia1_partition) {
+ if (opt_iaa_partition) {
+   hsps::index_set a;
+   a.fill(instance.n_atoms());
+   if (opt_cost)
+     h->compute_with_iterative_assignment_1
+       (hsps::CostACF(instance), a, !opt_H1, opt_fpia, opt_optimal,
+        instance.goal_atoms);
+   else
+     h->compute_with_iterative_assignment_1
+       (hsps::UnitACF(), a, !opt_H1, opt_fpia, opt_optimal,
+        instance.goal_atoms);
+   if (!opt_AH_max) h->disable_max();
+ }
+ else {
+   if (opt_cost)
+     h->compute_with_iterative_assignment_1
+       (hsps::CostACF(instance), instance.goal_atoms,
+        !opt_H1, opt_fpia, opt_optimal, instance.goal_atoms);
+   else
+     h->compute_with_iterative_assignment_1
+       (hsps::UnitACF(), instance.goal_atoms,
+        !opt_H1, opt_fpia, opt_optimal, instance.goal_atoms);
+   if (!opt_AH_max) h->disable_max();
+ }
+      }
+      else if (opt_ia2_partition) {
+ if (opt_iaa_partition) {
+   hsps::index_set a;
+   a.fill(instance.n_atoms());
+   if (opt_cost)
+     h->compute_with_iterative_assignment_2
+       (hsps::CostACF(instance),a,!opt_H1,opt_fpia,instance.goal_atoms);
+   else
+     h->compute_with_iterative_assignment_2
+       (hsps::UnitACF(), a, !opt_H1, opt_fpia, instance.goal_atoms);
+   if (!opt_AH_max) h->disable_max();
+ }
+ else {
+   if (opt_cost)
+     h->compute_with_iterative_assignment_2
+       (hsps::CostACF(instance), instance.goal_atoms,
+        !opt_H1, opt_fpia, instance.goal_atoms);
+   else
+     h->compute_with_iterative_assignment_2
+       (hsps::UnitACF(), instance.goal_atoms,
+        !opt_H1, opt_fpia, instance.goal_atoms);
+   if (!opt_AH_max) h->disable_max();
+ }
+      }
+      else if (opt_bu2_partition) {
+ if (opt_cost) {
+   h->compute_bottom_up_2
+     (hsps::CostACF(instance), instance.goal_atoms,
+      (hsps::index_type)((bu2_ratio * instance.n_atoms()).ceil().numerator()),
+      !opt_H1);
+   h->compute_max(hsps::UnitACF(), true);
+ }
+ else {
+   h->compute_bottom_up_2
+     (hsps::UnitACF(), instance.goal_atoms,
+      (hsps::index_type)((bu2_ratio * instance.n_atoms()).ceil().numerator()),
+      !opt_H1);
+   h->compute_max(hsps::UnitACF(), true);
+ }
+      }
+      else if (opt_bu_partition) {
+ if (opt_cost) {
+   h->compute_bottom_up(hsps::CostACF(instance), instance.goal_atoms, opt_bu_glue, !opt_H1);
+ }
+ else {
+   h->compute_bottom_up(hsps::UnitACF(), instance.goal_atoms, opt_bu_glue, !opt_H1);
+ }
+      }
+      else if (opt_new_decomposition) {
+ if (opt_cost) {
+   h->compute_with_new_decomposition(hsps::CostACF(instance),
+         instance.goal_atoms, !opt_H1);
+   if (opt_AH_max) h->compute_max(hsps::CostACF(instance), true);
+ }
+ else {
+   h->compute_with_new_decomposition(hsps::UnitACF(),
+         instance.goal_atoms, !opt_H1);
+   if (opt_AH_max) h->compute_max(hsps::UnitACF(), true);
+ }
+      }
+      else if (opt_layered_partition) {
+ if (opt_cost)
+   h->compute_with_layered_partitioning
+     (hsps::CostACF(instance), instance.goal_atoms);
+ else
+   h->compute_with_layered_partitioning
+     (hsps::UnitACF(), instance.goal_atoms);
+ if (!opt_AH_max) h->disable_max();
+      }
+      else {
+ if (opt_cost)
+   h->compute_with_relevance_partitioning
+     (hsps::CostACF(instance), instance.goal_atoms);
+ else
+   h->compute_with_relevance_partitioning
+     (hsps::UnitACF(), instance.goal_atoms);
+ if (!opt_AH_max) h->disable_max();
+      }
+      if (!stats.break_signal_raised()) {
+ std::cerr << "heuristic computed in " << stats.time()
+    << " seconds" << std::endl;
+      }
+      if (opt_structured) {
+ hsps::index_set invs;
+ for (hsps::index_type k = 0; k < instance.n_invariants(); k++)
+   if ((instance.invariants[k].lim == 1) &&
+       !instance.invariants[k].set.empty() &&
+       instance.invariants[k].exact)
+     invs.insert(k);
+ if (invs.length() > 1) {
+   hsps::CombineNByMax* h_max = new hsps::CombineNByMax(instance);
+   for (hsps::index_type k = 0; k < invs.length(); k++) {
+     hsps::HX* hx =
+       new hsps::HX(instance, *h, instance.invariants[invs[k]].set);
+     h_max->add(hx);
+   }
+   cost_est = h_max;
+ }
+ else if (invs.length() == 1) {
+   hsps::HX* hx =
+     new hsps::HX(instance, *h, instance.invariants[invs[0]].set);
+   cost_est = hx;
+ }
+ else {
+   cost_est = h;
+ }
+      }
+      else if ((opt_fpia || opt_new_decomposition) && !opt_cost) {
+ cost_est = new hsps::RoundUp(instance, *h);
+      }
+      else {
+ cost_est = h;
+      }
+    }
+    else {
+      std::cerr << "computing heuristic..." << std::endl;
+      hsps::CostTable* cost_tab = new hsps::CostTable(instance, stats);
+      if (opt_H1) {
+ if (opt_temporal)
+   cost_tab->compute_H1(hsps::MakespanACF(instance));
+ else if (opt_sequential && opt_cost)
+   cost_tab->compute_H1(hsps::CostACF(instance));
+ else
+   cost_tab->compute_H1(hsps::UnitACF());
+      }
+      else if (!opt_H0) {
+ if (opt_temporal) {
+   cost_tab->compute_H2C(hsps::MakespanACF(instance), opt_resource);
+ }
+ else if (opt_sequential) {
+   if (opt_H3) {
+     if (opt_cost)
+       cost_tab->compute_H3(hsps::CostACF(instance));
+     else
+       cost_tab->compute_H3(hsps::UnitACF());
+   }
+   else {
+     if (opt_cost)
+       cost_tab->compute_H2(hsps::CostACF(instance));
+     else
+       cost_tab->compute_H2(hsps::UnitACF());
+   }
+ }
+ else {
+   cost_tab->compute_H2C(hsps::UnitACF(), false);
+ }
+      }
+      if (!stats.break_signal_raised()) {
+ std::cerr << "heuristic computed in " << stats.time()
+    << " seconds" << std::endl;
+ if (opt_save) {
+   if (opt_pddl) {
+     cost_tab->write_pddl(std::cout, instance);
+   }
+   else {
+     std::cout << "heuristic table:" << std::endl;
+     cost_tab->write(std::cout);
+   }
+   if (!opt_resource) exit(0);
+ }
+      }
+      cost_est = cost_tab;
+    }
+    if (opt_apply_invariants) {
+      hsps::RegressionInvariantCheck* ic =
+ new hsps::RegressionInvariantCheck(instance, *cost_est,
+        opt_verify_invariants);
+      cost_est = ic;
+    }
+    if (opt_eval_cache) {
+      hsps::EvalActionCache* eac =
+ new hsps::EvalActionCache(instance, *cost_est);
+      cost_est = eac;
+    }
+    if (opt_ncw && !stats.break_signal_raised()) {
+      std::cerr << "computing n.c.w. sets..." << std::endl;
+      stats.start();
+      prep.compute_ncw_sets(*cost_est);
+      stats.stop();
+    }
+    if (opt_resource && !opt_R0 && !stats.break_signal_raised()) {
+      std::cerr << "computing resource estimators..." << std::endl;
+      stats.start();
+      for (hsps::index_type k = 0; k < instance.n_resources(); k++) {
+ if (opt_R2) {
+   hsps::CostTable* rce = new hsps::CostTable(instance, stats);
+   rce->compute_H2(hsps::ResourceConsACF(instance, k));
+   if (verbose_level > 2) {
+     std::cout << "resource " << instance.resources[k].name
+        << " estimator:" << std::endl;
+     rce->write(std::cout);
+   }
+   resource_est[k] = rce;
+ }
+ else {
+   hsps::CostTable* rce = new hsps::CostTable(instance, stats);
+   rce->compute_H1(hsps::ResourceConsACF(instance, k));
+   if (verbose_level > 2) {
+     std::cout << "resource " << instance.resources[k].name
+        << " estimator:" << std::endl;
+     rce->write(std::cout);
+   }
+   resource_est[k] = rce;
+ }
+      }
+      stats.stop();
+    }
+    if (!stats.break_signal_raised()) {
+      if (opt_save && opt_resource) {
+ for (hsps::index_type k = 0; k < instance.n_resources(); k++) {
+   if (opt_pddl) {
+     std::cout << ";; resource " << instance.resources[k].name
+        << std::endl;
+     ((hsps::CostTable*)resource_est[k])->write_pddl(std::cout, instance);
+   }
+   else {
+     std::cout << "resource " << instance.resources[k].name
+        << " estimator:" << std::endl;
+     ((hsps::CostTable*)resource_est[k])->write(std::cout);
+   }
+ }
+ exit(0);
+      }
+      hsps::State* search_root = 0;
+ hsps::ACF* acf =
+   (opt_cost ? (hsps::ACF*)new hsps::CostACF(instance) : (hsps::ACF*)new hsps::UnitACF());
+ hsps::RegressionResourceState* rcs =
+   (opt_resource ? new hsps::RegressionResourceState(instance, resource_est) : 0);
+ if (opt_apx) {
+   search_root = new hsps::ApxSeqRegState
+     (instance, *cost_est, *acf, instance.goal_atoms, rcs, apx_limit);
+ }
+ else if (opt_apply_cuts) {
+   search_root = new hsps::SeqCRegState
+     (instance, *cost_est, *acf, instance.goal_atoms, rcs);
+ }
+ else {
+   search_root = new hsps::SeqRegState
+     (instance, *cost_est, *acf, instance.goal_atoms, rcs);
+ }
+      std::cerr << "search root: " << *search_root
+  << " (est. cost: " << search_root->est_cost() << ")"
+  << std::endl;
+      std::cerr << "estimated goal cost: "
+  << cost_est->eval(instance.goal_atoms)
+  << std::endl;
+      hsps::SearchAlgorithm* search = 0;
+      hsps::SearchResult* result = &store;
+      if (opt_bfs) {
+ if (opt_bfs_px) {
+   std::cerr << "using partial expansion A*..." << std::endl;
+   search = new hsps::BFS_PX(stats, *result, px_threshold);
+ }
+ else {
+   std::cerr << "using A*..." << std::endl;
+   search = new hsps::BFS(stats, *result);
+ }
+      }
+      else if (opt_tt) {
+ std::cerr << "using IDA* with transposition table..." << std::endl;
+ tt = new hsps::HashTable(opt_tt_size);
+ hsps::IDA* ida_search = new hsps::IDA(stats, *result, tt);
+ ida_search->set_cycle_check(opt_cc);
+ if (iteration_limit > 0)
+   ida_search->set_iteration_limit(iteration_limit);
+ search = ida_search;
+      }
+      else {
+ std::cerr << "using IDA*..." << std::endl;
+ hsps::IDA* ida_search = new hsps::IDA(stats, *result);
+ ida_search->set_cycle_check(opt_cc);
+ if (iteration_limit > 0)
+   ida_search->set_iteration_limit(iteration_limit);
+ search = ida_search;
+      }
+      search->set_problem_name(instance.name);
+      if (opt_limit_to_length) {
+ if (opt_sequential) {
+   cost_limit = reader->serial_length;
+ }
+ else {
+   cost_limit = reader->parallel_length;
+ }
+      }
+      if ((cost_limit).finite()) search->set_cost_limit(cost_limit);
+      if (node_limit > 0) search->set_node_limit(node_limit);
+      root_est_cost = search_root->est_cost();
+      std::cerr << "searching..." << std::endl;
+      solution_cost = search->start(*search_root);
+      if (!stats.break_signal_raised()) {
+ std::cerr << "search complete (" << stats << ")" << std::endl;
+      }
+      solved = search->solved();
+      optimally = search->optimal();
+      if (!search->optimal())
+ solution_cost = search->cost();
+      if (opt_bfs && opt_bfs_write_graph) {
+ hsps::NodeSet& g = ((hsps::BFS*)search)->state_space();
+ g.mark_solved();
+ g.write_graph(std::cout);
+      }
+      if (opt_bfs && opt_bfs_write_stats) {
+ hsps::NodeSet& g = ((hsps::BFS*)search)->state_space();
+ g.mark_solved();
+ g.write_short(std::cout, instance.name);
+      }
+    }
+  }
+  if (opt_ipc || (verbose_level == 0)) {
+    if (opt_ipc) {
+      std::cout << "; Time " << hsps::Stopwatch::seconds() << std::endl;
+      std::cout << "; ParsingTime " << parse_stats.total_time() << std::endl;
+      if (solved) {
+ if (opt_sequential) {
+   if (opt_cost) {
+     std::cout << "; NrActions " << std::endl;
+     std::cout << "; MakeSpan " << std::endl;
+     std::cout << "; MetricValue " << std::resetiosflags(std::ios::scientific) << ((solution_cost).decimal())
+        << std::endl;
+   }
+   else {
+     std::cout << "; NrActions " << solution_cost << std::endl;
+     std::cout << "; MakeSpan " << std::endl;
+     std::cout << "; MetricValue " << std::endl;
+   }
+ }
+ else {
+   std::cout << "; NrActions " << std::endl;
+   std::cout << "; MakeSpan " << std::resetiosflags(std::ios::scientific) << ((solution_cost).decimal())
+      << std::endl;
+   std::cout << "; MetricValue " << std::endl;
+ }
+ hsps::PrintIPC print_plan(instance, std::cout);
+ if (opt_temporal) print_plan.set_epsilon(epsilon, false, opt_strict_ipc);
+ store.output(print_plan);
+      }
+      else {
+ std::cout << "; Not Solved (" << stats.flags() << ")" << std::endl;
+      }
+    }
+    else if (opt_pddl) {
+      if (solved && opt_print_plan) {
+ hsps::PrintPDDL print_plan(instance, std::cout);
+ store.output(print_plan);
+      }
+    }
+    if (opt_ipc || opt_pddl)
+      std::cout << ";; stats: ";
+    std::cout << instance.name
+       << ' ' << (solved ? 1 : 0)
+       << ' ' << (optimally ? 1 : 0)
+       << ' ' << std::resetiosflags(std::ios::scientific) << ((root_est_cost).decimal())
+       << ' ' << std::resetiosflags(std::ios::scientific) << ((solution_cost).decimal())
+       << ' ' << stats.total_nodes()
+       << ' ' << stats.total_time()
+       << ' ' << stats.peak_memory()
+       << ' ' << stats.peak_stack_size()
+       << ' ' << stats.complete_iterations()
+       << ' ' << stats.nodes_at_max_lower_bound()
+       << ' ' << stats.time()
+       << ' ' << hsps::AH::Hsum_wins/((double)(hsps::AH::Hsum_wins + hsps::AH::Hmax_wins + hsps::AH::draws))
+       << ' ' << hsps::AH::draws/((double)(hsps::AH::Hsum_wins + hsps::AH::Hmax_wins + hsps::AH::draws))
+       << std::endl;
+    if (opt_ipc || opt_pddl) {
+      std::cout << ";; ";
+      std::cout << "(:heuristic (";
+      for (hsps::index_type k = 0; k < instance.goal_atoms.length(); k++)
+ std::cout << instance.atoms[instance.goal_atoms[k]].name;
+      std::cout << ") " << stats.max_lower_bound() << ")" << std::endl;
+    }
+  }
+  else {
+    if (solved) {
+      std::cout << "solution cost: " << solution_cost;
+      if (optimally)
+ std::cout << " (optimal)";
+      else
+ std::cout << " (upper bound)";
+      std::cout << std::endl;
+      std::cout << store.n_solutions() << " solutions";
+      if (opt_all_different) {
+ std::cout << " (" << hsps::StoreDistinct::n_discarded
+    << " equivalent solutions discarded)";
+      }
+      std::cout << std::endl;
+    }
+    else {
+      std::cout << "no solution found" << std::endl;
+    }
+    stats.print_total(std::cout);
+    stats.print(std::cout, "(search) ");
+    std::cerr << "highest lower bound " << stats.max_lower_bound()
+       << " proven at " << stats.nodes_at_max_lower_bound()
+       << " nodes" << std::endl;
+    if (opt_look_ahead) {
+      std::cout << "look ahead searches: " << look_ahead_stats << std::endl;
+    }
+    double total_t = hsps::Stopwatch::seconds();
+    std::cout << total_t << " seconds total ("
+       << total_t - stats.total_time()
+       << " sec. not accounted for)" << std::endl;
+    std::cout << "peak memory use: " << stats.peak_memory() << "k"
+       << ", peak stack size: " << stats.peak_stack_size() << "k"
+       << std::endl;
+    if (opt_load_compare) {
+      hsps::count_type n = hsps::CompareEval::lower +
+ hsps::CompareEval::higher +
+ hsps::CompareEval::equal;
+      std::cout << "Alt. H: " << hsps::CompareEval::lower << " lower ("
+  << (hsps::CompareEval::lower/(double)n)*100 << "%), "
+  << hsps::CompareEval::higher << " higher ("
+  << (hsps::CompareEval::higher/(double)n)*100 << "%), "
+  << hsps::CompareEval::equal << " equal ("
+  << (hsps::CompareEval::equal/(double)n)*100 << "%)"
+  << std::endl;
+    }
+    if (opt_AH) {
+      std::cout << "AH: " << hsps::AH::Hmax_wins << " Hmax, "
+  << hsps::AH::Hsum_wins << " Hsum, "
+  << hsps::AH::draws << " equal ("
+  << (hsps::AH::Hsum_wins/((double)(hsps::AH::Hsum_wins + hsps::AH::Hmax_wins + hsps::AH::draws)))*100
+  << "% improved, "
+  << (hsps::AH::draws/((double)(hsps::AH::Hsum_wins + hsps::AH::Hmax_wins + hsps::AH::draws)))*100
+  << "% equal)" << std::endl;
+    }
+    if (opt_tt || opt_idao) {
+      assert(tt);
+      std::cout << "transposition table stats: TUF = " << tt->TUF()
+  << ", HCF: " << tt->HCF() << std::endl;
+    }
+    if (solved && opt_print_plan) {
+      if (opt_pddl) {
+ hsps::PrintPDDL print_plan(instance, std::cout);
+ store.output(print_plan);
+      }
+      else {
+ for (hsps::index_type p = 0; p < store.n_solutions(); p++) {
+   hsps::Schedule* plan = store.plan(p);
+   hsps::State* path_end_state = store.solution(p);
+   std::cout << "plan #" << p << ":" << std::endl;
+   hsps::Print print_plan(instance, std::cout);
+   plan->output(print_plan);
+ }
+      }
+    }
+  }
+  return 0;
+}

--- a/pr/seq-opt-hspsf/hsp_f.ccx
+++ b/pr/seq-opt-hspsf/hsp_f.ccx
@@ -1,0 +1,9105 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+void sort2(index_type& i, index_type& j);
+void sort3(index_type& i, index_type& j, index_type& l);
+class PairIndexFunction : index_vec {
+ public:
+  PairIndexFunction(index_type n);
+  ~PairIndexFunction();
+  index_type operator()(index_type i, index_type j) const;
+  index_type max_in() const;
+  index_type max_out() const;
+};
+class CostNode {
+ public:
+  struct Value {
+    hsps::rational val;
+    bool opt;
+    CostNode* next;
+    bool mark;
+    count_type work;
+    Value() : val(0), opt(false), next(0), mark(false), work(0) { };
+    Value(hsps::rational v, bool o) : val(v), opt(o), next(0), mark(false), work(0) { };
+    Value& operator=(const Value& v)
+    { val = v.val; opt = v.opt; return *this; };
+    Value& operator=(hsps::rational v) { val = v; return *this; };
+    bool operator==(const Value& v) { return (val == v.val); };
+    bool operator<(const Value& v) { return (val < v.val); };
+    bool operator<=(const Value& v) { return (val <= v.val); };
+    bool operator>(const Value& v) { return (val > v.val); };
+    bool operator>=(const Value& v) { return (val >= v.val); };
+    bool operator==(const hsps::rational v) { return (val == v); };
+    bool operator<(const hsps::rational v) { return (val < v); };
+    bool operator<=(const hsps::rational v) { return (val <= v); };
+    bool operator>(const hsps::rational v) { return (val > v); };
+    bool operator>=(const hsps::rational v) { return (val >= v); };
+    void clear() {
+      val = 0;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+    void clear(hsps::rational v_default) {
+      val = v_default;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+  };
+ private:
+  index_type _size;
+  index_type _depth;
+  index_type _first;
+  hsps::rational _default;
+  hsps::rational _max;
+  Value* _store;
+  CostNode* _prev;
+  CostNode(CostNode* p, index_type f);
+  hsps::rational eval(const index_set& s, index_type i);
+  hsps::rational eval(const bool_vec& s, index_type i);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, index_type i, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, index_type i, hsps::rational bound);
+  void find_all(const index_set& s, index_type i, const index_set& c,
+   index_set_vec& a);
+  void set_max(hsps::rational v);
+  void write(std::ostream& s, index_set q) const;
+  void write_pddl(std::ostream& s, Instance& ins, index_set q) const;
+ public:
+  static bool eval_set_mark;
+  CostNode(index_type size);
+  CostNode(index_type size, hsps::rational v_default);
+  ~CostNode();
+  index_type size() const { return _size; };
+  index_type depth() const { return _depth; };
+  index_type first() const { return _first; };
+  index_type last() const { return _size - 1; };
+  Value& val(index_type p);
+  const Value& val(index_type p) const;
+  hsps::rational max() const { return _max; };
+  hsps::rational max_finite() const;
+  CostNode& next(index_type p);
+  Value* val_p(index_type p);
+  CostNode* next_p(index_type p);
+  Value* find(const index_set& s);
+  Value* find(const bool_vec& s);
+  void find_all(const index_set& s, index_set_vec& a);
+  Value& insert(const index_set& s);
+  Value& insert(const bool_vec& s);
+  void store(index_type p, hsps::rational v, bool opt);
+  void store(index_type p, hsps::rational v);
+  hsps::rational eval(const index_set& s);
+  hsps::rational eval(const bool_vec& s);
+  hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  void store(const index_set& s, hsps::rational v, bool opt);
+  void store(const bool_vec& s, hsps::rational v, bool opt);
+  void store(const index_set& s, hsps::rational v);
+  void store(const bool_vec& s, hsps::rational v);
+  hsps::rational eval_min(const index_set& s);
+  void compute_max();
+  void clear_marks();
+  void clear();
+  void write(std::ostream& s) const;
+  void write_pddl(std::ostream& s, Instance& ins) const;
+};
+class CostTable : public Heuristic, public CostNode {
+ public:
+  class Entry {
+  public:
+    index_set set;
+    CostNode::Value& val;
+    Entry* prev;
+    Entry* next;
+    Entry(index_set s, CostNode::Value& v)
+      : set(s), val(v), prev(0), next(0) { };
+    Entry& operator=(const Entry& e);
+    bool operator==(const Entry& e) { return set == e.set; };
+    bool operator<(const Entry& e) { return val < e.val; };
+    bool operator<=(const Entry& e) { return val <= e.val; };
+    bool operator>(const Entry& e) { return val > e.val; };
+    bool operator>=(const Entry& e) { return val >= e.val; };
+    Entry* first();
+    Entry* last();
+    Entry* move_down();
+    Entry* move_up();
+    void unlink();
+    void place_before(Entry* p);
+    void place_after(Entry* p);
+    void delete_list();
+    count_type list_length();
+  };
+ private:
+  Statistics& stats;
+  hsps::rational* pre_cost;
+  hsps::rational* per_cost;
+  bool update(index_type i, hsps::rational v, bool_vec& f);
+  bool update(index_type i, hsps::rational v);
+  bool update(index_type i, index_type j, hsps::rational v);
+  bool update(index_type i, index_type j, index_type l, hsps::rational v);
+  Entry* entries(CostNode* n, index_set s, Entry* l,
+   const index_set* filter, bool ign_zero, bool ign_opt,
+   bool ign_inf, bool req_mark, bool sort);
+  count_type count_entries(CostNode* n, index_set s, bool ign_zero,
+      bool ign_opt, bool ign_inf);
+  void fill(index_set& s, index_type d);
+  Entry* create_new_entries(const index_set& set,
+       const index_set& conflict_set,
+       const index_set& cd_ignore,
+       CostTable::Entry* list);
+  void compute_hm_graph_min
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+  void compute_hm_graph_max
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+ public:
+  static bool strong_conflict_detection;
+  static bool ultra_weak_conflict_detection;
+  static bool boost_new_entries;
+  static count_type n_entries_boosted;
+  static count_type n_entries_solved;
+  static count_type n_entries_discarded;
+  static count_type n_entries_created;
+  static count_type n_boost_searches;
+  static count_type n_boost_searches_with_cd;
+  CostTable(Instance& i, Statistics& s);
+  CostTable(Instance& i, Statistics& s, hsps::rational v_default);
+  ~CostTable();
+  virtual hsps::rational eval(index_type i);
+  virtual hsps::rational eval(index_type i, index_type j);
+  virtual hsps::rational eval(index_type i, index_type j, index_type k);
+  virtual hsps::rational eval(const index_set& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational eval(const bool_vec& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual void store(const index_set& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const index_set& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  virtual void store(const bool_vec& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  void store_list(Entry* l);
+  static Entry* insert_entry(Entry* e, Entry* l);
+  static Entry* prepend_entry(Entry* e, Entry* l);
+  static Entry* remove_entry(Entry* e, Entry* l);
+  static Entry* find_entry(index_set& s, Entry* l);
+  static Entry* copy_list(Entry* l);
+  count_type write_list(std::ostream& s, Entry* l);
+  bool interesting(const index_set& s);
+  Entry* atoms();
+  Entry* pairs();
+  Entry* entries();
+  Entry* entries(bool ign_zero, bool ign_opt, bool ign_inf, bool req_mark);
+  Entry* entries(const index_set& s);
+  Entry* unsorted_entries(bool ign_zero, bool ign_opt, bool ign_inf,
+     bool req_mark);
+  Entry* boostable_entries();
+  Entry* boostable_entries(const index_set& s);
+  Entry* boost_cd_entries();
+  Entry* marked_entries(bool ign_nb);
+  count_type count_entries(bool ign_zero, bool ign_opt, bool ign_inf);
+  hsps::rational action_pre_cost(index_type i);
+  hsps::rational action_per_cost(index_type i);
+  bool compatible(index_type a, index_type b, bool opt_resources) const;
+  void compute_H1(const ACF& cost);
+  void compute_H1(const ACF& cost, const bool_vec& init);
+  void compute_H1max(const ACF& cost, const bool_vec& init);
+  void compute_H2(const ACF& cost);
+  void compute_H2(const ACF& cost, const bool_vec& init);
+  void compute_H3(const ACF& cost);
+  void compute_H2C(const ACF& cost, bool opt_resources);
+  void verify_H2C(const ACF& cost, bool opt_resources, bool opt_verbose);
+  void compute_action_cost();
+  void fill(index_type to_depth);
+  void clear();
+  void closure(const ACF& cost);
+  void closure(const ACF& cost, const index_set& nd);
+  void compute_hm_graph(const ACF& cost, const index_set& s,
+   index_set_graph& g);
+};
+class LinearScanH2Eval : public CostTable {
+  index_type n_pairs;
+  index_pair* pairs;
+  hsps::rational* values;
+  bool complete;
+ public:
+  LinearScanH2Eval(Instance& i, Statistics& s);
+  ~LinearScanH2Eval();
+  void compile_finite();
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH1 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH1(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH1();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH2 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH2(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH2();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+inline void sort2(index_type& i, index_type& j)
+{
+  if (i > j) {
+    index_type t = i;
+    i = j;
+    j = t;
+  }
+}
+inline void sort3(index_type& i, index_type& j, index_type& l)
+{
+  sort2(i, l);
+  sort2(i, j);
+  sort2(j, l);
+}
+inline CostNode::Value& CostNode::val(index_type p)
+{
+  return _store[p];
+}
+inline const CostNode::Value& CostNode::val(index_type p) const
+{
+  return _store[p];
+}
+inline CostNode::Value* CostNode::val_p(index_type p)
+{
+  return &(_store[p]);
+}
+inline CostNode& CostNode::next(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return *(_store[p].next);
+}
+inline CostNode* CostNode::next_p(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return _store[p].next;
+}
+inline CostTable::Entry& CostTable::Entry::operator=(const Entry& e)
+{
+  set = e.set;
+  val = e.val;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode::Value& v)
+{
+  s << std::resetiosflags(std::ios::scientific) << ((v.val).decimal());
+  if (v.opt) s << '*';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode& t)
+{
+  t.write(s);
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostTable::Entry& e)
+{
+  if (e.set.length() > 0) {
+    s << "{" << e.set[0];
+    for (index_type k = 1; k < e.set.length(); k++) s << ',' << e.set[k];
+    s << "}:" << e.val;
+  }
+  else {
+    s << "{}:" << e.val;
+  }
+  return s;
+}
+}
+namespace hsps {
+class Preprocessor {
+ public:
+  Instance& instance;
+  index_vec atom_map;
+  index_vec action_map;
+  index_vec inv_map;
+ protected:
+  Statistics& stats;
+  CostTable* inc_relation;
+  graph* inc_graph;
+  bool make_invariant(index_type init_atom,
+        index_set& inv_set,
+        bool& exact,
+        index_set& branch_set);
+  void analyze_branch_set(const index_set& branch_set,
+     const index_set& inv_set,
+     index_set& effective);
+  void dfs_find_invariants(index_type init_atom,
+      const index_set& base_set,
+      const index_set& branch_set,
+      index_type branch_depth,
+      index_type max_branch_depth);
+  void extend_LsC1_relevance(const index_set& check,
+        const graph& lmg,
+        const bool_vec& p_act,
+        const bool_vec& p_add,
+        bool_vec& rel_atms,
+        bool_vec& rel_acts);
+ public:
+  static int default_trace_level;
+  int trace_level;
+  Preprocessor(Instance& ins, Statistics& s);
+  ~Preprocessor();
+  void compute_reachability(bool_vec& reachable_atoms,
+       bool_vec& reachable_actions,
+       bool opt_H2 = false);
+  void compute_static_atoms(const bool_vec& reachable_actions,
+       bool_vec& static_atoms);
+  void compute_relevance(const index_set& check,
+    bool_vec& r_atm,
+    bool_vec& r_act);
+  void compute_relevance(const index_set& check,
+    index_type d_check,
+    index_vec& d_atm,
+    index_vec& d_act);
+  void between(index_type p,
+        index_type q,
+        const graph& lmg,
+        bool_vec& b_atm,
+        bool_vec& b_act);
+  void compute_L1C1_relevance(const index_set& check,
+         index_type d_check,
+         const graph& lmg,
+         index_vec& d_atm,
+         index_vec& d_act);
+  void compute_L1C1_relevance(const index_set& check,
+         const graph& lmg,
+         bool_vec& rel_atms,
+         bool_vec& rel_acts);
+  void compute_LsC1_relevance(const index_set& check,
+         const graph& lmg,
+         bool_vec& rel_atms,
+         bool_vec& rel_acts);
+  void compute_relaxed_relevance(const index_set& g,
+     index_vec& path,
+     const index_set& pre,
+     bool_vec& rel_acts);
+  void strictly_relevant_actions(index_type p,
+     Heuristic& h,
+     const ACF& f,
+     bool_vec& rel);
+  void strictly_relevant_actions(index_type p,
+     hsps::rational c,
+     Heuristic& h,
+     const ACF& f,
+     bool_vec& rel);
+  void relevant_at_cost(index_type p,
+   hsps::rational c,
+   Heuristic& h,
+   const ACF& f,
+   bool_vec& r_atoms,
+   bool_vec& r_actions);
+  void relevant_at_cost(const index_set& s,
+   hsps::rational c,
+   Heuristic& h,
+   const ACF& f,
+   bool_vec& r_atoms,
+   bool_vec& r_actions);
+  CostTable* inconsistency();
+  graph* inconsistency_graph();
+  bool inconsistent(index_type p, index_type q, Heuristic& inc);
+  bool consistent(index_type p, index_type q, Heuristic& inc);
+  bool inconsistent(const index_set& s, index_type p, Heuristic& inc);
+  bool consistent(const index_set& s, index_type p, Heuristic& inc);
+  bool inconsistent(index_type p, index_type q);
+  bool consistent(index_type p, index_type q);
+  bool inconsistent(const index_set& s);
+  bool consistent(const index_set& s);
+  bool inconsistent(const index_set& s, index_type p);
+  bool consistent(const index_set& s, index_type p);
+  bool inconsistent(const index_set& s0, const index_set& s1);
+  bool consistent(const index_set& s0, const index_set& s1);
+  bool implies(index_type p, index_type q, Heuristic& inc);
+  bool implies(const index_set& s, index_type q, Heuristic& inc);
+  bool implies(index_type p, index_type q);
+  bool implies(const index_set& s, index_type q);
+  void implied_atom_set(const index_set& s, index_set& is, Heuristic& inc);
+  bool landmark_test(const index_set& init,
+       const index_set& goal,
+       index_type p,
+       bool opt_H2 = false);
+  void compute_landmarks(const index_set& init,
+    const index_set& goal,
+    index_set& landmark_atoms);
+  void compute_landmarks(bool exclude_goal,
+    bool exclude_init,
+    bool_vec& landmark_atoms);
+  void compute_landmarks(bool exclude_goal,
+    bool exclude_init,
+    index_set& landmark_atoms);
+  void quick_landmark_graph(graph& g, bool opt_H2 = false);
+  void compute_landmark_graph(graph& g, bool opt_H2 = false);
+  void compute_hierarchy(index_set_graph& g);
+  void compute_hierarchy(graph& g0, index_set_graph& g);
+  void necessary_completions_for_safeness(index_set& atoms_missing_negation);
+  void compute_irrelevant_atoms();
+  void dfs_find_invariants(index_type max_branch_depth);
+  void bfs_find_invariants();
+  void find_inconsistent_set_invariants(graph& inc);
+  void find_maximal_inconsistent_set_invariants(graph& inc);
+  void find_binary_iff_invariants(bool opt_weak_verify);
+  bool verify_invariant(Instance::Constraint& inv, Heuristic& inc);
+  bool verify_invariants(Heuristic& inc);
+  void compute_ncw_sets(Heuristic& inc);
+  void compute_ncw_sets();
+  void preprocess(bool opt_H2 = false);
+  void remove_irrelevant_atoms();
+  void remove_unverified_invariants();
+  void remove_useless_actions();
+  void remove_useless_invariants();
+  void remove_redundant_preconditions();
+  void eliminate_strictly_determined_atoms();
+  void make_safe();
+  void apply_place_replication();
+  void write_heuristic_graph(std::ostream& s,
+        Heuristic& h,
+        const ACF& cost,
+        const bool_vec& atoms,
+        const bool_vec& actions);
+  void write_heuristic_graph(std::ostream& s,
+        Heuristic& h,
+        const ACF& cost);
+  void write_relevance_graph(std::ostream& s,
+        const index_vec& d_atm,
+        const index_vec& d_act,
+        const char* label);
+  void write_relevance_graph(std::ostream& s,
+        const index_vec& d_atm,
+        const index_vec& d_act,
+        const bool_vec& mark_atm,
+        const bool_vec& mark_act,
+        const char* label);
+  bool find_inverse_actions(const Instance::Action& act, Heuristic& inc,
+       index_set& inverses);
+};
+}
+#include <stdio.h>
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+#include <stdio.h>
+#include <stdlib.h>
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class PDDL_Name;
+class PDDL_Base {
+ public:
+  static bool use_default_function_value;
+  static hsps::rational default_function_value;
+  static bool use_strict_borrow_definition;
+  static bool use_extended_borrow_definition;
+  static bool del_before_add_semantics;
+  static bool compact_resource_effects;
+  static bool compile_away_disjunctive_preconditions;
+  static bool check_precondition_consistency;
+  static bool compile_away_conditional_effects;
+  static bool compile_away_plan_constraints;
+  static bool compile_away_object_functions;
+  static bool compile_for_validator;
+  static bool create_all_atoms;
+  static bool create_all_actions;
+  static bool number_multiple_action_instances;
+  static bool exclude_all_dkel_items;
+  static string_set excluded_dkel_tags;
+  static string_set required_dkel_tags;
+  static bool strict_set_export;
+  static bool best_effort;
+  static bool write_PDDL31;
+  static bool write_warnings;
+  static bool write_info;
+  static bool write_trace;
+  static bool trace_print_context;
+  static bool name_instance_by_problem_file;
+  static const char* instance_name_prefix;
+  enum symbol_class {
+    sym_object,
+    sym_typename,
+    sym_predicate,
+    sym_object_function,
+    sym_function,
+    sym_action,
+    sym_variable,
+    sym_misc,
+    sym_preference,
+    sym_set,
+    sym_meta_variable
+  };
+  enum metric_class {
+    metric_none,
+    metric_makespan,
+    metric_minimize,
+    metric_maximize
+  };
+  enum mode_keyword {
+    md_none,
+    md_start,
+    md_end,
+    md_all,
+    md_init,
+    md_pos_goal,
+    md_neg_goal
+  };
+  enum partial_value { p_false, p_true, p_unknown };
+  enum expression_class {
+    exp_fun,
+    exp_list,
+    exp_const,
+    exp_add,
+    exp_sub,
+    exp_mul,
+    exp_div,
+    exp_time,
+    exp_preference
+  };
+  enum relation_type {
+    rel_equal,
+    rel_greater,
+    rel_greater_equal,
+    rel_less,
+    rel_less_equal
+  };
+  enum formula_class { fc_false,
+         fc_true,
+         fc_atom,
+         fc_equality,
+         fc_negation,
+         fc_conjunction,
+         fc_disjunction,
+         fc_equivalence,
+         fc_implication,
+         fc_universal,
+         fc_existential,
+         fc_list
+  };
+  struct Symbol;
+  struct TypeSymbol;
+  struct Atom;
+  struct FTerm;
+  struct FChangeAtom;
+  struct SetOf;
+  struct ListExpression;
+  struct ActionSymbol;
+  struct Reference;
+  struct IrrelevantItem;
+  typedef lvector<TypeSymbol*> type_vec;
+  typedef lvector<Atom*> atom_vec;
+  typedef lvector<FChangeAtom*> ch_atom_vec;
+  typedef lvector<SetOf*> atom_set_vec;
+  typedef lvector<Reference*> ref_vec;
+  typedef lvector<IrrelevantItem*> irrelevant_vec;
+  struct TypeSet : public type_vec {
+    TypeSet() : type_vec(0, 0) { };
+    TypeSet(const TypeSet& s) : type_vec(s) { };
+    TypeSet(TypeSymbol* t) : type_vec(t, 1) { };
+    index_type n_elements() const;
+    Symbol* get_element(index_type n);
+    bool is_object() const;
+    bool subtype_or_equal(const TypeSet& s) const;
+    bool subtype_or_equal(TypeSymbol* t) const;
+    void print(std::ostream& s) const;
+    void write_type(std::ostream& s) const;
+  };
+  struct Symbol {
+    symbol_class sym_class;
+    char* print_name;
+    TypeSet sym_types;
+    bool defined_in_problem;
+    bool visible;
+    Symbol(symbol_class c, char* n)
+      : sym_class(c), print_name(n), defined_in_problem(false), visible(true) { };
+    Symbol(char* n)
+      : sym_class(sym_object), print_name(n), defined_in_problem(false), visible(true) { };
+    void print(std::ostream& s) const;
+  };
+  typedef zero_init_pair<Symbol*> symbol_pair;
+  typedef lvector<Symbol*> symbol_vec;
+  typedef svector<Symbol*> symbol_set;
+  typedef lvector<symbol_pair> symbol_pair_vec;
+  static bool extend_substitution(Symbol* out, Symbol* in, symbol_pair_vec& u);
+  static bool print_substitution(std::ostream& s, const symbol_pair_vec& u);
+  static bool print_inequality(std::ostream& s, const symbol_pair_vec& neq);
+  static bool substitution_violates_inequality(const symbol_pair_vec& neq,
+            const symbol_pair_vec& u);
+  static index_type find_matching_atom(Atom* a, atom_vec& v);
+  static index_type find_matching_atom(Atom* a, mode_keyword m, atom_vec& v);
+  static index_type find_matching_fluent_atom
+    (FChangeAtom* a, mode_keyword m, ch_atom_vec& v);
+  struct TypeSymbol : public Symbol {
+    symbol_vec elements;
+    bool is_base_type;
+    TypeSymbol(char* n) : Symbol(sym_typename, n), elements(0, 0),
+  is_base_type(false) { };
+    void add_element(Symbol* e);
+    bool is_object() const { return (strcmp(print_name, "object") == 0); };
+    bool subtype_or_equal(TypeSymbol* t) const;
+    bool subtype_or_equal(const TypeSet& t) const;
+    void print(std::ostream& s) const;
+  };
+  struct VariableSymbol : public Symbol {
+    Symbol* value;
+    FTerm* binding;
+    VariableSymbol(char* n) : Symbol(sym_variable, n), value(0), binding(0) {};
+    bool equality_type_check(Symbol* s);
+    void print(std::ostream& s);
+  };
+  typedef lvector<VariableSymbol*> variable_vec;
+  struct ParamSymbol : public Symbol {
+    variable_vec param;
+    ParamSymbol(symbol_class c, char* n) : Symbol(c, n), param(0, 0) { };
+  };
+  struct PredicateSymbol : public ParamSymbol {
+    bool pos_pre;
+    bool neg_pre;
+    bool added;
+    bool deleted;
+    bool locked;
+    bool modded;
+    ptr_table init;
+    ptr_table pos_goal;
+    ptr_table neg_goal;
+    ptr_table pos_prop;
+    ptr_table neg_prop;
+    irrelevant_vec irr_ins;
+    PredicateSymbol(char* n) : ParamSymbol(sym_predicate, n),
+  pos_pre(false), neg_pre(false), added(false), deleted(false),
+  locked(false), modded(false), irr_ins(0, 0) { };
+    bool is_static() const { return !modded; };
+    bool is_equality() const { return (strcmp(print_name, "=") == 0); };
+    void instantiate(Instance& ins);
+    void initialise_missing(const symbol_vec& p,
+       atom_vec* created,
+       index_type i = 0);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+  };
+  struct ObjectFunctionSymbol : public ParamSymbol {
+    bool modded;
+    ptr_table init;
+    ObjectFunctionSymbol(char* n)
+      : ParamSymbol(sym_object_function, n), modded(false) { };
+    bool is_static() const { return !modded; };
+    void print(std::ostream& s);
+  };
+  struct FunctionSymbol : public ParamSymbol {
+    bool modified;
+    bool integral;
+    bool linear;
+    bool conditioned;
+    bool increased;
+    bool decreased;
+    bool assigned;
+    bool borrowed;
+    ptr_table init;
+    FunctionSymbol(char* n) : ParamSymbol(sym_function, n),
+  modified(false), integral(true), linear(true), conditioned(false),
+  increased(false), decreased(false), assigned(false), borrowed(false)
+    { };
+    bool is_static() const
+    { return !modified; };
+    bool is_reusable() const
+    { return borrowed && !increased && !decreased && !assigned; };
+    bool is_consumable() const
+    { return !borrowed && !increased && decreased && !assigned; };
+    interval eval_init_bounds(ptr_table* p, index_type i, ListExpression* r);
+    void print(std::ostream& s);
+  };
+  struct AtomBase {
+    symbol_vec param;
+    mode_keyword at;
+    hsps::rational at_time;
+    AtomBase() : param(0, 0), at(md_none), at_time(0) { };
+    AtomBase(mode_keyword t) : param(0, 0), at(t), at_time(0) { };
+    AtomBase(AtomBase* b);
+    bool equals(AtomBase& b);
+    void free_variables(variable_vec& v);
+    bool occurs(Symbol* s);
+    void fill_in_args(AtomBase* b);
+    void collect_bound_variables(variable_vec& v);
+    void insert(ptr_table& t);
+    static bool print_bindings;
+    void print(std::ostream& s) const;
+    void print_instance(std::ostream& s);
+  };
+  typedef lvector<AtomBase*> atom_base_vec;
+  struct Atom : AtomBase {
+    PredicateSymbol* pred;
+    Atom(PredicateSymbol* p) : pred(p) { };
+    Atom(PredicateSymbol* p, mode_keyword t) : AtomBase(t), pred(p) { };
+    Atom(PredicateSymbol* p, variable_vec& a, bool as_value)
+      : pred(p)
+    {
+      param.set_length(a.length());
+      for (index_type k = 0; k < a.length(); k++)
+ param[k] = (as_value ? a[k]->value : a[k]);
+    };
+    Atom(PredicateSymbol* p, Symbol* a0)
+      : pred(p)
+    {
+      param.append(a0);
+    };
+    Atom(Atom* a) : AtomBase(a), pred(a->pred) { };
+    bool equals(Atom& a);
+    bool is_static() const {
+      return ((at == md_init) ||
+       (at == md_pos_goal) ||
+       (at == md_neg_goal) ||
+       pred->is_static());
+    };
+    bool check();
+    Instance::Atom* find_prop(Instance& ins, bool neg, bool create);
+    void build(Instance& ins, bool neg, index_type p);
+    Atom* instantiate_partially();
+    partial_value partial_eval(ptr_table* r, index_type p);
+    partial_value partial_eval();
+    bool initial_value();
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    void print(std::ostream& s, bool neg) const;
+    void print(std::ostream& s) const { print(s, false); };
+  };
+  struct CAtom : public Atom {
+    symbol_pair_vec neq;
+    CAtom(Atom* a) : Atom(a), neq(symbol_pair(0, 0), 0) { };
+    CAtom(CAtom* s) : Atom(s), neq(s->neq) { };
+    CAtom(const Atom* a, symbol_pair_vec& u);
+    CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool instance_of(CAtom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(CAtom* a, symbol_pair_vec& u);
+    void print(std::ostream& s);
+  };
+  typedef lvector<CAtom*> catom_vec;
+  struct FTerm : AtomBase {
+    ObjectFunctionSymbol* fun;
+    FTerm(ObjectFunctionSymbol* f) : fun(f) { };
+    bool equals(FTerm& a);
+    void print(std::ostream& s) const;
+  };
+  struct OInitAtom : AtomBase {
+    ObjectFunctionSymbol* fun;
+    Symbol* val;
+    OInitAtom(ObjectFunctionSymbol* f) : fun(f), val(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<OInitAtom*> obj_init_atom_vec;
+  struct FInitAtom : AtomBase {
+    FunctionSymbol* fun;
+    hsps::rational val;
+    Instance::resource_ref res;
+    FInitAtom(FunctionSymbol* f) : fun(f), val(0) { };
+    FInitAtom(FChangeAtom* a);
+    bool is_static() const { return fun->is_static(); };
+    void print(std::ostream& s);
+  };
+  typedef lvector<FInitAtom*> fun_init_atom_vec;
+  struct Expression;
+  typedef lvector<Expression*> exp_vec;
+  struct Expression {
+    expression_class exp_class;
+    Expression(expression_class c) : exp_class(c) { };
+    static bool print_nary;
+    bool is_static();
+    bool is_constant();
+    bool is_integral();
+    hsps::rational eval_static();
+    bool eval_partial(hsps::rational& val);
+    interval eval_bounds();
+    hsps::rational eval_init();
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    hsps::rational eval_delta(Symbol* preference, hsps::rational p_value, hsps::rational d_value);
+    Expression* copy();
+    Expression* simplify();
+    void collect_constants(exp_vec& c);
+    void mark_functions_in_condition();
+    hsps::rational integrify();
+    void substitute_for_time(Expression* e);
+    Expression* substitute_for_preference(Symbol* n, Expression* e);
+    bool equals(Expression* e);
+    void print_sum(std::ostream& s, bool grnd);
+    void print_product(std::ostream& s, bool grnd);
+    void print(std::ostream& s, bool grnd);
+  };
+  struct ListExpression : public Expression {
+    Symbol* sym;
+    ListExpression* rest;
+    ListExpression(Symbol* s, ListExpression* r) :
+      Expression(exp_list), sym(s), rest(r) { };
+    bool match(AtomBase* atom);
+  };
+  struct FunctionExpression : public Expression {
+    FunctionSymbol* fun;
+    ListExpression* args;
+    FunctionExpression(FunctionSymbol* f, ListExpression* a) :
+      Expression(exp_fun), fun(f), args(a) { };
+    bool match(FChangeAtom* atom);
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    FChangeAtom* make_atom_base();
+  };
+  struct ConstantExpression : public Expression {
+    hsps::rational val;
+    ConstantExpression(hsps::rational v) :
+      Expression(exp_const), val(v) { };
+  };
+  struct TimeExpression : public Expression {
+    Expression* time_exp;
+    TimeExpression() :
+      Expression(exp_time), time_exp(0) { };
+    TimeExpression(Expression* e) :
+      Expression(exp_time), time_exp(e) { };
+  };
+  struct BinaryExpression : public Expression {
+    Expression* first;
+    Expression* second;
+    BinaryExpression(expression_class c, Expression* e1, Expression* e2) :
+      Expression(c), first(e1), second(e2) { };
+  };
+  struct PreferenceExpression : public Expression {
+    Symbol* name;
+    PreferenceExpression(Symbol* n) :
+      Expression(exp_preference), name(n) { };
+  };
+  struct Relation {
+    relation_type rel;
+    mode_keyword at;
+    Expression* first;
+    Expression* second;
+    Relation(relation_type r, Expression* e1, Expression* e2) :
+      rel(r), at(md_none), first(e1), second(e2) { };
+    Relation(relation_type r, mode_keyword m, Expression* e1, Expression* e2) :
+      rel(r), at(m), first(e1), second(e2) { };
+    Expression* match_gteq_constant(FChangeAtom* atom);
+    FunctionExpression* match_lteq_fun(FChangeAtom* atom);
+    bool is_static();
+    partial_value partial_eval();
+    void print(std::ostream& s, bool grnd);
+  };
+  typedef lvector<Relation*> relation_vec;
+  struct FChangeAtom : AtomBase {
+    FunctionSymbol* fun;
+    Expression* val;
+    FChangeAtom(FunctionSymbol* f) :
+      fun(f), val(0) { };
+    FChangeAtom(FunctionSymbol* f, mode_keyword t) :
+      AtomBase(t), fun(f), val(0) { };
+    FChangeAtom(FChangeAtom* a, hsps::rational v) :
+      AtomBase(a), fun(a->fun), val(new ConstantExpression(v)) { };
+    bool equals(FChangeAtom& a);
+    bool fluent_equals(FChangeAtom& a);
+    bool fluent_and_mode_equals(FChangeAtom& a);
+    FChangeAtom* find_fluent_equals(ch_atom_vec& vec);
+    Instance::Resource* find_resource(Instance& ins);
+    void print(std::ostream& s);
+  };
+  struct Formula {
+    formula_class fc;
+    Formula(formula_class c) : fc(c) { };
+    void rename_variables_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_variables_2(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_2(PDDL_Base::symbol_pair_vec& sub);
+    Formula* simplify();
+    void write_otter(std::ostream& s) const;
+    void print(std::ostream& s) const;
+    void untype(PDDL_Base* base);
+  };
+  typedef lvector<Formula*> formula_vec;
+  struct AFormula : public Formula, public Atom {
+    AFormula(Atom* a) :
+      Formula(fc_atom), Atom(a) { };
+    AFormula(PredicateSymbol* p) :
+      Formula(fc_atom), Atom(p) { };
+    AFormula(PredicateSymbol* p, variable_vec& a) :
+      Formula(fc_atom), Atom(p, a, false) { };
+    void print(std::ostream& s) const;
+    void write_otter(std::ostream& s) const;
+  };
+  struct EqFormula : public Formula {
+    Symbol* t1;
+    Symbol* t2;
+    EqFormula(Symbol* s1, Symbol* s2) :
+      Formula(fc_equality), t1(s1), t2(s2) { };
+    void write_otter(std::ostream& s) const;
+  };
+  struct NFormula : public Formula {
+    Formula* f;
+    NFormula(Formula* g) : Formula(fc_negation), f(g) { };
+  };
+  struct BFormula : public Formula {
+    Formula* f1;
+    Formula* f2;
+    BFormula(formula_class c, Formula* g1, Formula* g2) :
+      Formula(c), f1(g1), f2(g2) { };
+  };
+  struct CFormula : public Formula {
+    formula_vec parts;
+    CFormula(formula_class c) : Formula(c), parts(0, 0) { };
+    CFormula(formula_class c, Formula* f1, Formula* f2) :
+      Formula(c), parts(0, 0)
+    {
+      parts.append(f1);
+      parts.append(f2);
+    };
+    void add(Formula* f) { parts.append(f); };
+    void add(formula_vec& f) { parts.append(f); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct QFormula : public Formula {
+    variable_vec vars;
+    Formula* f;
+    QFormula(formula_class c) : Formula(c), vars(0, 0), f(0) { };
+    QFormula(formula_class c, Formula* g) : Formula(c), vars(0, 0), f(g) { };
+    QFormula(formula_class c, variable_vec& v, Formula* g) :
+      Formula(c), vars(0, 0), f(g)
+    {
+      for (index_type k = 0; k < v.length(); k++) vars.append(v[k]);
+    };
+    void add(PDDL_Base::VariableSymbol* v) { vars.append(v); };
+    void add(PDDL_Base::variable_vec& v) { vars.append(v); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct TypeConstraint {
+    VariableSymbol* var;
+    TypeSymbol* typ;
+    TypeConstraint(VariableSymbol* v, TypeSymbol* t) : var(v), typ(t) { };
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+  };
+  typedef lvector<TypeConstraint*> type_constraint_vec;
+  struct Context {
+    variable_vec param;
+    atom_vec pos_con;
+    atom_vec neg_con;
+    type_constraint_vec type_con;
+    Context() : param(0, 0), pos_con(0, 0), neg_con(0, 0), type_con(0, 0) { };
+    Context(const Context* c) : param(c->param), pos_con(c->pos_con),
+  neg_con(c->neg_con), type_con(c->type_con) { };
+    bool context_is_static() const;
+    bool occurs_in_context(Symbol* s);
+    void clear_arguments();
+    void set_mode(mode_keyword m);
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+    void print_assignment(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct DKEL_Item : public Context {
+    char* item_name;
+    Symbol* name;
+    string_set item_tags;
+    bool defined_in_problem;
+    bool included;
+    DKEL_Item(char* name) : item_name(name), name(0),
+  defined_in_problem(false), included(true) { };
+    DKEL_Item(const DKEL_Item* i) : Context(i), item_name(i->item_name),
+  name(i->name), item_tags(i->item_tags),
+  defined_in_problem(i->defined_in_problem), included(i->included) { };
+    bool item_is_included(string_set& ex_tags, string_set& req_tags);
+    void print_begin(std::ostream& s);
+    void print_end(std::ostream& s);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SetOf : public Context {
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    SetOf() : pos_atoms(0, 0), neg_atoms(0, 0) { };
+    SetOf(const SetOf* s)
+      : Context(s), pos_atoms(s->pos_atoms), neg_atoms(s->neg_atoms)
+    { };
+    SetOf(Atom* a)
+    { pos_atoms.append(a); };
+    SetOf(Atom* a, bool n)
+    { if (n) neg_atoms.append(a); else pos_atoms.append(a); };
+    bool is_static() const;
+    void set_mode(mode_keyword m);
+    partial_value partial_eval(bool as_disjunction = false);
+    partial_value partial_eval(index_type p, bool as_disjunction = false);
+    void instantiate_as_set(Instance& ins, index_set& s);
+    void instantiate_as_effect(Instance& ins, index_set& s_add,
+          index_set& s_del);
+    void instantiate_conditional(Instance& ins, rule_set& s_pos,
+     rule_set& s_neg);
+    SetOf* instantiate_partially();
+    void compile(atom_vec& pos_ins, atom_vec& neg_ins, index_type p);
+    void compile_non_static(atom_set_vec& ins, index_type p);
+    void print(std::ostream& s);
+    void print_as_disjunction(std::ostream& s);
+    void build_set(Instance& ins, index_set& s, index_type p);
+    void build_effect(Instance& ins, index_set& s_add, index_set& s_del,
+        index_type p);
+    void build_conditional(Instance& ins, rule_set& s_pos, rule_set& s_neg,
+      index_type p);
+  };
+  struct QCNumericEffect : public Context {
+    FChangeAtom* atom;
+    QCNumericEffect() : atom(0) { };
+    QCNumericEffect(FChangeAtom* a) : atom(a) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<QCNumericEffect*> qc_numeric_effect_vec;
+  enum set_constraint_keyword { sc_at_least, sc_at_most, sc_exactly };
+  struct SetConstraint : public DKEL_Item {
+    set_constraint_keyword sc_type;
+    index_type sc_count;
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    atom_set_vec atom_sets;
+    SetConstraint() : DKEL_Item(":invariant"), sc_type(sc_at_least),
+  sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0), atom_sets(0, 0) { };
+    SetConstraint(const DKEL_Item* item) : DKEL_Item(item),
+  sc_type(sc_at_least), sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0),
+  atom_sets(0, 0) { };
+    void build(Instance& ins, index_type p);
+    void instantiate(Instance& ins);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InvariantFormula : public DKEL_Item {
+    Formula* f;
+    InvariantFormula(Formula* g)
+      : DKEL_Item(":invariant"), f(g) { };
+    InvariantFormula(const DKEL_Item* item, Formula* g)
+      : DKEL_Item(item), f(g) { };
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct Reference : public AtomBase {
+    Symbol* name;
+    bool neg;
+    bool has_args;
+    index_set index;
+    Reference(Symbol* n) : name(n), neg(false), has_args(true) { };
+    Reference(Symbol* n, bool ng, bool ha)
+      : name(n), neg(ng), has_args(ha) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    void* find_action();
+    void find(const name_vec& names, index_set& ind);
+    Reference* instantiate_partially();
+    void print(std::ostream& s);
+  };
+  struct IrrelevantItem : public DKEL_Item {
+    Reference* entity;
+    IrrelevantItem() : DKEL_Item(":irrelevant"), entity(0) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    IrrelevantItem* instantiate_partially();
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SequentialTaskNet : public Context {
+    ref_vec tasks;
+    ActionSymbol* abs_act;
+    SequentialTaskNet() : tasks(0, 0), abs_act(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<SequentialTaskNet*> task_net_vec;
+  struct SetSymbol : public Symbol {
+    ptr_table set_table;
+    lvector<index_set*> sets;
+    name_vec names;
+    SetSymbol(char* n) : Symbol(sym_set, n), sets(0, 0), names(0, 0) { };
+  };
+  struct SetName : public AtomBase {
+    SetSymbol* sym;
+    SetName(SetSymbol* s) : sym(s) { };
+    index_set* find();
+    SetName* instantiate_partially();
+    void print(std::ostream& s);
+    void print_instance(std::ostream& s);
+  };
+  struct ActionSymbol : public ParamSymbol {
+    atom_vec pos_pre;
+    atom_vec neg_pre;
+    atom_set_vec set_pre;
+    atom_set_vec dis_pre;
+    relation_vec num_pre;
+    atom_vec adds;
+    atom_vec dels;
+    atom_set_vec set_eff;
+    atom_vec cons;
+    atom_set_vec cond_eff;
+    atom_vec locks;
+    atom_vec enables;
+    ch_atom_vec reqs;
+    ch_atom_vec incs;
+    ch_atom_vec decs;
+    ch_atom_vec fass;
+    qc_numeric_effect_vec qc_incs;
+    qc_numeric_effect_vec qc_decs;
+    qc_numeric_effect_vec qc_fass;
+    Expression* dmin;
+    Expression* dmax;
+    irrelevant_vec irr_ins;
+    ref_vec refs;
+    task_net_vec exps;
+    ptr_table instances;
+    SetName* part;
+    const char* assoc;
+    ActionSymbol(char* n) : ParamSymbol(sym_action, n), pos_pre(0, 0),
+  neg_pre(0, 0), set_pre(0, 0), dis_pre(0, 0), num_pre(0, 0),
+  adds(0, 0), dels(0, 0), set_eff(0, 0), cons(0, 0), cond_eff(0, 0),
+  locks(0, 0), enables(0, 0), reqs(0, 0), incs(0, 0), decs(0, 0),
+  fass(0, 0), qc_incs(0, 0), qc_decs(0, 0), qc_fass(0, 0), dmin(0),
+  dmax(0), irr_ins(0, 0), refs(0, 0), exps(0, 0), part(0), assoc(0) { };
+    void build(Instance& ins, index_type p, Expression* cost_exp);
+    Instance::Action& build_action(Instance& ins,
+       PDDL_Name* name,
+       index_type& count,
+       const index_set& pre,
+       const index_set& add,
+       const index_set& del,
+       const index_set& lck,
+       const index_cost_vec& r_use,
+       const index_cost_vec& r_cons,
+       hsps::rational dmin,
+       hsps::rational dmax,
+       hsps::rational dur,
+       hsps::rational cost);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          index_vec& s,
+          index_type p);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc);
+    void build_actions_with_dc_and_ce(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          const rule_set& pce,
+          const rule_set& nce,
+          const bool_vec& ece);
+    index_type param_index(VariableSymbol* p);
+    void get_param_inequalities(symbol_pair_vec& neq);
+    void set_arguments(const symbol_vec& args);
+    void set_arguments(const ptr_table::key_vec& args);
+    void clear_arguments();
+    void* find_instance();
+    bool is_abstract();
+    void post_process();
+    void instantiate(Instance& ins, Expression* cost_exp);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InputPlanStep {
+    Reference* act;
+    hsps::rational start_time;
+    InputPlanStep() : act(0), start_time(0) { };
+    InputPlanStep(Reference* a, hsps::rational t) : act(a), start_time(t) { };
+  };
+  struct InputPlan {
+    Symbol* name;
+    bool is_opt;
+    lvector<InputPlanStep*> steps;
+    InputPlan() : name(0), is_opt(false), steps(0, 0) { };
+    bool export_to_instance(Instance& ins, const index_vec& map, Plan& p);
+    void print(std::ostream& s);
+  };
+  struct HTableEntry {
+    atom_vec atoms;
+    bool_vec neg;
+    hsps::rational cost;
+    bool opt;
+    HTableEntry() : atoms(0, 0), neg(false, 0), cost(0), opt(false) { };
+  };
+  struct SimpleReferenceSet : public Context {
+    Reference* ref;
+    SimpleReferenceSet(Reference* r) : ref(r) { };
+    bool build(const name_vec& names, index_set& set, index_type p);
+    void print(std::ostream& s);
+  };
+  typedef lvector<SimpleReferenceSet*> refs_vec;
+  struct ReferenceSet : public Context {
+    refs_vec refs;
+    Symbol* name;
+    ReferenceSet() : refs(0, 0), name(0) { };
+    void add(SimpleReferenceSet* ref) { refs.append(ref); };
+    void build(const name_vec& names, index_set_vec& sets, index_type p);
+    void print(std::ostream& s);
+  };
+  struct CPG {
+    atom_vec atoms;
+    index_vec atom_first_arg;
+    bool_vec neg;
+    symbol_vec args;
+    type_vec arg_types;
+    CPG() : atoms(0, 0), neg(false, 0), args(0, 0), arg_types(0, 0) { };
+    CPG(CPG& g, index_vec& s);
+    void make_key(ptr_table::key_vec& key);
+    void make_typed_key(ptr_table::key_vec& key);
+    void make_parameters(variable_vec& params);
+    ListExpression* make_argument_list(index_type first);
+    void add_asserting_effects(ActionSymbol* act,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          bool strict);
+    void add_destroying_effects(ActionSymbol* act,
+    ParamSymbol* pf,
+    PredicateSymbol* p,
+    bool p_val,
+    PredicateSymbol* g,
+    FunctionSymbol* f,
+    Expression* f_val,
+    bool strict);
+    bool initial_value();
+    void add_asserting_effects(index_type c_atom,
+          ActionSymbol* act,
+          index_type c_eff,
+          bool_vec& sat,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          symbol_pair_vec& eq,
+          symbol_pair_vec& neq,
+          bool strict);
+    void add_propositional_effect(ActionSymbol* act,
+      PredicateSymbol* p, bool p_val,
+      index_type c_atom, Atom* a_eff,
+      bool strict);
+    void add_fluent_effect(ActionSymbol* act,
+      FunctionSymbol* f, Expression* f_val,
+      index_type c_atom, Atom* a_eff);
+    void add_effect_conditions(Context* e, ParamSymbol* pf, bool_vec& sat,
+          symbol_vec& subs, symbol_pair_vec& eq,
+          symbol_pair_vec& neq);
+  };
+  enum goal_class { goal_pos_atom, goal_neg_atom, goal_relation, goal_task,
+      goal_conjunction, goal_disjunction, goal_forall,
+      goal_exists, goal_always, goal_sometime,
+      goal_at_most_once, goal_within, goal_always_within,
+      goal_sometime_before, goal_sometime_after };
+  struct Goal {
+    goal_class g_class;
+    Goal(goal_class c) : g_class(c) { };
+    bool is_state();
+    bool is_propositional();
+    bool is_singular();
+    bool makeCPG(CPG& g);
+    bool makeCPG(CPG& g, index_vec& s);
+    void instantiate(Instance& ins, hsps::rational deadline);
+    void instantiate(Instance& ins, index_set& set, Symbol* p, index_type i);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Goal*> goal_vec;
+  struct AtomicGoal : public Goal {
+    Atom* atom;
+    AtomicGoal(Atom* a, bool neg)
+      : Goal(neg ? goal_neg_atom : goal_pos_atom), atom(a) { };
+    void print(std::ostream& s);
+  };
+  struct NumericGoal : public Goal {
+    Relation* rel;
+    NumericGoal(Relation* r) : Goal(goal_relation), rel(r) { };
+    void print(std::ostream& s);
+  };
+  struct TaskGoal : public Goal {
+    Reference* task;
+    TaskGoal(Reference* r) : Goal(goal_task), task(r) { };
+    void print(std::ostream& s);
+  };
+  struct ConjunctiveGoal : public Goal {
+    goal_vec goals;
+    ConjunctiveGoal() : Goal(goal_conjunction), goals(0, 0) { };
+    ConjunctiveGoal(goal_class gc) : Goal(gc), goals(0, 0) { };
+    void print(std::ostream& s);
+  };
+  struct DisjunctiveGoal : public ConjunctiveGoal {
+    DisjunctiveGoal() : ConjunctiveGoal(goal_disjunction) { };
+    void print(std::ostream& s);
+  };
+  struct QuantifiedGoal : public Goal, public Context {
+    Goal* goal;
+    QuantifiedGoal() : Goal(goal_forall), goal(0) { };
+    QuantifiedGoal(goal_class gc) : Goal(gc), goal(0) { };
+    void print(std::ostream& s);
+  };
+  struct SimpleSequenceGoal : public Goal {
+    Goal* constraint;
+    SimpleSequenceGoal(goal_class c, Goal* g) : Goal(c), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredSequenceGoal : public Goal {
+    Goal* trigger;
+    Goal* constraint;
+    TriggeredSequenceGoal(goal_class c, Goal* t, Goal* g)
+      : Goal(c), trigger(t), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct DeadlineGoal : public Goal {
+    Goal* goal;
+    hsps::rational at;
+    DeadlineGoal(hsps::rational t, Goal* g) : Goal(goal_within), goal(g), at(t) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredDeadlineGoal : public Goal {
+    Goal* trigger;
+    Goal* goal;
+    hsps::rational delay;
+    TriggeredDeadlineGoal(Goal* t, hsps::rational d, Goal* g)
+      : Goal(goal_always_within), trigger(t), delay(d), goal(g) { };
+    void print(std::ostream& s);
+  };
+  struct Preference {
+    Symbol* name;
+    Goal* goal;
+    Preference() : name(0), goal(0) { };
+    Preference(Symbol* n) : name(n), goal(0) { };
+    Preference(Symbol* n, Goal* g) : name(n), goal(g) { };
+    bool is_state() { return goal->is_state(); };
+    bool is_propositional() { return goal->is_propositional(); };
+    hsps::rational value(metric_class metric_type, Expression* m);
+    void instantiate(SoftInstance& ins,
+       metric_class metric_type,
+       Expression* m);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Preference*> preference_vec;
+  char* domain_name;
+  char* problem_name;
+  char* domain_file;
+  char* problem_file;
+  bool ready_to_instantiate;
+  char* problem_file_basename();
+  char* enum_problem_filename(const char* s, index_type i);
+  StringTable& tab;
+  type_vec dom_types;
+  type_vec dom_base_types;
+  TypeSymbol* dom_top_type;
+  symbol_vec dom_constants;
+  PredicateSymbol* dom_eq_pred;
+  PredicateSymbol* dom_assign_pred;
+  Symbol* dom_undefined_obj;
+  static PredicateSymbol* current_eq_predicate;
+  lvector<PredicateSymbol*> dom_predicates;
+  lvector<ObjectFunctionSymbol*> dom_object_functions;
+  lvector<FunctionSymbol*> dom_functions;
+  lvector<ActionSymbol*> dom_actions;
+  lvector<SetConstraint*> dom_sc_invariants;
+  lvector<InvariantFormula*> dom_f_invariants;
+  lvector<IrrelevantItem*> dom_irrelevant;
+  atom_vec dom_init;
+  obj_init_atom_vec dom_obj_init;
+  fun_init_atom_vec dom_fun_init;
+  goal_vec dom_goals;
+  preference_vec dom_preferences;
+  ref_vec goal_tasks;
+  metric_class metric_type;
+  Expression* metric;
+  hsps::rational serial_length;
+  hsps::rational parallel_length;
+  lvector<InputPlan*> input_plans;
+  lvector<HTableEntry*> h_table;
+  lvector<ReferenceSet*> input_sets;
+  lvector<SetSymbol*> partitions;
+  static ActionSymbol* src_action_symbol(ptr_pair* p);
+  TypeSymbol* find_type(const char* name);
+  PredicateSymbol* find_predicate(const char* name);
+  FunctionSymbol* find_function(const char* name);
+  bool find_initial_fact(const char* pname, const symbol_vec& arg);
+  hsps::rational find_function_value(const char* fname, const symbol_vec& arg);
+  index_type find_element_satisfying(const symbol_vec& elements,
+         const char* pname,
+         symbol_vec& arg,
+         index_type element_arg_p);
+  void find_elements_satisfying(const symbol_vec& elements,
+    const char* pname,
+    symbol_vec& arg,
+    index_type element_arg_p,
+    index_set& sats);
+  Atom* goal_to_atom(Goal* g);
+  bool goal_to_atom_vec(Goal* g, atom_vec& av);
+  PDDL_Base(StringTable& t);
+  ~PDDL_Base();
+  void set_variable_type(variable_vec& vec, TypeSymbol* t);
+  void set_variable_type(variable_vec& vec, const TypeSet& t);
+  void set_type_type(type_vec& vec, TypeSymbol* t);
+  void set_constant_type(symbol_vec& vec, TypeSymbol* t);
+  void clear_context(variable_vec& vec);
+  void clear_context(variable_vec& vec, index_type n_min, index_type n_max);
+  bool merge_type_vectors(type_vec& v0, type_vec& v1);
+  void make_parameters(type_vec& t, const char* prefix, variable_vec& v);
+  Atom* make_atom_from_prop(ptr_pair& src, bool& neg);
+  Symbol* gensym(symbol_class c, const char* p, const TypeSet& t);
+  Symbol* gensym(symbol_class c, const char* p, TypeSymbol* t);
+  Symbol* gensym_i(symbol_class c, const char* p, index_type i, TypeSymbol* t);
+  Symbol* gensym_s(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t);
+  Symbol* gensym_n(symbol_class c, const char* p, const Name* n, TypeSymbol* t);
+  void new_variable_substitution(Atom* a,
+     symbol_pair_vec& u,
+     symbol_pair_vec& new_u);
+  Atom* new_meta_atom(PredicateSymbol* p);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& u);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+  void extend_cc(CAtom* l, catom_vec& m, catom_vec& nm,
+   lvector< swapable_pair<catom_vec> >& x,
+   index_type d);
+  void find_cc();
+  void post_process();
+  void instantiate(Instance& ins);
+  void instantiate_soft(SoftInstance& ins);
+  void instantiate_atom_set(Instance& ins, atom_vec& a, index_set& s);
+  index_type n_plans() const { return input_plans.length(); };
+  bool export_plan(index_type i, Instance& ins, const index_vec& map, Plan& p);
+  bool export_plan(index_type i, Instance& ins, Plan& p);
+  void export_heuristic(Instance& ins,
+   const index_vec& map,
+   bool opt_maximize,
+   Heuristic& h);
+  void export_sets(const name_vec& names, index_set_vec& sets);
+  void export_action_partitions(name_vec& names, index_set_vec& sets);
+  void lift_DKEL_Items(const Instance& ins);
+  PredicateSymbol* find_type_predicate(Symbol* type_sym);
+  void untype();
+  void compile_preferences();
+  void compile_constraints_1();
+  void compile_constraints_2();
+  void select_preferences(const bool_vec& sel);
+  void metric_to_goal(hsps::rational bound);
+  void compile_set_conditions_and_effects();
+  void compile_object_functions();
+  Expression* replace_violations_1(Expression* exp,
+       CPG* cpg[],
+       FunctionSymbol* f_violated[]);
+  Goal* compile_constraint_1(Goal* g, index_type i, const Symbol* n,
+        symbol_vec& aut_states, index_type n_ra);
+  AtomicGoal* make_automaton_type_a(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_e(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_o(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sb(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sa(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  void make_automaton_transition(Symbol* s_from,
+     Symbol* s_to,
+     bool is_accept,
+     CPG* f, bool neg_f,
+     CPG* g, bool neg_g,
+     PredicateSymbol* p_state,
+     PredicateSymbol* p_accept,
+     PredicateSymbol* p_synch);
+  void add_precondition_formula(ActionSymbol* a, CPG* f, bool is_neg);
+  Goal* compile_constraint_2(Goal* g, const Symbol* n);
+  Goal* compile_always_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_sometime_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_at_most_once_constraint(SimpleSequenceGoal* g,
+     const Symbol* n);
+  Goal* compile_sometime_before_constraint(TriggeredSequenceGoal* g,
+        const Symbol* n);
+  void compile_set_conditions_and_effects(ActionSymbol* act);
+  void compile_set_conditions_and_effects(ActionSymbol* act,
+       variable_vec& i_param,
+       variable_vec& d_param,
+       index_type p);
+  Atom* make_binding_atom(VariableSymbol* v);
+  void compile_object_functions(ActionSymbol* act, Symbol* undefined_value);
+  void compile_object_functions_for_validator(ActionSymbol* act);
+  Goal* compile_object_functions(Goal* g);
+  void write_declarations(std::ostream& s);
+  void write_action(std::ostream& s, ActionSymbol* act);
+  void write_set_precondition(std::ostream& s, SetOf* set);
+  void write_disjunctive_set_precondition(std::ostream& s, SetOf* set);
+  void write_set_effect(std::ostream& s, SetOf* set);
+  void write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn);
+  void write_objects(std::ostream& s, bool defined_in_problem);
+  void write_init(std::ostream& s);
+  void write_goal(std::ostream& s);
+  void write_metric(std::ostream& s);
+  void write_dkel_items(std::ostream& s, bool defined_in_problem);
+  void write_domain_begin(std::ostream& s);
+  void write_problem_begin(std::ostream& s);
+  void write_end(std::ostream& s);
+  void write_dkel_domain(std::ostream& s, bool leave_open);
+  void write_dkel_problem(std::ostream& s, bool leave_open);
+  void write_plans(std::ostream& s);
+  void write_heuristic_table(std::ostream& s);
+  void write_sets(std::ostream& s);
+  void print(std::ostream& s);
+};
+class InstanceName : public Name {
+  char* domain_name;
+  char* problem_name;
+ public:
+  InstanceName(char* d, char* p) : domain_name(d), problem_name(p) { };
+  virtual ~InstanceName() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class PDDL_Name : public Name {
+ protected:
+  bool neg;
+  PDDL_Base::Symbol* sym;
+  PDDL_Base::symbol_vec arg;
+  bool vis;
+  bool_vec avis;
+ public:
+  static char catc;
+  static bool obscure_symbol_names;
+  PDDL_Name(PDDL_Base::Symbol* s)
+    : neg(false), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, bool n)
+    : neg(n), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::symbol_vec a, bool n)
+    : neg(n), sym(s), arg(a), vis(true), avis(true, a.length()) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n);
+  void add(PDDL_Base::Symbol* s);
+  void add(PDDL_Base::Symbol* s, bool v);
+  PDDL_Base::Symbol* symbol() { return sym; };
+  PDDL_Base::symbol_vec& args() { return arg; };
+  index_type argc() { return arg.length(); };
+  bool is_neg() { return neg; };
+  virtual ~PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class Numbered_PDDL_Name : public PDDL_Name {
+  index_type copy;
+ public:
+  Numbered_PDDL_Name(PDDL_Base::Symbol* sym, index_type c)
+    : PDDL_Name(sym), copy(c) { };
+  Numbered_PDDL_Name(PDDL_Name* n, index_type c);
+  virtual ~Numbered_PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+};
+}
+#include <sstream>
+typedef union {
+  hsps::StringTable::Cell* sym;
+  hsps::PDDL_Base::Expression* exp;
+  hsps::PDDL_Base::ListExpression* lst;
+  hsps::PDDL_Base::Relation* rel;
+  hsps::PDDL_Base::Goal* goal;
+  hsps::PDDL_Base::Formula* ff;
+  hsps::PDDL_Base::mode_keyword tkw;
+  hsps::PDDL_Base::relation_type rkw;
+  hsps::PDDL_Base::set_constraint_keyword sckw;
+  hsps::rational::XR rval;
+  int ival;
+  char* sval;
+} yy_PDDL_Parser_stype;
+class PDDL_Parser : public hsps::PDDL_Base
+{
+public:
+enum YY_PDDL_Parser_ENUM_TOKEN { YY_PDDL_Parser_NULL_TOKEN=0
+ ,TK_OPEN=258
+ ,TK_CLOSE=259
+ ,TK_OPEN_SQ=260
+ ,TK_CLOSE_SQ=261
+ ,TK_GREATER=262
+ ,TK_GREATEQ=263
+ ,TK_LESS=264
+ ,TK_LESSEQ=265
+ ,TK_COLON=266
+ ,TK_HASHT=267
+ ,TK_EQ=268
+ ,TK_HYPHEN=269
+ ,TK_PLUS=270
+ ,TK_MUL=271
+ ,TK_DIV=272
+ ,TK_UMINUS=273
+ ,TK_NEW_SYMBOL=274
+ ,TK_OBJ_SYMBOL=275
+ ,TK_TYPE_SYMBOL=276
+ ,TK_PRED_SYMBOL=277
+ ,TK_OBJFUN_SYMBOL=278
+ ,TK_FUN_SYMBOL=279
+ ,TK_VAR_SYMBOL=280
+ ,TK_ACTION_SYMBOL=281
+ ,TK_MISC_SYMBOL=282
+ ,TK_KEYWORD=283
+ ,TK_NEW_VAR_SYMBOL=284
+ ,TK_PREFERENCE_SYMBOL=285
+ ,TK_SET_SYMBOL=286
+ ,TK_FLOAT=287
+ ,TK_INT=288
+ ,TK_STRING=289
+ ,KW_REQS=290
+ ,KW_CONSTANTS=291
+ ,KW_PREDS=292
+ ,KW_FUNS=293
+ ,KW_TYPES=294
+ ,KW_DEFINE=295
+ ,KW_DOMAIN=296
+ ,KW_ACTION=297
+ ,KW_PROCESS=298
+ ,KW_EVENT=299
+ ,KW_ARGS=300
+ ,KW_PRE=301
+ ,KW_COND=302
+ ,KW_AT_START=303
+ ,KW_AT_END=304
+ ,KW_OVER_ALL=305
+ ,KW_EFFECT=306
+ ,KW_INVARIANT=307
+ ,KW_DURATION=308
+ ,KW_AND=309
+ ,KW_OR=310
+ ,KW_EXISTS=311
+ ,KW_FORALL=312
+ ,KW_IMPLY=313
+ ,KW_NOT=314
+ ,KW_WHEN=315
+ ,KW_EITHER=316
+ ,KW_PROBLEM=317
+ ,KW_FORDOMAIN=318
+ ,KW_OBJECTS=319
+ ,KW_INIT=320
+ ,KW_GOAL=321
+ ,KW_LENGTH=322
+ ,KW_SERIAL=323
+ ,KW_PARALLEL=324
+ ,KW_METRIC=325
+ ,KW_MINIMIZE=326
+ ,KW_MAXIMIZE=327
+ ,KW_DURATION_VAR=328
+ ,KW_TOTAL_TIME=329
+ ,KW_INCREASE=330
+ ,KW_DECREASE=331
+ ,KW_SCALE_UP=332
+ ,KW_SCALE_DOWN=333
+ ,KW_ASSIGN=334
+ ,KW_TAG=335
+ ,KW_NAME=336
+ ,KW_VARS=337
+ ,KW_SET_CONSTRAINT=338
+ ,KW_SETOF=339
+ ,KW_AT_LEAST_N=340
+ ,KW_AT_MOST_N=341
+ ,KW_EXACTLY_N=342
+ ,KW_CONTEXT=343
+ ,KW_FORMULA=344
+ ,KW_IRRELEVANT=345
+ ,KW_PLAN=346
+ ,KW_HEURISTIC=347
+ ,KW_OPT=348
+ ,KW_INF=349
+ ,KW_FACT=350
+ ,KW_SET=351
+ ,KW_EXPANSION=352
+ ,KW_TASKS=353
+ ,KW_PREFERENCE=354
+ ,KW_VIOLATED=355
+ ,KW_WITHIN=356
+ ,KW_ASSOC=357
+ ,KW_CONSTRAINTS=358
+ ,KW_ALWAYS=359
+ ,KW_SOMETIME=360
+ ,KW_AT_MOST_ONCE=361
+ ,KW_SOMETIME_BEFORE=362
+ ,KW_SOMETIME_AFTER=363
+ ,KW_ALWAYS_WITHIN=364
+ ,KW_IFF=365
+ ,KW_FALSE=366
+ ,KW_TRUE=367
+ ,KW_NUMBER=368
+ ,KW_UNDEFINED=369
+     };
+public:
+ int yyparse(void);
+ virtual void log_error(char *msg) = 0;
+ virtual int next_token() = 0;
+ yy_PDDL_Parser_stype yylval;
+ int yynerrs;
+ int yychar;
+public:
+ int yydebug;
+public:
+ PDDL_Parser(hsps::StringTable& t);
+public:
+ public: virtual std::ostream& at_position(std::ostream& s) = 0; virtual char* current_file() = 0; bool error_flag; private: hsps::PDDL_Base::variable_vec current_param; hsps::index_vec stored_n_param; hsps::PDDL_Base::TypeSet current_type_set; hsps::index_type last_n_functions; hsps::PDDL_Base::AtomBase* current_atom; hsps::PDDL_Base::atom_base_vec current_atom_stack; hsps::PDDL_Base::Context* current_context; hsps::lvector<Context*> stored_context; hsps::PDDL_Base::DKEL_Item* current_item; hsps::lvector<ConjunctiveGoal*> current_goal; hsps::PDDL_Base::Symbol* current_preference_name; hsps::PDDL_Base::HTableEntry* current_entry; char* current_plan_file; hsps::index_type n_plans_in_current_file;
+};
+typedef struct yy_buffer_state *YY_BUFFER_STATE;
+class PDDL_Scanner
+{
+ private:
+ char *yy_c_buf_p;
+ char yy_hold_char;
+ int yy_n_chars;
+ int yy_init;
+ int yy_start;
+ int yy_did_buffer_switch_on_eof;
+ private:
+ void yy_initialize();
+ int input();
+ int yyinput() {return input();};
+ int yy_get_next_buffer();
+ void yyunput( char c, char *buf_ptr );
+ long yy_get_previous_state_ ( void );
+ long yy_try_NUL_trans_ ( long current_state_ );
+ protected:
+ YY_BUFFER_STATE YY_CURRENT_BUFFER;
+ void yyrestart ( FILE *input_file );
+ void yy_switch_to_buffer( YY_BUFFER_STATE new_buffer );
+ void yy_load_buffer_state( void );
+ YY_BUFFER_STATE yy_create_buffer( FILE *file, int size );
+ void yy_delete_buffer( YY_BUFFER_STATE b );
+ void yy_init_buffer( YY_BUFFER_STATE b, FILE *file );
+ protected:
+ virtual void yy_echo()
+  ;
+ virtual int yy_input(char *buf,int &result,int max_size)
+  ;
+ virtual void yy_fatal_error(char *msg)
+  ;
+ virtual int yy_wrap()
+  ;
+ public:
+ char *yytext;
+ int yyleng;
+ FILE *yyin;
+ FILE *yyout;
+ int next_token ( yy_PDDL_Parser_stype& val);
+ PDDL_Scanner(hsps::StringTable& t) ;
+ virtual ~PDDL_Scanner() ;
+ int yy_flex_debug;
+ public:
+ private: hsps::StringTable& _tab; bool _reset; char* _filename; int _line_no; bool _trace_line; public: void open_file(char* fname, bool trace); void close_file(); char* current_file() const { return _filename; }; int current_line() const { return _line_no; };
+};
+namespace hsps {
+class Parser : public PDDL_Parser {
+  PDDL_Scanner scanner;
+ public:
+  Parser(StringTable& t) : PDDL_Parser(t), scanner(t) { };
+  void read(char *name, bool trace);
+  virtual int next_token();
+  virtual void log_error(char* msg);
+  virtual std::ostream& at_position(std::ostream& s);
+  virtual char* current_file();
+};
+}
+namespace hsps {
+class AH : public Heuristic {
+  void max_cost_mset(index_type m, const index_set& g, index_set& s);
+  void goal_relevant_remaining_actions(const index_set& g,
+           index_set& a,
+           bool_vec& rem);
+ protected:
+  CostTable* Hmax;
+  lvector<CostTable*> H_vec;
+  Statistics& stats;
+ public:
+  static count_type Hmax_wins;
+  static count_type Hsum_wins;
+  static count_type draws;
+  static bool use_linear_scan_eval;
+  AH(Instance& i, Statistics& s);
+  virtual ~AH();
+  index_type n_additive_components() { return H_vec.length(); };
+  CostTable* additive_component(index_type i) { return H_vec[i]; };
+  CostTable* max_component() { return Hmax; };
+  void compute_additive(const ACF& cost, const index_set_vec& p, bool useH2);
+  void compute_fractional(const ACF& cost, index_set_vec& p, bool useH2);
+  void compute_max(const ACF& cost, bool useH2);
+  void disable_max();
+  void compute_with_relevance_partitioning
+    (const ACF& cost, const index_set& g);
+  void compute_with_iterative_assignment
+    (const ACF& cost, const index_set& g, index_set_vec& app,
+     bool useH2, bool fractional, const index_set& g_limit);
+  void compute_with_iterative_assignment_1
+    (const ACF& cost, const index_set& g,
+     bool useH2, bool fractional, bool optimal,
+     const index_set& g_limit);
+  void compute_with_iterative_assignment_2
+    (const ACF& cost, const index_set& g, bool useH2, bool fractional,
+     const index_set& g_limit);
+  void compute_with_layered_partitioning
+    (const ACF& cost, const index_set& g);
+  void compute_layered_action_partition
+    (index_type m, const index_set& g, index_set_vec& p, index_type pg,
+     bool_vec& rem);
+  void compute_with_new_decomposition
+    (const ACF& cost, const index_set& g, bool useH2);
+  void compute_bottom_up_2
+    (const ACF& cost, const index_set& g, index_type p_max, bool useH2);
+  void compute_bottom_up
+    (const ACF& cost, const index_set& g, bool do_glue, bool useH2);
+  void compute_with_k_cuts
+    (const ACF& cost, const index_set& g, index_type k, bool useH2);
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual void write_eval(const index_set& s, std::ostream& st,
+     char* p = 0, bool e = true);
+  virtual void write_eval(const bool_vec& s, std::ostream& st,
+     char* p = 0, bool e = true);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+};
+}
+namespace hsps {
+class AtomSet {
+ protected:
+  Instance& instance;
+  bool_vec set;
+  index_type size;
+  index_type count();
+ private:
+  hsps::rational split(index_set g, index_type p, index_type n_out, index_type limit,
+       StateFactory& f, State* sp, Search& s, hsps::rational bound);
+  hsps::rational split_random(index_set g, index_type p, index_type n_out,
+       index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+ public:
+  static index_type max_set_size_encountered;
+  AtomSet(Instance& i);
+  AtomSet(Instance& i, const index_set& g);
+  AtomSet(Instance& i, const bool_vec& g);
+  AtomSet(const AtomSet& s);
+  ~AtomSet();
+  index_type atom_set_size() { return size; };
+  void add(const index_set& s);
+  void add(const bool_vec& s);
+  void del(const index_set& s);
+  void del(const bool_vec& s);
+  bool is_init_all();
+  bool is_init_some();
+  bool is_goal_all();
+  bool is_goal_some();
+  index_vec& copy_to(index_vec& s);
+  bool_vec& copy_to(bool_vec& s);
+  hsps::rational split(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound);
+  hsps::rational split_random(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+  int compare(const AtomSet& s);
+  index_type hash();
+};
+class AtomSetState : public AtomSet, public State {
+ protected:
+  Heuristic& heuristic;
+  hsps::rational est;
+  hsps::rational eval();
+  hsps::rational eval(hsps::rational b_est);
+  hsps::rational eval_with_trace_level(int level);
+  void apply_path_max();
+ public:
+  AtomSetState(Instance& i, Heuristic& h);
+  AtomSetState(Instance& i, Heuristic& h, const index_set& g);
+  AtomSetState(Instance& i, Heuristic& h, const bool_vec& g);
+  AtomSetState(const AtomSetState& s);
+  virtual ~AtomSetState();
+  index_type atom_set_size() { return size; };
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual void write(std::ostream& s);
+  virtual void write_eval(std::ostream& s, char* p = 0, bool e = true);
+};
+}
+namespace hsps {
+class SeqProgState : public AtomSetState, public StateFactory {
+ protected:
+  const ACF& cost;
+  index_type act;
+  BasicResourceState* res;
+  virtual bool applicable(Instance::Action& a);
+  virtual SeqProgState* apply(Instance::Action& a);
+  bool is_update(Instance::Action& a) {
+    return (a.del.empty() && (cost(a.index)).zero() && (res == 0));
+  };
+  void apply_update_actions();
+ public:
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c);
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c, const index_set& s);
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& s);
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c,
+        BasicResourceState* r);
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c, const index_set& s,
+        BasicResourceState* r);
+  SeqProgState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& s,
+        BasicResourceState* r);
+  SeqProgState(const SeqProgState& s);
+  virtual ~SeqProgState();
+  static bool separate_update_actions;
+  virtual bool is_final();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void set_predecessor(State* p);
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write_plan(std::ostream& s);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual void write(std::ostream& s);
+};
+class SeqCProgState : public SeqProgState {
+ public:
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c)
+    : SeqProgState(i, h, c) { };
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c, const index_set& s)
+    : SeqProgState(i, h, c, s) { };
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& s)
+    : SeqProgState(i, h, c, s) { };
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c, BasicResourceState* r)
+    : SeqProgState(i, h, c, r) { };
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c,
+        const index_set& s, BasicResourceState* r)
+    : SeqProgState(i, h, c, s, r) { };
+  SeqCProgState(Instance& i, Heuristic& h, const ACF& c,
+        const bool_vec& s, BasicResourceState* r)
+    : SeqProgState(i, h, c, s, r) { };
+  SeqCProgState(const SeqProgState& s)
+    : SeqProgState(s) { };
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual int compare(const State& s);
+  index_type hash();
+  virtual void write(std::ostream& s);
+};
+class RestrictedSeqProgState : public SeqProgState {
+ protected:
+  const bool_vec& p_atoms;
+  bool_vec& f_atoms;
+ public:
+  RestrictedSeqProgState(Instance& i, const bool_vec& pa, bool_vec& fa,
+    Heuristic& h, const ACF& c, const index_set& s)
+    : SeqProgState(i, h, c, s), p_atoms(pa), f_atoms(fa) { };
+  RestrictedSeqProgState(Instance& i, const bool_vec& pa, bool_vec& fa,
+    Heuristic& h, const ACF& c, const bool_vec& s)
+    : SeqProgState(i, h, c, s), p_atoms(pa), f_atoms(fa) { };
+  RestrictedSeqProgState(Instance& i, const bool_vec& pa, bool_vec& fa,
+    Heuristic& h, const ACF& c, const index_set& s,
+    BasicResourceState* r)
+    : SeqProgState(i, h, c, s, r), p_atoms(pa), f_atoms(fa) { };
+  RestrictedSeqProgState(Instance& i, const bool_vec& pa, bool_vec& fa,
+    Heuristic& h, const ACF& c, const bool_vec& s,
+    BasicResourceState* r)
+    : SeqProgState(i, h, c, s, r), p_atoms(pa), f_atoms(fa) { };
+  RestrictedSeqProgState(const RestrictedSeqProgState& s)
+    : SeqProgState(*this), p_atoms(s.p_atoms), f_atoms(s.f_atoms) { };
+  virtual ~RestrictedSeqProgState() { };
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+};
+class ExtendedSeqProgState : public SeqProgState {
+ protected:
+  virtual bool applicable(Instance::Action& a);
+  virtual SeqProgState* apply(Instance::Action& a);
+ public:
+  ExtendedSeqProgState(Instance& i, Heuristic& h, const ACF& c)
+    : SeqProgState(i, h, c) { };
+  ExtendedSeqProgState(Instance& i, Heuristic& h, const ACF& c,
+         const index_set& s)
+    : SeqProgState(i, h, c, s) { };
+  ExtendedSeqProgState(Instance& i, Heuristic& h, const ACF& c,
+   const bool_vec& s)
+    : SeqProgState(i, h, c, s) { };
+  ExtendedSeqProgState(const ExtendedSeqProgState& s)
+    : SeqProgState(s) { };
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+};
+class RelaxedSeqProgState : public SeqProgState {
+ protected:
+  index_set x_atoms;
+  bool_vec x_action;
+  void compute_x_actions();
+  void closure();
+  virtual bool applicable(Instance::Action& a);
+  virtual SeqProgState* apply(Instance::Action& a);
+ public:
+  RelaxedSeqProgState(Instance& i, const index_set& x, Heuristic& h,
+        const ACF& c, const index_set& s)
+    : SeqProgState(i, h, c, s), x_atoms(x)
+  {
+    compute_x_actions();
+    closure();
+  };
+  RelaxedSeqProgState(Instance& i, const index_set& x, Heuristic& h,
+        const ACF& c, const bool_vec& g)
+    : SeqProgState(i, h, c, g), x_atoms(x)
+  {
+    compute_x_actions();
+    closure();
+  };
+  RelaxedSeqProgState(const RelaxedSeqProgState& s);
+  virtual ~RelaxedSeqProgState() { };
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+};
+class FwdUnitHeuristic : public Heuristic {
+ public:
+  FwdUnitHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~FwdUnitHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+}
+namespace hsps {
+class ActionSequence : public index_vec, public Plan {
+ public:
+  ActionSequence() : index_vec(no_such_index, 0) { };
+  ActionSequence(const index_vec& vec) : index_vec(vec) { };
+  ActionSequence(const ActionSequence& seq) : index_vec(seq) { };
+  virtual ~ActionSequence() { };
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  virtual void output(Plan& to);
+};
+class ActionSequenceSet : public lvector<ActionSequence>, public PlanSet {
+ public:
+  ActionSequenceSet() : lvector<ActionSequence>() { };
+  virtual ~ActionSequenceSet() { };
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+};
+class CountActions
+: public lvector<count_type>, public Plan, public PlanSet
+{
+ public:
+  CountActions() : lvector<count_type>(0, 0) { };
+  CountActions(index_type n) : lvector<count_type>(0, n) { };
+  virtual ~CountActions() { };
+  void reset() { assign_value(0, length()); };
+  void reset(index_type n) { assign_value(0, n); };
+  count_type sum();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class ApxResult : public Result {
+  bool min_sol;
+  index_type sol_depth;
+ public:
+  ApxResult() : min_sol(false), sol_depth(0) { };
+  virtual ~ApxResult() { };
+  bool min_solution() { return min_sol; };
+  index_type solution_depth() { return sol_depth; };
+  virtual void solution(State& s, hsps::rational cost);
+  virtual bool more();
+};
+class Print : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  hsps::rational current_t;
+  amt_vec peak_use;
+  amt_vec res_cons;
+  count_type n_actions;
+  count_type n_plans;
+  hsps::rational sum_cost;
+ public:
+  static bool print_noops;
+  static bool decimal_time;
+  Print(Instance& i, ::std::ostream& s);
+  virtual ~Print();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintActions : public Plan, public PlanSet {
+ protected:
+  Instance& instance;
+  ::std::ostream& to;
+  char action_sep;
+  bool first_action;
+  char plan_sep;
+  bool first_plan;
+ public:
+  PrintActions(Instance& i, ::std::ostream& s);
+  PrintActions(Instance& i, ::std::ostream& s, char as);
+  PrintActions(Instance& i, ::std::ostream& s, char as, char ps);
+  virtual ~PrintActions();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintActionSetNames : public PrintActions {
+ public:
+  PrintActionSetNames(Instance& i, ::std::ostream& s)
+    : PrintActions(i, s) { };
+  PrintActionSetNames(Instance& i, ::std::ostream& s, char p)
+    : PrintActions(i, s, p) { };
+  virtual ~PrintActionSetNames() { };
+  virtual void insert(index_type act);
+};
+class PrintPDDL : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  hsps::rational start_t;
+ public:
+  PrintPDDL(Instance& i, ::std::ostream& s);
+  virtual ~PrintPDDL();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintIPC : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  bool temporal;
+  hsps::rational epsilon;
+  bool included_epsilon;
+  bool strict_separation;
+  hsps::rational start_t;
+  bool occ_current_t;
+ public:
+  PrintIPC(Instance& i, ::std::ostream& s);
+  virtual ~PrintIPC();
+  void set_epsilon(hsps::rational e, bool included, bool strict);
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintAssoc : public Plan {
+  Instance& instance;
+  ::std::ostream& to;
+ public:
+  PrintAssoc(Instance& i, ::std::ostream& s);
+  virtual ~PrintAssoc();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class Store : public Result, public ScheduleSet {
+  state_vec solutions;
+ public:
+  Store(Instance& i);
+  virtual ~Store();
+  void reset();
+  void clear();
+  virtual void solution(State& s, hsps::rational cost);
+  index_type n_solutions() { return solutions.length(); };
+  State* solution(index_type k);
+  index_type n_plans() { return length(); };
+  Schedule* plan(index_type k);
+  virtual void output(PlanSet& to);
+  virtual void output(Result& to);
+};
+class StoreFilter : public SearchResult {
+ protected:
+  Store& store;
+ public:
+  StoreFilter(Store& s) : store(s) { };
+  virtual ~StoreFilter() { };
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class StoreMinCost : public StoreFilter {
+ public:
+  StoreMinCost(Store& s) : StoreFilter(s) { };
+  virtual ~StoreMinCost() { };
+  virtual void solution(State& s, hsps::rational cost);
+};
+class StoreDistinct : public StoreFilter {
+  Instance& instance;
+ public:
+  static count_type n_discarded;
+  StoreDistinct(Instance& i, Store& s) : StoreFilter(s), instance(i) { };
+  virtual ~StoreDistinct() { };
+  virtual void solution(State& s, hsps::rational cost);
+};
+class Conflicts : public Result {
+  Instance& instance;
+  index_set nec_del;
+  index_set pos_del;
+  amt_vec min_peak;
+  amt_vec max_peak;
+  bool first;
+  bool need_to_clear;
+ public:
+  Conflicts(Instance& ins);
+  virtual ~Conflicts();
+  const index_set& nec_deleted() const { return nec_del; };
+  const index_set& pos_deleted() const { return pos_del; };
+  const amt_vec& min_peak_resource_use() const { return min_peak; };
+  const amt_vec& max_peak_resource_use() const { return max_peak; };
+  void clear();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions();
+};
+}
+namespace hsps {
+class HashTable {
+ public:
+  struct Entry {
+    State* state;
+    index_type depth;
+    hsps::rational cost;
+  };
+ private:
+  index_type size;
+  index_type nocc;
+  Entry* tab;
+  count_type hits;
+  count_type cols;
+  count_type miss;
+ public:
+  HashTable(index_type s);
+  ~HashTable();
+  void inc_occ_count() { nocc += 1; };
+  Entry& operator[](index_type i);
+  index_type index(State& s);
+  Entry* find(State& s);
+  void insert(State& s, hsps::rational v, index_type d);
+  void insert(State& s, hsps::rational v);
+  void clear();
+  double hit_ratio();
+  double HCF();
+  double TUF();
+};
+}
+namespace hsps {
+class IDA : public MultiSearchAlgorithm {
+  HashTable* ttab;
+  bool cycle_check;
+  hsps::rational current_bound;
+  count_type iteration_limit;
+  count_type iteration_count;
+  static const count_type TRACE_LEVEL_2_NOTIFY = 100000;
+ public:
+  IDA(Statistics& s, SearchResult& r);
+  IDA(Statistics& s, SearchResult& r, HashTable* t);
+  virtual ~IDA();
+  void set_iteration_limit(count_type i_max) { iteration_limit = i_max; };
+  void increase_iteration_limit(count_type i) { iteration_limit += i; };
+  count_type get_iteration_limit() { return iteration_limit; };
+  void set_cycle_check(bool cc) { cycle_check = cc; };
+  hsps::rational main(State& s, hsps::rational bound);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+  virtual hsps::rational cost() const;
+  virtual hsps::rational resume(State& s, hsps::rational b);
+};
+}
+namespace hsps {
+class Node;
+typedef Node* nodep;
+typedef lvector<nodep> node_vec;
+struct Link {
+  Node* node;
+  hsps::rational delta;
+  Link() : node(0), delta(0) { };
+  Link(Node* s, hsps::rational d) : node(s), delta(d) { };
+  Link& operator=(const Link& l);
+  bool operator==(const Link& l);
+  bool operator<(const Link& l);
+  bool operator>(const Link& l);
+  bool operator<=(const Link& l);
+  bool operator>=(const Link& l);
+};
+typedef svector<Link> link_vec;
+class Node {
+ public:
+  index_type id;
+  State* state;
+  link_vec succ;
+  bool closed;
+  hsps::rational acc;
+  hsps::rational est;
+  hsps::rational val;
+  hsps::rational opt;
+  index_type pos;
+  count_type exp;
+  Node* bp_pre;
+  hsps::rational bp_delta;
+  link_vec* all_pre;
+  Node() :
+    id(0), state(0), closed(false), acc(0), est(0), val(0), opt(POS_INF),
+    pos(no_such_index), exp(0), bp_pre(0), bp_delta(0), all_pre(0) { };
+  ~Node();
+  hsps::rational min_delta_to(Node* n);
+  bool solved() { return (opt).finite(); };
+  bool back_path_contains(Node* n);
+  void add_predecessor(Node* n, hsps::rational d);
+  void backup_costs(node_vec& p);
+  void write(std::ostream& s, const Name* p = 0);
+  void write_short(std::ostream& s, const Name* p = 0);
+  void write_graph_node(std::ostream& s);
+  void write_graph_edges(std::ostream& s);
+};
+class NodeQueue : public node_vec {
+  const node_vec::order& before;
+ public:
+  NodeQueue(const node_vec::order& b);
+  ~NodeQueue();
+  void check_queue();
+  Node* peek();
+  void enqueue(Node*);
+  Node* dequeue();
+  void shift_up(index_type i);
+  void shift_down(index_type i);
+};
+class NodeSet {
+ protected:
+  static index_type next_id;
+  node_vec roots;
+ public:
+  static bool write_state_in_graph_node;
+  virtual ~NodeSet();
+  virtual Node* insert_node(State& s) = 0;
+  virtual Node* find_node(State& s) = 0;
+  virtual void clear() = 0;
+  virtual void collect_nodes(node_vec& ns) = 0;
+  Node* insert_root_node(State& s);
+  void make_root(Node* n);
+  node_vec& root_nodes();
+  void compute_reverse_links(node_vec& v);
+  void compute_reverse_links();
+  void mark_solved_apsp();
+  void mark_solved();
+  void backup_costs();
+  void set_back_path_solution_cost(Node* n, hsps::rational c_sol);
+  void cache_pg(hsps::rational c_sol);
+  void back_path_to_sequence(Node* n, node_vec& ns);
+  State* build_path(node_vec& ns);
+  State* build_path(Node* tn);
+  void write_short(std::ostream& s, const Name* p = 0);
+  void write_graph(std::ostream& s);
+};
+class NodeSetSearchState : public State {
+  Node* node;
+  hsps::rational delta;
+  State* path;
+ public:
+  NodeSetSearchState(Node* n);
+  NodeSetSearchState(NodeSetSearchState* p, Link& l, State* s);
+  NodeSetSearchState(const NodeSetSearchState& s);
+  virtual ~NodeSetSearchState();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write(std::ostream& s);
+  virtual void write_plan(std::ostream& s);
+};
+class TreeNodeSet : public Node, public NodeSet {
+  TreeNodeSet* left;
+  TreeNodeSet* right;
+ public:
+  TreeNodeSet();
+  virtual ~TreeNodeSet();
+  virtual Node* insert_node(State& s);
+  virtual Node* find_node(State& s);
+  virtual void clear();
+  virtual void collect_nodes(node_vec& ns);
+};
+class HashNodeSet : public NodeSet {
+  index_type size;
+  TreeNodeSet** tab;
+ public:
+  HashNodeSet(index_type s);
+  virtual ~HashNodeSet();
+  virtual Node* insert_node(State& s);
+  virtual Node* find_node(State& s);
+  virtual void clear();
+  virtual void collect_nodes(node_vec& ns);
+};
+inline Link& Link::operator=(const Link& l)
+{
+  node = l.node;
+  delta = l.delta;
+  return *this;
+}
+inline bool Link::operator==(const Link& l)
+{
+  return ((node == l.node) && (delta == l.delta));
+}
+inline bool Link::operator<(const Link& l)
+{
+  return ((node < l.node) || ((node == l.node) && (delta < l.delta)));
+}
+inline bool Link::operator>(const Link& l)
+{
+  return ((node > l.node) || ((node == l.node) && (delta > l.delta)));
+}
+inline bool Link::operator<=(const Link& l)
+{
+  return ((node <= l.node) || ((node == l.node) && (delta <= l.delta)));
+}
+inline bool Link::operator>=(const Link& l)
+{
+  return ((node >= l.node) || ((node == l.node) && (delta >= l.delta)));
+}
+}
+namespace hsps {
+class NodeOrderForBFS : public node_vec::order {
+ public:
+  NodeOrderForBFS() { };
+  virtual bool operator()(const nodep& v0, const nodep& v1) const;
+};
+class BFS : public SingleSearchAlgorithm {
+  static NodeOrderForBFS b_op;
+ protected:
+  static const count_type TRACE_LEVEL_2_NOTIFY = 10000;
+  HashNodeSet graph;
+  NodeQueue queue;
+  Node* current_node;
+  hsps::rational best_node_cost;
+  count_type acc_succ;
+  count_type new_succ;
+  void update_cost(Node* n, Node* p, hsps::rational d);
+ public:
+  NodeSet& state_space() { return graph; };
+  BFS(Statistics& s, SearchResult& r);
+  BFS(Statistics& s, SearchResult& r, index_type nt_size);
+  virtual ~BFS();
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+  virtual hsps::rational resume();
+  virtual hsps::rational main();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual hsps::rational cost() const;
+  virtual bool done() const;
+};
+class BFS_PX : public BFS {
+  hsps::rational threshold;
+ public:
+  BFS_PX(Statistics& s, SearchResult& r, hsps::rational thresh)
+    : BFS(s, r), threshold(thresh) { };
+  BFS_PX(Statistics& s, SearchResult& r, index_type nt_size, hsps::rational thresh)
+    : BFS(s, r, nt_size), threshold(thresh) { };
+  virtual ~BFS_PX() { };
+  virtual hsps::rational main();
+};
+}
+int main(int argc, char *argv[]) {
+  hsps::StringTable symbols(50, hsps::lowercase_map);
+  bool opt_forward_rc = false;
+  bool opt_forward_H1 = false;
+  bool opt_forward_H2 = false;
+  bool opt_reverse_H2 = false;
+  bool opt_reverse_AH2 = false;
+  bool opt_fpia = false;
+  bool opt_bu_partition = false;
+  bool opt_bu_glue = false;
+  bool opt_bu2_partition = false;
+  hsps::rational bu2_ratio = (hsps::rational(1,4).reduce());
+  bool opt_kcut_partition = false;
+  hsps::index_type opt_kcuts = 2;
+  bool opt_compare_h = false;
+  bool opt_H0 = false;
+  bool opt_HAlmost0 = false;
+  bool opt_pdb = true;
+  bool opt_pdb_load = false;
+  bool opt_ipdb = false;
+  bool opt_fast_pdb = false;
+  hsps::index_type opt_repeat = 1;
+  bool opt_pdb_incremental = false;
+  bool opt_pdb_bin = false;
+  bool opt_pdb_random_bin = false;
+  bool opt_pdb_random_independent_bin = false;
+  bool opt_pdb_spanning = true;
+  hsps::index_type opt_pdb_span_search_limit = hsps::no_such_index;
+  hsps::index_type opt_pdb_random_bin_swaps = 10000;
+  bool opt_pdb_ip = false;
+  bool opt_pdb_weighted_independent_bin = false;
+  bool opt_pdb_collapse = true;
+  hsps::index_type opt_pdb_size = 1000000;
+  hsps::index_type opt_total_size = 10000000;
+  hsps::index_type opt_pdb_set_size = hsps::index_type_max;
+  bool opt_pdb_add = true;
+  bool opt_pdb_ext_add = false;
+  bool opt_pdb_add_all = false;
+  hsps::rational ext_add_threshold = 0;
+  bool opt_pdb_inc = true;
+  bool opt_maximal_add = true;
+  bool opt_sas_min = false;
+  bool opt_sas_safe = false;
+  bool opt_sas_select = false;
+  bool opt_apx_clique = false;
+  bool opt_extended = false;
+  bool opt_relaxed = false;
+  bool opt_resource = false;
+  bool opt_res_ipdb = false;
+  bool opt_compose_resources = false;
+  hsps::index_type composite_resource_size = 2;
+  bool opt_R2 = false;
+  bool opt_cost = false;
+  bool opt_zero = false;
+  bool opt_apply_cuts = true;
+  bool opt_preprocess = true;
+  bool opt_preprocess_2 = true;
+  bool opt_rm_irrelevant = false;
+  bool opt_find_invariants = true;
+  bool opt_quick_find_invariants = false;
+  bool opt_verify_invariants = true;
+  bool opt_extend_goal = true;
+  bool opt_find_all = false;
+  bool opt_all_different = false;
+  bool opt_exhaustive = false;
+  bool opt_print_plan = true;
+  bool opt_schedule = false;
+  bool opt_post_op = false;
+  bool opt_validate = false;
+  bool opt_pddl = false;
+  bool opt_ipc = false;
+  bool opt_strict_ipc = false;
+  hsps::rational epsilon = hsps::rational(1,100);
+  hsps::index_type ipdb_param_d_skip = 1;
+  hsps::index_type ipdb_param_s_max = hsps::index_type_max;
+  double ipdb_param_i_min = 0;
+  hsps::index_type ipdb_param_n_trials = 10;
+  hsps::index_type ipdb_param_n_samples = 100;
+  bool opt_save = false;
+  bool opt_cc = false;
+  bool opt_tt = false;
+  hsps::index_type opt_tt_size = 31337;
+  bool opt_bfs = false;
+  bool opt_bfs_px = false;
+  hsps::rational px_threshold = 0;
+  bool opt_bb = false;
+  bool opt_dfs = false;
+  bool opt_bfida = false;
+  bool opt_bfxd = false;
+  bool opt_test = false;
+  double time_limit = 0;
+  long memory_limit = 0;
+  hsps::index_type iteration_limit = 0;
+  hsps::count_type node_limit = 0;
+  hsps::rational cost_limit = 0;
+  int verbose_level = 1;
+  bool opt_bfs_write_graph = false;
+  bool opt_bfs_write_stats = false;
+  hsps::Statistics parse_stats;
+  hsps::Parser* reader = new hsps::Parser(symbols);
+  hsps::LC_RNG rng;
+  for (int k = 1; k < argc; k++) {
+    if ((strcmp(argv[k],"-v") == 0) && (k < argc - 1)) {
+      verbose_level = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-dba-semantics") == 0) {
+      hsps::PDDL_Base::del_before_add_semantics = true;
+    }
+    else if (strcmp(argv[k],"-use-strict-borrow") == 0) {
+      hsps::PDDL_Base::use_strict_borrow_definition = true;
+    }
+    else if (strcmp(argv[k],"-use-extended-borrow") == 0) {
+      hsps::PDDL_Base::use_extended_borrow_definition = true;
+    }
+    else if (strcmp(argv[k],"-no-compile") == 0) {
+      hsps::PDDL_Base::create_all_atoms = true;
+      hsps::PDDL_Base::compile_away_disjunctive_preconditions = false;
+      hsps::PDDL_Base::compile_away_conditional_effects = false;
+    }
+    else if (strcmp(argv[k],"-no-compact") == 0) {
+      hsps::PDDL_Base::compact_resource_effects = false;
+    }
+    else if (strcmp(argv[k],"-test") == 0) {
+      opt_test = true;
+    }
+    else if (strcmp(argv[k],"-x") == 0) {
+      opt_extended = true;
+    }
+    else if (strcmp(argv[k],"-relax") == 0) {
+      opt_relaxed = true;
+    }
+    else if (strcmp(argv[k],"-res") == 0) {
+      opt_resource = true;
+    }
+    else if (strcmp(argv[k],"-res-ipdb") == 0) {
+      opt_res_ipdb = true;
+    }
+    else if ((strcmp(argv[k],"-compose") == 0) && (k < argc - 1)) {
+      opt_compose_resources = true;
+      composite_resource_size = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-cost") == 0) {
+      opt_cost = true;
+    }
+    else if (strcmp(argv[k],"-zero") == 0) {
+      opt_zero = true;
+    }
+    else if (strcmp(argv[k],"-sua") == 0) {
+      hsps::SeqProgState::separate_update_actions = true;
+    }
+    else if (strcmp(argv[k],"-cut") == 0) {
+      opt_apply_cuts = true;
+    }
+    else if (strcmp(argv[k],"-no-cut") == 0) {
+      opt_apply_cuts = false;
+    }
+    else if (strcmp(argv[k],"-prep") == 0) {
+      opt_preprocess = true;
+    }
+    else if (strcmp(argv[k],"-prep-1") == 0) {
+      opt_preprocess = true;
+      opt_preprocess_2 = false;
+    }
+    else if (strcmp(argv[k],"-no-prep") == 0) {
+      opt_preprocess = false;
+    }
+    else if (strcmp(argv[k],"-extend") == 0) {
+      opt_extend_goal = true;
+    }
+    else if (strcmp(argv[k],"-no-extend") == 0) {
+      opt_extend_goal = false;
+    }
+    else if (strcmp(argv[k],"-rm") == 0) {
+      opt_rm_irrelevant = true;
+    }
+    else if (strcmp(argv[k],"-find") == 0) {
+      opt_find_invariants = true;
+    }
+    else if (strcmp(argv[k],"-quick-find") == 0) {
+      opt_quick_find_invariants = true;
+    }
+    else if (strcmp(argv[k],"-no-find") == 0) {
+      opt_find_invariants = false;
+      opt_quick_find_invariants = false;
+    }
+    else if (strcmp(argv[k],"-verify") == 0) {
+      opt_verify_invariants = true;
+    }
+    else if (strcmp(argv[k],"-no-verify") == 0) {
+      opt_verify_invariants = false;
+    }
+    else if (strcmp(argv[k],"-r") == 0) {
+      opt_reverse_H2 = true;
+      opt_pdb = false;
+      opt_find_invariants = false;
+      opt_verify_invariants = false;
+    }
+    else if (strcmp(argv[k],"-rAH") == 0) {
+      opt_reverse_AH2 = true;
+      opt_pdb = false;
+      opt_find_invariants = false;
+      opt_verify_invariants = false;
+    }
+    else if (strcmp(argv[k],"-fpia") == 0) {
+      opt_fpia = true;
+    }
+    else if (strcmp(argv[k],"-use-lse") == 0) {
+      hsps::AH::use_linear_scan_eval = true;
+    }
+    else if (strcmp(argv[k],"-pbu") == 0) {
+      opt_bu_partition = true;
+    }
+    else if (strcmp(argv[k],"-pbug") == 0) {
+      opt_bu_partition = true;
+      opt_bu_glue = true;
+    }
+    else if ((strcmp(argv[k],"-pbu2") == 0) && (k < argc - 1)) {
+      opt_bu2_partition = true;
+      bu2_ratio = hsps::rational::ator(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-pkc") == 0) && (k < argc - 1)) {
+      opt_kcut_partition = true;
+      opt_kcuts = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-f") == 0) {
+      opt_forward_rc = true;
+      opt_pdb = false;
+      opt_find_invariants = false;
+      opt_verify_invariants = false;
+    }
+    else if (strcmp(argv[k],"-f1") == 0) {
+      opt_forward_H1 = true;
+      opt_pdb = false;
+      opt_find_invariants = false;
+      opt_verify_invariants = false;
+    }
+    else if (strcmp(argv[k],"-f2") == 0) {
+      opt_forward_H2 = true;
+      opt_pdb = false;
+      opt_find_invariants = false;
+      opt_verify_invariants = false;
+    }
+    else if (strcmp(argv[k],"-0") == 0) {
+      opt_H0 = true;
+      opt_pdb = false;
+      opt_find_invariants = false;
+      opt_verify_invariants = false;
+    }
+    else if (strcmp(argv[k],"-almost-blind") == 0) {
+      opt_HAlmost0 = true;
+      opt_pdb = false;
+      opt_find_invariants = false;
+      opt_verify_invariants = false;
+    }
+    else if (strcmp(argv[k],"-compare") == 0) {
+      opt_compare_h = true;
+    }
+    else if (strcmp(argv[k],"-pdb-load") == 0) {
+      opt_pdb_load = true;
+      opt_pdb = false;
+    }
+    else if (strcmp(argv[k],"-pdb-fast") == 0) {
+      opt_fast_pdb = true;
+    }
+    else if (strcmp(argv[k],"-ipdb") == 0) {
+      opt_ipdb = true;
+      opt_pdb = false;
+      opt_extend_goal = false;
+      ipdb_param_d_skip = 1;
+      ipdb_param_i_min = 0.01;
+      ipdb_param_n_trials = 10;
+      ipdb_param_n_samples = 100;
+    }
+    else if ((strcmp(argv[k],"-ipdb-param") == 0) && (k < argc - 5)) {
+      ipdb_param_d_skip = atoi(argv[++k]);
+      ipdb_param_s_max = atoi(argv[++k]);
+      ipdb_param_i_min = atof(argv[++k]);
+      ipdb_param_n_trials = atoi(argv[++k]);
+      ipdb_param_n_samples = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-repeat") == 0) && (k < argc - 1)) {
+      opt_repeat = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-pdb-i") == 0) {
+      opt_pdb_incremental = true;
+      opt_extend_goal = false;
+      ipdb_param_d_skip = 1;
+      ipdb_param_n_samples = 25;
+    }
+    else if ((strcmp(argv[k],"-pdb-i-param") == 0) && (k < argc - 2)) {
+      opt_pdb_incremental = true;
+      opt_extend_goal = false;
+      ipdb_param_d_skip = atoi(argv[++k]);
+      ipdb_param_n_samples = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-pdb-bin") == 0) {
+      opt_pdb_bin = true;
+    }
+    else if (strcmp(argv[k],"-pdb-rbin") == 0) {
+      opt_pdb_random_bin = true;
+    }
+    else if (strcmp(argv[k],"-pdb-rib") == 0) {
+      opt_pdb_random_independent_bin = true;
+    }
+    else if (strcmp(argv[k],"-pdb-strict-rib") == 0) {
+      opt_pdb_random_independent_bin = true;
+      opt_pdb_collapse = false;
+    }
+    else if ((strcmp(argv[k],"-rbin-swaps") == 0) && (k < argc - 1)) {
+      opt_pdb_random_bin_swaps = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-pdb-no-span") == 0) {
+      opt_pdb_spanning = false;
+    }
+    else if ((strcmp(argv[k],"-pdb-span-search-limit") == 0) && (k < argc - 1)) {
+      opt_pdb_span_search_limit = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-pdb-ip") == 0) {
+      opt_pdb_ip = true;
+    }
+    else if (strcmp(argv[k],"-pdb-windbin") == 0) {
+      opt_pdb_weighted_independent_bin = true;
+    }
+    else if (strcmp(argv[k],"-pdb-strict-windbin") == 0) {
+      opt_pdb_weighted_independent_bin = true;
+      opt_pdb_collapse = false;
+    }
+    else if ((strcmp(argv[k],"-pdb-size") == 0) && (k < argc - 1)) {
+      opt_pdb_size = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-pdb-total-size") == 0) && (k < argc - 1)) {
+      opt_total_size = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-pdb-set-size") == 0) && (k < argc - 1)) {
+      opt_pdb_set_size = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-add") == 0) {
+      opt_pdb_add = true;
+    }
+    else if (strcmp(argv[k],"-no-add") == 0) {
+      opt_pdb_add = false;
+    }
+    else if (strcmp(argv[k],"-apx-add") == 0) {
+      opt_pdb_add = true;
+      opt_maximal_add = false;
+    }
+    else if (strcmp(argv[k],"-add-all") == 0) {
+      opt_pdb_add = true;
+      opt_pdb_add_all = true;
+    }
+    else if ((strcmp(argv[k],"-xadd") == 0) && (k < argc - 1)) {
+      opt_pdb_add = true;
+      opt_pdb_ext_add = true;
+      ext_add_threshold = hsps::rational::ator(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-inc") == 0) {
+      opt_pdb_inc = true;
+    }
+    else if (strcmp(argv[k],"-no-inc") == 0) {
+      opt_pdb_inc = false;
+    }
+    else if (strcmp(argv[k],"-R2") == 0) {
+      opt_R2 = true;
+    }
+    else if (strcmp(argv[k],"-bfs") == 0) {
+      opt_bfs = true;
+      opt_apply_cuts = false;
+    }
+    else if (strcmp(argv[k],"-bfida") == 0) {
+      opt_bfida = true;
+      opt_apply_cuts = false;
+    }
+    else if (strcmp(argv[k],"-bfxd") == 0) {
+      opt_bfxd = true;
+      opt_apply_cuts = false;
+    }
+    else if ((strcmp(argv[k],"-px") == 0) && (k < argc - 1)) {
+      opt_bfs_px = true;
+      px_threshold = hsps::rational::ator(argv[++k]);
+      opt_apply_cuts = false;
+    }
+    else if (strcmp(argv[k],"-bb") == 0) {
+      opt_bb = true;
+    }
+    else if (strcmp(argv[k],"-dfs") == 0) {
+      opt_dfs = true;
+    }
+    else if (strcmp(argv[k],"-cc") == 0) {
+      opt_cc = true;
+    }
+    else if (strcmp(argv[k],"-tt") == 0) {
+      opt_tt = true;
+    }
+    else if ((strcmp(argv[k],"-tt-size") == 0) && (k < argc - 1)) {
+      opt_tt_size = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-all") == 0) {
+      opt_find_all = true;
+    }
+    else if (strcmp(argv[k],"-all-different") == 0) {
+      opt_find_all = true;
+      opt_all_different = true;
+    }
+    else if (strcmp(argv[k],"-ex") == 0) {
+      opt_find_all = false;
+      opt_exhaustive = true;
+    }
+    else if ((strcmp(argv[k],"-t") == 0) && (k < argc - 1)) {
+      time_limit = atof(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-y") == 0) && (k < argc - 1)) {
+      memory_limit = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-i") == 0) && (k < argc - 1)) {
+      iteration_limit = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-c") == 0) && (k < argc - 1)) {
+      cost_limit = hsps::rational::ator(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-n") == 0) && (k < argc - 1)) {
+      node_limit = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-val") == 0) {
+      opt_validate = true;
+    }
+    else if (strcmp(argv[k],"-schedule") == 0) {
+      opt_schedule = true;
+    }
+    else if (strcmp(argv[k],"-post") == 0) {
+      opt_schedule = true;
+      opt_post_op = true;
+    }
+    else if (strcmp(argv[k],"-no-plan") == 0) {
+      opt_print_plan = false;
+    }
+    else if (strcmp(argv[k],"-pddl") == 0) {
+      opt_print_plan = true;
+      opt_pddl = true;
+      opt_ipc = false;
+    }
+    else if (strcmp(argv[k],"-ipc") == 0) {
+      opt_print_plan = true;
+      opt_ipc = true;
+      opt_pddl = false;
+    }
+    else if (strcmp(argv[k],"-strict-ipc") == 0) {
+      opt_print_plan = true;
+      opt_ipc = true;
+      opt_strict_ipc = true;
+      opt_pddl = false;
+    }
+    else if ((strcmp(argv[k],"-epsilon") == 0) && (k < argc - 1)) {
+      epsilon = hsps::rational::ator(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-nsn") == 0) {
+      hsps::Instance::write_atom_set_with_symbolic_names = false;
+      hsps::Instance::write_action_set_with_symbolic_names = false;
+    }
+    else if (strcmp(argv[k],"-save") == 0) {
+      opt_save = true;
+    }
+    else if (strcmp(argv[k],"-sas-select") == 0) {
+      opt_sas_select = true;
+    }
+    else if (strcmp(argv[k],"-sas-min") == 0) {
+      opt_sas_min = true;
+    }
+    else if (strcmp(argv[k],"-sas-safe") == 0) {
+      opt_sas_safe = true;
+    }
+    else if (strcmp(argv[k],"-ac") == 0) {
+      opt_apx_clique = true;
+    }
+    else if (((strcmp(argv[k],"-rnd") == 0) ||
+       (strcmp(argv[k],"-r") == 0)) &&
+      (k < argc - 1)) {
+      rng.seed(atoi(argv[++k]));
+    }
+    else if ((strcmp(argv[k],"-rnd-pid") == 0) ||
+      (strcmp(argv[k],"-rp") == 0)) {
+      rng.seed_with_pid();
+    }
+    else if ((strcmp(argv[k],"-rnd-time") == 0) ||
+      (strcmp(argv[k],"-rt") == 0)) {
+      rng.seed_with_time();
+    }
+    else if ((strcmp(argv[k],"-exclude") == 0) && (k < argc - 1)) {
+      char* tag = argv[++k];
+      if (strcmp(tag, "all") == 0) {
+ hsps::PDDL_Base::exclude_all_dkel_items = true;
+      }
+      else {
+ const hsps::StringTable::Cell* c = symbols.find(tag);
+ if (c) hsps::PDDL_Base::excluded_dkel_tags.insert(c->text);
+      }
+    }
+    else if ((strcmp(argv[k],"-require") == 0) && (k < argc - 1)) {
+      const hsps::StringTable::Cell* c = symbols.find(argv[++k]);
+      if (c) hsps::PDDL_Base::required_dkel_tags.insert(c->text);
+    }
+    else if (strcmp(argv[k],"-strict") == 0) {
+      hsps::PDDL_Base::best_effort = false;
+    }
+    else if (strcmp(argv[k],"-bfs-write-stats") == 0) {
+      opt_bfs_write_stats = true;
+    }
+    else if (strcmp(argv[k],"-bfs-write-graph") == 0) {
+      opt_bfs_write_graph = true;
+    }
+    else if (*argv[k] != '-') {
+      parse_stats.start();
+      reader->read(argv[k], false);
+      parse_stats.stop();
+    }
+  }
+  hsps::SearchAlgorithm::default_trace_level = verbose_level;
+  hsps::Heuristic::default_trace_level = verbose_level - 1;
+  hsps::Instance::default_trace_level = verbose_level - 1;
+  hsps::Preprocessor::default_trace_level = verbose_level - 1;
+  if (verbose_level < 1) opt_print_plan = false;
+  if (verbose_level <= 0) hsps::PDDL_Base::write_warnings = false;
+  if (verbose_level > 1) hsps::PDDL_Base::write_info = true;
+  hsps::Instance instance;
+  hsps::cost_vec saved_dur;
+  hsps::cost_vec saved_res;
+  hsps::Statistics stats;
+  hsps::count_type pre_search_nodes = 0;
+  hsps::Preprocessor prep(instance, stats);
+  hsps::rational root_est_cost = 0;
+  bool solved = false;
+  bool optimally = false;
+  hsps::rational solution_cost = 0;
+  hsps::Store store(instance);
+  hsps::HashTable* tt = 0;
+  stats.enable_interrupt(false);
+  if (time_limit > 0) stats.enable_time_out(time_limit, false);
+  if (memory_limit > 0) stats.enable_memory_limit(memory_limit, false);
+  stats.start();
+  std::cerr << "instantiating..." << std::endl;
+  reader->instantiate(instance);
+  if (opt_resource && opt_compose_resources && (instance.n_resources() > 1)) {
+    hsps::mSubsetEnumerator crs(instance.n_resources(),
+    composite_resource_size);
+    bool more = crs.first();
+    while (more) {
+      hsps::index_set s;
+      crs.current_set(s);
+      instance.create_composite_resource(s);
+      more = crs.next();
+    }
+  }
+  if (opt_preprocess) {
+    std::cerr << "preprocessing..." << std::endl;
+    prep.preprocess(opt_preprocess_2 && !opt_rm_irrelevant);
+    if (opt_rm_irrelevant) {
+      prep.compute_irrelevant_atoms();
+      prep.remove_irrelevant_atoms();
+      if (opt_preprocess_2)
+ prep.preprocess(true);
+    }
+    if (!instance.cross_referenced()) {
+      std::cerr << "re-cross referencing..." << std::endl;
+      instance.cross_reference();
+    }
+  }
+  else {
+    std::cerr << "cross referencing..." << std::endl;
+    instance.cross_reference();
+  }
+  if (opt_quick_find_invariants) {
+    hsps::graph* g_inc = prep.inconsistency_graph();
+    prep.find_inconsistent_set_invariants(*g_inc);
+    instance.add_missing_negation_invariants();
+  }
+  else if (opt_find_invariants) {
+    prep.bfs_find_invariants();
+  }
+  if (opt_verify_invariants) {
+    prep.verify_invariants(*(prep.inconsistency()));
+    prep.remove_unverified_invariants();
+  }
+  hsps::index_set original_goal_atoms(instance.goal_atoms);
+  if (opt_extend_goal) {
+    hsps::index_set new_goals;
+    prep.implied_atom_set(instance.goal_atoms,new_goals,*prep.inconsistency());
+    std::cerr << new_goals.length() << " implied goals found" << std::endl;
+    if (new_goals.length() > 0) {
+      hsps::index_set new_goal(instance.goal_atoms);
+      new_goal.insert(new_goals);
+      instance.set_goal(new_goal);
+    }
+  }
+  stats.stop();
+  std::cerr << "instance " << instance.name << " built in "
+     << stats.time() << " seconds" << std::endl;
+  std::cerr << instance.n_atoms() << " atoms ("
+     << instance.goal_atoms.length() << " goals), "
+     << instance.n_resources() << " resources ("
+     << instance.n_reusable_resources() << " reusable, "
+     << instance.n_consumable_resources() << " consumable), "
+     << instance.n_actions() << " actions, "
+     << instance.n_invariants() << " invariants"
+     << std::endl;
+  hsps::Heuristic* cost_est = 0;
+  hsps::estimator_vec resource_est(0, 0);
+  if (!stats.break_signal_raised()) {
+    stats.start();
+    if (opt_H0) {
+      cost_est = new hsps::ZeroHeuristic(instance);
+    }
+    else if (opt_HAlmost0) {
+      cost_est = new hsps::FwdUnitHeuristic(instance);
+    }
+    else if (opt_forward_rc) {
+      hsps::ForwardReachabilityCheck* fh =
+ new hsps::ForwardReachabilityCheck(instance, instance.goal_atoms);
+      cost_est = fh;
+    }
+    else if (opt_forward_H1) {
+      hsps::ACF* cost = (opt_cost ?
+    (hsps::ACF*)new hsps::CostACF(instance) :
+    (opt_zero ? (hsps::ACF*)new hsps::ZeroACF() :
+     (hsps::ACF*)new hsps::UnitACF()));
+      hsps::ForwardH1* fh =
+ new hsps::ForwardH1(instance, instance.goal_atoms, *cost, stats);
+      cost_est = fh;
+    }
+    else if (opt_forward_H2) {
+      hsps::ACF* cost = (opt_cost ?
+     (hsps::ACF*)new hsps::CostACF(instance) :
+     (opt_zero ? (hsps::ACF*)new hsps::ZeroACF() :
+      (hsps::ACF*)new hsps::UnitACF()));
+      hsps::ForwardH2* fh =
+ new hsps::ForwardH2(instance, instance.goal_atoms, *cost, stats);
+      cost_est = fh;
+    }
+    else if (opt_reverse_H2 || opt_reverse_AH2) {
+      std::cerr << "constructing reversed instance..." << std::endl;
+      hsps::Instance* c_instance = instance.copy();
+      c_instance->complete_atom_negations();
+      c_instance->cross_reference();
+      hsps::pair_vec pn;
+      for (hsps::index_type k = 0; k < c_instance->n_atoms(); k++)
+ if (k < c_instance->atoms[k].neg)
+   pn.append(hsps::index_pair(k, c_instance->atoms[k].neg));
+      assert((pn.length() * 2) == c_instance->n_atoms());
+      hsps::mapping bm(c_instance->n_atoms());
+      for (hsps::index_type k = instance.n_atoms(); k < c_instance->n_atoms(); k++)
+ bm[k] = hsps::no_such_index;
+      hsps::AtomMapAdapter c_inc(*c_instance, bm, *(prep.inconsistency()));
+      for (hsps::index_type i = 0; i < pn.length(); i++) {
+ if ((c_inc.incremental_eval(c_instance->goal_atoms, pn[i].first)).infinite()) {
+   c_instance->atoms[pn[i].second].goal = true;
+   c_instance->goal_atoms.insert(pn[i].second);
+ }
+ else if ((c_inc.incremental_eval(c_instance->goal_atoms, pn[i].second)).infinite()) {
+   c_instance->atoms[pn[i].first].goal = true;
+   c_instance->goal_atoms.insert(pn[i].first);
+ }
+      }
+      for (hsps::index_type k = 0; k < c_instance->n_actions(); k++) {
+ for (hsps::index_type i = 0; i < c_instance->actions[k].add.length(); i++)
+   if ((c_inc.incremental_eval(c_instance->actions[k].pre, c_instance->actions[k].add[i])).infinite())
+     c_instance->actions[k].pre.insert(c_instance->atoms[c_instance->actions[k].add[i]].neg);
+ for (hsps::index_type i = 0; i < c_instance->actions[k].del.length(); i++)
+   if ((c_inc.incremental_eval(c_instance->actions[k].pre, c_instance->atoms[c_instance->actions[k].del[i]].neg)).infinite())
+     c_instance->actions[k].pre.insert(c_instance->actions[k].del[i]);
+      }
+      hsps::Instance* r_instance = new hsps::Instance(instance.name);
+      r_instance->reverse_copy(*c_instance);
+      r_instance->cross_reference();
+      std::cerr << "reversed instance: "
+  << r_instance->n_atoms() << " atoms ("
+  << r_instance->goal_atoms.length() << " goals), "
+  << r_instance->n_actions() << " actions, "
+  << std::endl;
+      delete c_instance;
+      std::cerr << "computing heuristic..." << std::endl;
+      hsps::ACF* cost = (opt_cost ?
+     (hsps::ACF*)new hsps::CostACF(*r_instance) :
+     (opt_zero ? (hsps::ACF*)new hsps::ZeroACF() :
+      (hsps::ACF*)new hsps::UnitACF()));
+      if (opt_reverse_AH2) {
+ hsps::AH* h = new hsps::AH(*r_instance, stats);
+ if (opt_kcut_partition) {
+   h->compute_with_k_cuts(*cost, r_instance->goal_atoms, opt_kcuts, true);
+   h->compute_max(*cost, true);
+ }
+ else if (opt_bu2_partition) {
+   h->compute_bottom_up_2
+     (*cost, r_instance->goal_atoms,
+      (hsps::index_type)((bu2_ratio * r_instance->n_atoms()).ceil().numerator()), true);
+ }
+ else if (opt_bu_partition) {
+   h->compute_bottom_up(*cost, r_instance->goal_atoms, opt_bu_glue, true);
+ }
+ else {
+   h->compute_with_iterative_assignment_2
+     (*cost, r_instance->goal_atoms, true, opt_fpia, r_instance->goal_atoms);
+ }
+ hsps::CompleteNegationAdapter* rh =
+   new hsps::CompleteNegationAdapter(instance, pn, *h);
+ cost_est = rh;
+      }
+      else {
+ hsps::CostTable* h = new hsps::CostTable(*r_instance, stats);
+ h->compute_H2(*cost);
+ hsps::CompleteNegationAdapter* rh =
+   new hsps::CompleteNegationAdapter(instance, pn, *h);
+ cost_est = rh;
+      }
+    }
+    stats.stop();
+    if (!stats.break_signal_raised()) {
+      std::cerr << "heuristic computed in " << stats.time()
+  << " seconds (" << stats << ")" << std::endl;
+    }
+    pre_search_nodes = stats.total_nodes();
+    if (!stats.break_signal_raised()) {
+      hsps::State* search_root = 0;
+      if (opt_extended) {
+ hsps::ACF* acf = (opt_cost ?
+     (hsps::ACF*)new hsps::CostACF(instance) :
+     (hsps::ACF*)new hsps::UnitACF());
+ search_root =
+   new hsps::ExtendedSeqProgState(instance, *cost_est, *acf,
+      instance.init_atoms);
+      }
+      else {
+ hsps::ACF* acf = (opt_cost ?
+     (hsps::ACF*)new hsps::CostACF(instance) :
+     (hsps::ACF*)new hsps::UnitACF());
+ hsps::BasicResourceState* rcs =
+   (opt_resource ? new hsps::BasicResourceState(instance, resource_est) : 0);
+ if (opt_apply_cuts)
+   search_root = new hsps::SeqCProgState(instance, *cost_est, *acf,
+      instance.init_atoms, rcs);
+ else
+   search_root = new hsps::SeqProgState(instance, *cost_est, *acf,
+            instance.init_atoms, rcs);
+      }
+      std::cerr << "search root: " << *search_root << std::endl;
+      std::cerr << "estimated goal cost: "
+  << cost_est->eval(instance.init_atoms)
+  << std::endl;
+      hsps::SearchAlgorithm* search = 0;
+      hsps::SearchResult* result = &store;
+      if (opt_bfs) {
+ if (opt_bfs_px) {
+   std::cerr << "using partial expansion A*..." << std::endl;
+   search = new hsps::BFS_PX(stats, *result, px_threshold);
+ }
+ else {
+   std::cerr << "using A*..." << std::endl;
+   search = new hsps::BFS(stats, *result);
+ }
+      }
+      else if (opt_tt) {
+ std::cerr << "using IDA* with transposition table..." << std::endl;
+ tt = new hsps::HashTable(opt_tt_size);
+ hsps::IDA* i_search = new hsps::IDA(stats, *result, tt);
+ i_search->set_cycle_check(opt_cc);
+ if (iteration_limit > 0)
+   i_search->set_iteration_limit(iteration_limit);
+ search = i_search;
+      }
+      else {
+ std::cerr << "using IDA*..." << std::endl;
+ hsps::IDA* i_search = new hsps::IDA(stats, *result);
+ i_search->set_cycle_check(opt_cc);
+ if (iteration_limit > 0)
+   i_search->set_iteration_limit(iteration_limit);
+ search = i_search;
+      }
+      if (cost_limit > 0) search->set_cost_limit(cost_limit);
+      if (node_limit > 0) search->set_node_limit(node_limit);
+      root_est_cost = search_root->est_cost();
+      std::cerr << "searching..." << std::endl;
+      solution_cost = search->start(*search_root);
+      if (!stats.break_signal_raised()) {
+ std::cerr << "search complete (" << stats << ")" << std::endl;
+      }
+      solved = search->solved();
+      optimally = search->optimal();
+      if (!search->optimal())
+ solution_cost = search->cost();
+      if (opt_bfs && opt_bfs_write_graph) {
+ hsps::NodeSet& g = ((hsps::BFS*)search)->state_space();
+ g.write_graph(std::cout);
+      }
+      if (opt_bfs && opt_bfs_write_stats) {
+ hsps::NodeSet& g = ((hsps::BFS*)search)->state_space();
+ g.write_short(std::cout, instance.name);
+      }
+    }
+  }
+  hsps::rational min_makespan = POS_INF;
+  if (solved && opt_validate) {
+    for (hsps::index_type p = 0; p < store.n_solutions(); p++) {
+      hsps::Schedule* plan = store.plan(p);
+      hsps::ExecTrace trace(instance);
+      std::cerr << "simulating plan " << p << "..." << std::endl;
+      bool ok = plan->simulate(&trace);
+      if (ok) {
+ std::cout << "plan " << p << " ok" << std::endl;
+ if (instance.n_resources() > 0) {
+   hsps::amt_vec peak;
+   trace.peak_resource_use(peak);
+   for (hsps::index_type k = 0; k < instance.n_resources(); k++) {
+     hsps::rational ratio = (peak[k] / instance.resources[k].init);
+     std::cout << instance.resources[k].name
+        << '\t' << peak[k]
+        << '\t' << instance.resources[k].init
+        << '\t' << std::resetiosflags(std::ios::scientific) << ((ratio*100).decimal())
+        << std::endl;
+   }
+ }
+      }
+      else {
+ std::cerr << "plan " << p << " failed" << std::endl;
+      }
+    }
+  }
+  if (opt_ipc || (verbose_level == 0)) {
+    if (opt_ipc) {
+      std::cout << "; Time " << hsps::Stopwatch::seconds() << std::endl;
+      std::cout << "; ParsingTime " << parse_stats.total_time() << std::endl;
+      if (solved) {
+ if (opt_cost) {
+   std::cout << "; NrActions " << std::endl;
+   std::cout << "; MakeSpan " << std::endl;
+   std::cout << "; MetricValue " << std::resetiosflags(std::ios::scientific) << ((solution_cost).decimal())
+      << std::endl;
+ }
+ else {
+   std::cout << "; NrActions " << solution_cost << std::endl;
+   std::cout << "; MakeSpan " << std::endl;
+   std::cout << "; MetricValue " << std::endl;
+ }
+ hsps::PrintIPC print_plan(instance, std::cout);
+ store.output(print_plan);
+      }
+      else {
+ std::cout << "; Not Solved (" << stats.flags() << ")" << std::endl;
+      }
+    }
+    else if (opt_pddl) {
+      if (solved && opt_print_plan) {
+ hsps::PrintPDDL print_plan(instance, std::cout);
+ store.output(print_plan);
+      }
+    }
+    if (opt_ipc || opt_pddl)
+      std::cout << ";; stats: ";
+    std::cout << instance.name
+       << ' ' << (solved ? 1 : 0)
+       << ' ' << (optimally ? 1 : 0)
+       << ' ' << std::resetiosflags(std::ios::scientific) << ((root_est_cost).decimal())
+       << ' ' << std::resetiosflags(std::ios::scientific) << ((solution_cost).decimal())
+       << ' ' << stats.total_nodes()
+       << ' ' << stats.total_time()
+       << ' ' << stats.peak_memory()
+       << ' ' << stats.peak_stack_size()
+       << ' ' << stats.complete_iterations()
+       << ' ' << stats.nodes_at_max_lower_bound()
+       << ' ' << stats.time()
+       << ' ' << hsps::AH::Hsum_wins/((double)(hsps::AH::Hsum_wins + hsps::AH::Hmax_wins + hsps::AH::draws))
+       << ' ' << hsps::AH::draws/((double)(hsps::AH::Hsum_wins + hsps::AH::Hmax_wins + hsps::AH::draws))
+       << std::endl;
+    if (opt_ipc || opt_pddl) {
+      std::cout << ";; ";
+      std::cout << "(:heuristic (";
+      for (hsps::index_type k = 0; k < instance.goal_atoms.length(); k++)
+ std::cout << instance.atoms[instance.goal_atoms[k]].name;
+      std::cout << ") " << stats.max_lower_bound() << ")" << std::endl;
+    }
+  }
+  else {
+    if (solved) {
+      std::cout << "solution cost: " << solution_cost;
+      if (optimally)
+ std::cout << " (optimal)";
+      else
+ std::cout << " (upper bound)";
+      std::cout << std::endl;
+      std::cout << store.n_solutions() << " solutions";
+      if (opt_all_different) {
+ std::cout << " (" << hsps::StoreDistinct::n_discarded
+    << " equivalent solutions discarded)";
+      }
+      std::cout << std::endl;
+    }
+    else {
+      std::cout << "no solution found" << std::endl;
+    }
+    stats.print_total(std::cout);
+    stats.print(std::cout, "(search) ");
+    std::cerr << "highest lower bound " << stats.max_lower_bound()
+       << " proven at " << stats.nodes_at_max_lower_bound()
+       << " nodes" << std::endl;
+    double total_t = hsps::Stopwatch::seconds();
+    std::cout << total_t << " seconds total ("
+       << total_t - stats.total_time()
+       << " sec. not accounted for)" << std::endl;
+    std::cout << "peak memory use: " << stats.peak_memory() << "k"
+       << ", peak stack size: " << stats.peak_stack_size() << "k"
+       << std::endl;
+    if (opt_reverse_AH2) {
+      std::cout << "AH: " << hsps::AH::Hmax_wins << " Hmax, "
+  << hsps::AH::Hsum_wins << " Hsum, "
+  << hsps::AH::draws << " equal ("
+  << (hsps::AH::Hsum_wins/((double)(hsps::AH::Hsum_wins + hsps::AH::Hmax_wins + hsps::AH::draws)))*100
+  << "% improved, "
+  << (hsps::AH::draws/((double)(hsps::AH::Hsum_wins + hsps::AH::Hmax_wins + hsps::AH::draws)))*100
+  << "% equal)" << std::endl;
+    }
+    if (opt_tt) {
+      assert(tt);
+      std::cout << "transposition table stats: TUF = " << tt->TUF()
+  << ", HCF: " << tt->HCF() << std::endl;
+    }
+    if (solved && opt_print_plan) {
+      if (opt_pddl) {
+ hsps::PrintPDDL print_plan(instance, std::cout);
+ store.output(print_plan);
+      }
+      else {
+ for (hsps::index_type p = 0; p < store.n_solutions(); p++) {
+   hsps::Schedule* plan = store.plan(p);
+   hsps::State* path_end_state = store.solution(p);
+   std::cout << "plan #" << p << ":" << std::endl;
+   hsps::Print print_plan(instance, std::cout);
+   plan->output(print_plan);
+ }
+      }
+    }
+  }
+  return 0;
+}

--- a/pr/seq-opt-hspsf/hsp_p.ccx
+++ b/pr/seq-opt-hspsf/hsp_p.ccx
@@ -1,0 +1,8525 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+void sort2(index_type& i, index_type& j);
+void sort3(index_type& i, index_type& j, index_type& l);
+class PairIndexFunction : index_vec {
+ public:
+  PairIndexFunction(index_type n);
+  ~PairIndexFunction();
+  index_type operator()(index_type i, index_type j) const;
+  index_type max_in() const;
+  index_type max_out() const;
+};
+class CostNode {
+ public:
+  struct Value {
+    hsps::rational val;
+    bool opt;
+    CostNode* next;
+    bool mark;
+    count_type work;
+    Value() : val(0), opt(false), next(0), mark(false), work(0) { };
+    Value(hsps::rational v, bool o) : val(v), opt(o), next(0), mark(false), work(0) { };
+    Value& operator=(const Value& v)
+    { val = v.val; opt = v.opt; return *this; };
+    Value& operator=(hsps::rational v) { val = v; return *this; };
+    bool operator==(const Value& v) { return (val == v.val); };
+    bool operator<(const Value& v) { return (val < v.val); };
+    bool operator<=(const Value& v) { return (val <= v.val); };
+    bool operator>(const Value& v) { return (val > v.val); };
+    bool operator>=(const Value& v) { return (val >= v.val); };
+    bool operator==(const hsps::rational v) { return (val == v); };
+    bool operator<(const hsps::rational v) { return (val < v); };
+    bool operator<=(const hsps::rational v) { return (val <= v); };
+    bool operator>(const hsps::rational v) { return (val > v); };
+    bool operator>=(const hsps::rational v) { return (val >= v); };
+    void clear() {
+      val = 0;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+    void clear(hsps::rational v_default) {
+      val = v_default;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+  };
+ private:
+  index_type _size;
+  index_type _depth;
+  index_type _first;
+  hsps::rational _default;
+  hsps::rational _max;
+  Value* _store;
+  CostNode* _prev;
+  CostNode(CostNode* p, index_type f);
+  hsps::rational eval(const index_set& s, index_type i);
+  hsps::rational eval(const bool_vec& s, index_type i);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, index_type i, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, index_type i, hsps::rational bound);
+  void find_all(const index_set& s, index_type i, const index_set& c,
+   index_set_vec& a);
+  void set_max(hsps::rational v);
+  void write(std::ostream& s, index_set q) const;
+  void write_pddl(std::ostream& s, Instance& ins, index_set q) const;
+ public:
+  static bool eval_set_mark;
+  CostNode(index_type size);
+  CostNode(index_type size, hsps::rational v_default);
+  ~CostNode();
+  index_type size() const { return _size; };
+  index_type depth() const { return _depth; };
+  index_type first() const { return _first; };
+  index_type last() const { return _size - 1; };
+  Value& val(index_type p);
+  const Value& val(index_type p) const;
+  hsps::rational max() const { return _max; };
+  hsps::rational max_finite() const;
+  CostNode& next(index_type p);
+  Value* val_p(index_type p);
+  CostNode* next_p(index_type p);
+  Value* find(const index_set& s);
+  Value* find(const bool_vec& s);
+  void find_all(const index_set& s, index_set_vec& a);
+  Value& insert(const index_set& s);
+  Value& insert(const bool_vec& s);
+  void store(index_type p, hsps::rational v, bool opt);
+  void store(index_type p, hsps::rational v);
+  hsps::rational eval(const index_set& s);
+  hsps::rational eval(const bool_vec& s);
+  hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  void store(const index_set& s, hsps::rational v, bool opt);
+  void store(const bool_vec& s, hsps::rational v, bool opt);
+  void store(const index_set& s, hsps::rational v);
+  void store(const bool_vec& s, hsps::rational v);
+  hsps::rational eval_min(const index_set& s);
+  void compute_max();
+  void clear_marks();
+  void clear();
+  void write(std::ostream& s) const;
+  void write_pddl(std::ostream& s, Instance& ins) const;
+};
+class CostTable : public Heuristic, public CostNode {
+ public:
+  class Entry {
+  public:
+    index_set set;
+    CostNode::Value& val;
+    Entry* prev;
+    Entry* next;
+    Entry(index_set s, CostNode::Value& v)
+      : set(s), val(v), prev(0), next(0) { };
+    Entry& operator=(const Entry& e);
+    bool operator==(const Entry& e) { return set == e.set; };
+    bool operator<(const Entry& e) { return val < e.val; };
+    bool operator<=(const Entry& e) { return val <= e.val; };
+    bool operator>(const Entry& e) { return val > e.val; };
+    bool operator>=(const Entry& e) { return val >= e.val; };
+    Entry* first();
+    Entry* last();
+    Entry* move_down();
+    Entry* move_up();
+    void unlink();
+    void place_before(Entry* p);
+    void place_after(Entry* p);
+    void delete_list();
+    count_type list_length();
+  };
+ private:
+  Statistics& stats;
+  hsps::rational* pre_cost;
+  hsps::rational* per_cost;
+  bool update(index_type i, hsps::rational v, bool_vec& f);
+  bool update(index_type i, hsps::rational v);
+  bool update(index_type i, index_type j, hsps::rational v);
+  bool update(index_type i, index_type j, index_type l, hsps::rational v);
+  Entry* entries(CostNode* n, index_set s, Entry* l,
+   const index_set* filter, bool ign_zero, bool ign_opt,
+   bool ign_inf, bool req_mark, bool sort);
+  count_type count_entries(CostNode* n, index_set s, bool ign_zero,
+      bool ign_opt, bool ign_inf);
+  void fill(index_set& s, index_type d);
+  Entry* create_new_entries(const index_set& set,
+       const index_set& conflict_set,
+       const index_set& cd_ignore,
+       CostTable::Entry* list);
+  void compute_hm_graph_min
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+  void compute_hm_graph_max
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+ public:
+  static bool strong_conflict_detection;
+  static bool ultra_weak_conflict_detection;
+  static bool boost_new_entries;
+  static count_type n_entries_boosted;
+  static count_type n_entries_solved;
+  static count_type n_entries_discarded;
+  static count_type n_entries_created;
+  static count_type n_boost_searches;
+  static count_type n_boost_searches_with_cd;
+  CostTable(Instance& i, Statistics& s);
+  CostTable(Instance& i, Statistics& s, hsps::rational v_default);
+  ~CostTable();
+  virtual hsps::rational eval(index_type i);
+  virtual hsps::rational eval(index_type i, index_type j);
+  virtual hsps::rational eval(index_type i, index_type j, index_type k);
+  virtual hsps::rational eval(const index_set& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational eval(const bool_vec& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual void store(const index_set& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const index_set& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  virtual void store(const bool_vec& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  void store_list(Entry* l);
+  static Entry* insert_entry(Entry* e, Entry* l);
+  static Entry* prepend_entry(Entry* e, Entry* l);
+  static Entry* remove_entry(Entry* e, Entry* l);
+  static Entry* find_entry(index_set& s, Entry* l);
+  static Entry* copy_list(Entry* l);
+  count_type write_list(std::ostream& s, Entry* l);
+  bool interesting(const index_set& s);
+  Entry* atoms();
+  Entry* pairs();
+  Entry* entries();
+  Entry* entries(bool ign_zero, bool ign_opt, bool ign_inf, bool req_mark);
+  Entry* entries(const index_set& s);
+  Entry* unsorted_entries(bool ign_zero, bool ign_opt, bool ign_inf,
+     bool req_mark);
+  Entry* boostable_entries();
+  Entry* boostable_entries(const index_set& s);
+  Entry* boost_cd_entries();
+  Entry* marked_entries(bool ign_nb);
+  count_type count_entries(bool ign_zero, bool ign_opt, bool ign_inf);
+  hsps::rational action_pre_cost(index_type i);
+  hsps::rational action_per_cost(index_type i);
+  bool compatible(index_type a, index_type b, bool opt_resources) const;
+  void compute_H1(const ACF& cost);
+  void compute_H1(const ACF& cost, const bool_vec& init);
+  void compute_H1max(const ACF& cost, const bool_vec& init);
+  void compute_H2(const ACF& cost);
+  void compute_H2(const ACF& cost, const bool_vec& init);
+  void compute_H3(const ACF& cost);
+  void compute_H2C(const ACF& cost, bool opt_resources);
+  void verify_H2C(const ACF& cost, bool opt_resources, bool opt_verbose);
+  void compute_action_cost();
+  void fill(index_type to_depth);
+  void clear();
+  void closure(const ACF& cost);
+  void closure(const ACF& cost, const index_set& nd);
+  void compute_hm_graph(const ACF& cost, const index_set& s,
+   index_set_graph& g);
+};
+class LinearScanH2Eval : public CostTable {
+  index_type n_pairs;
+  index_pair* pairs;
+  hsps::rational* values;
+  bool complete;
+ public:
+  LinearScanH2Eval(Instance& i, Statistics& s);
+  ~LinearScanH2Eval();
+  void compile_finite();
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH1 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH1(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH1();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH2 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH2(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH2();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+inline void sort2(index_type& i, index_type& j)
+{
+  if (i > j) {
+    index_type t = i;
+    i = j;
+    j = t;
+  }
+}
+inline void sort3(index_type& i, index_type& j, index_type& l)
+{
+  sort2(i, l);
+  sort2(i, j);
+  sort2(j, l);
+}
+inline CostNode::Value& CostNode::val(index_type p)
+{
+  return _store[p];
+}
+inline const CostNode::Value& CostNode::val(index_type p) const
+{
+  return _store[p];
+}
+inline CostNode::Value* CostNode::val_p(index_type p)
+{
+  return &(_store[p]);
+}
+inline CostNode& CostNode::next(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return *(_store[p].next);
+}
+inline CostNode* CostNode::next_p(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return _store[p].next;
+}
+inline CostTable::Entry& CostTable::Entry::operator=(const Entry& e)
+{
+  set = e.set;
+  val = e.val;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode::Value& v)
+{
+  s << std::resetiosflags(std::ios::scientific) << ((v.val).decimal());
+  if (v.opt) s << '*';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode& t)
+{
+  t.write(s);
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostTable::Entry& e)
+{
+  if (e.set.length() > 0) {
+    s << "{" << e.set[0];
+    for (index_type k = 1; k < e.set.length(); k++) s << ',' << e.set[k];
+    s << "}:" << e.val;
+  }
+  else {
+    s << "{}:" << e.val;
+  }
+  return s;
+}
+}
+namespace hsps {
+class Preprocessor {
+ public:
+  Instance& instance;
+  index_vec atom_map;
+  index_vec action_map;
+  index_vec inv_map;
+ protected:
+  Statistics& stats;
+  CostTable* inc_relation;
+  graph* inc_graph;
+  bool make_invariant(index_type init_atom,
+        index_set& inv_set,
+        bool& exact,
+        index_set& branch_set);
+  void analyze_branch_set(const index_set& branch_set,
+     const index_set& inv_set,
+     index_set& effective);
+  void dfs_find_invariants(index_type init_atom,
+      const index_set& base_set,
+      const index_set& branch_set,
+      index_type branch_depth,
+      index_type max_branch_depth);
+  void extend_LsC1_relevance(const index_set& check,
+        const graph& lmg,
+        const bool_vec& p_act,
+        const bool_vec& p_add,
+        bool_vec& rel_atms,
+        bool_vec& rel_acts);
+ public:
+  static int default_trace_level;
+  int trace_level;
+  Preprocessor(Instance& ins, Statistics& s);
+  ~Preprocessor();
+  void compute_reachability(bool_vec& reachable_atoms,
+       bool_vec& reachable_actions,
+       bool opt_H2 = false);
+  void compute_static_atoms(const bool_vec& reachable_actions,
+       bool_vec& static_atoms);
+  void compute_relevance(const index_set& check,
+    bool_vec& r_atm,
+    bool_vec& r_act);
+  void compute_relevance(const index_set& check,
+    index_type d_check,
+    index_vec& d_atm,
+    index_vec& d_act);
+  void between(index_type p,
+        index_type q,
+        const graph& lmg,
+        bool_vec& b_atm,
+        bool_vec& b_act);
+  void compute_L1C1_relevance(const index_set& check,
+         index_type d_check,
+         const graph& lmg,
+         index_vec& d_atm,
+         index_vec& d_act);
+  void compute_L1C1_relevance(const index_set& check,
+         const graph& lmg,
+         bool_vec& rel_atms,
+         bool_vec& rel_acts);
+  void compute_LsC1_relevance(const index_set& check,
+         const graph& lmg,
+         bool_vec& rel_atms,
+         bool_vec& rel_acts);
+  void compute_relaxed_relevance(const index_set& g,
+     index_vec& path,
+     const index_set& pre,
+     bool_vec& rel_acts);
+  void strictly_relevant_actions(index_type p,
+     Heuristic& h,
+     const ACF& f,
+     bool_vec& rel);
+  void strictly_relevant_actions(index_type p,
+     hsps::rational c,
+     Heuristic& h,
+     const ACF& f,
+     bool_vec& rel);
+  void relevant_at_cost(index_type p,
+   hsps::rational c,
+   Heuristic& h,
+   const ACF& f,
+   bool_vec& r_atoms,
+   bool_vec& r_actions);
+  void relevant_at_cost(const index_set& s,
+   hsps::rational c,
+   Heuristic& h,
+   const ACF& f,
+   bool_vec& r_atoms,
+   bool_vec& r_actions);
+  CostTable* inconsistency();
+  graph* inconsistency_graph();
+  bool inconsistent(index_type p, index_type q, Heuristic& inc);
+  bool consistent(index_type p, index_type q, Heuristic& inc);
+  bool inconsistent(const index_set& s, index_type p, Heuristic& inc);
+  bool consistent(const index_set& s, index_type p, Heuristic& inc);
+  bool inconsistent(index_type p, index_type q);
+  bool consistent(index_type p, index_type q);
+  bool inconsistent(const index_set& s);
+  bool consistent(const index_set& s);
+  bool inconsistent(const index_set& s, index_type p);
+  bool consistent(const index_set& s, index_type p);
+  bool inconsistent(const index_set& s0, const index_set& s1);
+  bool consistent(const index_set& s0, const index_set& s1);
+  bool implies(index_type p, index_type q, Heuristic& inc);
+  bool implies(const index_set& s, index_type q, Heuristic& inc);
+  bool implies(index_type p, index_type q);
+  bool implies(const index_set& s, index_type q);
+  void implied_atom_set(const index_set& s, index_set& is, Heuristic& inc);
+  bool landmark_test(const index_set& init,
+       const index_set& goal,
+       index_type p,
+       bool opt_H2 = false);
+  void compute_landmarks(const index_set& init,
+    const index_set& goal,
+    index_set& landmark_atoms);
+  void compute_landmarks(bool exclude_goal,
+    bool exclude_init,
+    bool_vec& landmark_atoms);
+  void compute_landmarks(bool exclude_goal,
+    bool exclude_init,
+    index_set& landmark_atoms);
+  void quick_landmark_graph(graph& g, bool opt_H2 = false);
+  void compute_landmark_graph(graph& g, bool opt_H2 = false);
+  void compute_hierarchy(index_set_graph& g);
+  void compute_hierarchy(graph& g0, index_set_graph& g);
+  void necessary_completions_for_safeness(index_set& atoms_missing_negation);
+  void compute_irrelevant_atoms();
+  void dfs_find_invariants(index_type max_branch_depth);
+  void bfs_find_invariants();
+  void find_inconsistent_set_invariants(graph& inc);
+  void find_maximal_inconsistent_set_invariants(graph& inc);
+  void find_binary_iff_invariants(bool opt_weak_verify);
+  bool verify_invariant(Instance::Constraint& inv, Heuristic& inc);
+  bool verify_invariants(Heuristic& inc);
+  void compute_ncw_sets(Heuristic& inc);
+  void compute_ncw_sets();
+  void preprocess(bool opt_H2 = false);
+  void remove_irrelevant_atoms();
+  void remove_unverified_invariants();
+  void remove_useless_actions();
+  void remove_useless_invariants();
+  void remove_redundant_preconditions();
+  void eliminate_strictly_determined_atoms();
+  void make_safe();
+  void apply_place_replication();
+  void write_heuristic_graph(std::ostream& s,
+        Heuristic& h,
+        const ACF& cost,
+        const bool_vec& atoms,
+        const bool_vec& actions);
+  void write_heuristic_graph(std::ostream& s,
+        Heuristic& h,
+        const ACF& cost);
+  void write_relevance_graph(std::ostream& s,
+        const index_vec& d_atm,
+        const index_vec& d_act,
+        const char* label);
+  void write_relevance_graph(std::ostream& s,
+        const index_vec& d_atm,
+        const index_vec& d_act,
+        const bool_vec& mark_atm,
+        const bool_vec& mark_act,
+        const char* label);
+  bool find_inverse_actions(const Instance::Action& act, Heuristic& inc,
+       index_set& inverses);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+#include <stdio.h>
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+#include <stdio.h>
+#include <stdlib.h>
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class PDDL_Name;
+class PDDL_Base {
+ public:
+  static bool use_default_function_value;
+  static hsps::rational default_function_value;
+  static bool use_strict_borrow_definition;
+  static bool use_extended_borrow_definition;
+  static bool del_before_add_semantics;
+  static bool compact_resource_effects;
+  static bool compile_away_disjunctive_preconditions;
+  static bool check_precondition_consistency;
+  static bool compile_away_conditional_effects;
+  static bool compile_away_plan_constraints;
+  static bool compile_away_object_functions;
+  static bool compile_for_validator;
+  static bool create_all_atoms;
+  static bool create_all_actions;
+  static bool number_multiple_action_instances;
+  static bool exclude_all_dkel_items;
+  static string_set excluded_dkel_tags;
+  static string_set required_dkel_tags;
+  static bool strict_set_export;
+  static bool best_effort;
+  static bool write_PDDL31;
+  static bool write_warnings;
+  static bool write_info;
+  static bool write_trace;
+  static bool trace_print_context;
+  static bool name_instance_by_problem_file;
+  static const char* instance_name_prefix;
+  enum symbol_class {
+    sym_object,
+    sym_typename,
+    sym_predicate,
+    sym_object_function,
+    sym_function,
+    sym_action,
+    sym_variable,
+    sym_misc,
+    sym_preference,
+    sym_set,
+    sym_meta_variable
+  };
+  enum metric_class {
+    metric_none,
+    metric_makespan,
+    metric_minimize,
+    metric_maximize
+  };
+  enum mode_keyword {
+    md_none,
+    md_start,
+    md_end,
+    md_all,
+    md_init,
+    md_pos_goal,
+    md_neg_goal
+  };
+  enum partial_value { p_false, p_true, p_unknown };
+  enum expression_class {
+    exp_fun,
+    exp_list,
+    exp_const,
+    exp_add,
+    exp_sub,
+    exp_mul,
+    exp_div,
+    exp_time,
+    exp_preference
+  };
+  enum relation_type {
+    rel_equal,
+    rel_greater,
+    rel_greater_equal,
+    rel_less,
+    rel_less_equal
+  };
+  enum formula_class { fc_false,
+         fc_true,
+         fc_atom,
+         fc_equality,
+         fc_negation,
+         fc_conjunction,
+         fc_disjunction,
+         fc_equivalence,
+         fc_implication,
+         fc_universal,
+         fc_existential,
+         fc_list
+  };
+  struct Symbol;
+  struct TypeSymbol;
+  struct Atom;
+  struct FTerm;
+  struct FChangeAtom;
+  struct SetOf;
+  struct ListExpression;
+  struct ActionSymbol;
+  struct Reference;
+  struct IrrelevantItem;
+  typedef lvector<TypeSymbol*> type_vec;
+  typedef lvector<Atom*> atom_vec;
+  typedef lvector<FChangeAtom*> ch_atom_vec;
+  typedef lvector<SetOf*> atom_set_vec;
+  typedef lvector<Reference*> ref_vec;
+  typedef lvector<IrrelevantItem*> irrelevant_vec;
+  struct TypeSet : public type_vec {
+    TypeSet() : type_vec(0, 0) { };
+    TypeSet(const TypeSet& s) : type_vec(s) { };
+    TypeSet(TypeSymbol* t) : type_vec(t, 1) { };
+    index_type n_elements() const;
+    Symbol* get_element(index_type n);
+    bool is_object() const;
+    bool subtype_or_equal(const TypeSet& s) const;
+    bool subtype_or_equal(TypeSymbol* t) const;
+    void print(std::ostream& s) const;
+    void write_type(std::ostream& s) const;
+  };
+  struct Symbol {
+    symbol_class sym_class;
+    char* print_name;
+    TypeSet sym_types;
+    bool defined_in_problem;
+    bool visible;
+    Symbol(symbol_class c, char* n)
+      : sym_class(c), print_name(n), defined_in_problem(false), visible(true) { };
+    Symbol(char* n)
+      : sym_class(sym_object), print_name(n), defined_in_problem(false), visible(true) { };
+    void print(std::ostream& s) const;
+  };
+  typedef zero_init_pair<Symbol*> symbol_pair;
+  typedef lvector<Symbol*> symbol_vec;
+  typedef svector<Symbol*> symbol_set;
+  typedef lvector<symbol_pair> symbol_pair_vec;
+  static bool extend_substitution(Symbol* out, Symbol* in, symbol_pair_vec& u);
+  static bool print_substitution(std::ostream& s, const symbol_pair_vec& u);
+  static bool print_inequality(std::ostream& s, const symbol_pair_vec& neq);
+  static bool substitution_violates_inequality(const symbol_pair_vec& neq,
+            const symbol_pair_vec& u);
+  static index_type find_matching_atom(Atom* a, atom_vec& v);
+  static index_type find_matching_atom(Atom* a, mode_keyword m, atom_vec& v);
+  static index_type find_matching_fluent_atom
+    (FChangeAtom* a, mode_keyword m, ch_atom_vec& v);
+  struct TypeSymbol : public Symbol {
+    symbol_vec elements;
+    bool is_base_type;
+    TypeSymbol(char* n) : Symbol(sym_typename, n), elements(0, 0),
+  is_base_type(false) { };
+    void add_element(Symbol* e);
+    bool is_object() const { return (strcmp(print_name, "object") == 0); };
+    bool subtype_or_equal(TypeSymbol* t) const;
+    bool subtype_or_equal(const TypeSet& t) const;
+    void print(std::ostream& s) const;
+  };
+  struct VariableSymbol : public Symbol {
+    Symbol* value;
+    FTerm* binding;
+    VariableSymbol(char* n) : Symbol(sym_variable, n), value(0), binding(0) {};
+    bool equality_type_check(Symbol* s);
+    void print(std::ostream& s);
+  };
+  typedef lvector<VariableSymbol*> variable_vec;
+  struct ParamSymbol : public Symbol {
+    variable_vec param;
+    ParamSymbol(symbol_class c, char* n) : Symbol(c, n), param(0, 0) { };
+  };
+  struct PredicateSymbol : public ParamSymbol {
+    bool pos_pre;
+    bool neg_pre;
+    bool added;
+    bool deleted;
+    bool locked;
+    bool modded;
+    ptr_table init;
+    ptr_table pos_goal;
+    ptr_table neg_goal;
+    ptr_table pos_prop;
+    ptr_table neg_prop;
+    irrelevant_vec irr_ins;
+    PredicateSymbol(char* n) : ParamSymbol(sym_predicate, n),
+  pos_pre(false), neg_pre(false), added(false), deleted(false),
+  locked(false), modded(false), irr_ins(0, 0) { };
+    bool is_static() const { return !modded; };
+    bool is_equality() const { return (strcmp(print_name, "=") == 0); };
+    void instantiate(Instance& ins);
+    void initialise_missing(const symbol_vec& p,
+       atom_vec* created,
+       index_type i = 0);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+  };
+  struct ObjectFunctionSymbol : public ParamSymbol {
+    bool modded;
+    ptr_table init;
+    ObjectFunctionSymbol(char* n)
+      : ParamSymbol(sym_object_function, n), modded(false) { };
+    bool is_static() const { return !modded; };
+    void print(std::ostream& s);
+  };
+  struct FunctionSymbol : public ParamSymbol {
+    bool modified;
+    bool integral;
+    bool linear;
+    bool conditioned;
+    bool increased;
+    bool decreased;
+    bool assigned;
+    bool borrowed;
+    ptr_table init;
+    FunctionSymbol(char* n) : ParamSymbol(sym_function, n),
+  modified(false), integral(true), linear(true), conditioned(false),
+  increased(false), decreased(false), assigned(false), borrowed(false)
+    { };
+    bool is_static() const
+    { return !modified; };
+    bool is_reusable() const
+    { return borrowed && !increased && !decreased && !assigned; };
+    bool is_consumable() const
+    { return !borrowed && !increased && decreased && !assigned; };
+    interval eval_init_bounds(ptr_table* p, index_type i, ListExpression* r);
+    void print(std::ostream& s);
+  };
+  struct AtomBase {
+    symbol_vec param;
+    mode_keyword at;
+    hsps::rational at_time;
+    AtomBase() : param(0, 0), at(md_none), at_time(0) { };
+    AtomBase(mode_keyword t) : param(0, 0), at(t), at_time(0) { };
+    AtomBase(AtomBase* b);
+    bool equals(AtomBase& b);
+    void free_variables(variable_vec& v);
+    bool occurs(Symbol* s);
+    void fill_in_args(AtomBase* b);
+    void collect_bound_variables(variable_vec& v);
+    void insert(ptr_table& t);
+    static bool print_bindings;
+    void print(std::ostream& s) const;
+    void print_instance(std::ostream& s);
+  };
+  typedef lvector<AtomBase*> atom_base_vec;
+  struct Atom : AtomBase {
+    PredicateSymbol* pred;
+    Atom(PredicateSymbol* p) : pred(p) { };
+    Atom(PredicateSymbol* p, mode_keyword t) : AtomBase(t), pred(p) { };
+    Atom(PredicateSymbol* p, variable_vec& a, bool as_value)
+      : pred(p)
+    {
+      param.set_length(a.length());
+      for (index_type k = 0; k < a.length(); k++)
+ param[k] = (as_value ? a[k]->value : a[k]);
+    };
+    Atom(PredicateSymbol* p, Symbol* a0)
+      : pred(p)
+    {
+      param.append(a0);
+    };
+    Atom(Atom* a) : AtomBase(a), pred(a->pred) { };
+    bool equals(Atom& a);
+    bool is_static() const {
+      return ((at == md_init) ||
+       (at == md_pos_goal) ||
+       (at == md_neg_goal) ||
+       pred->is_static());
+    };
+    bool check();
+    Instance::Atom* find_prop(Instance& ins, bool neg, bool create);
+    void build(Instance& ins, bool neg, index_type p);
+    Atom* instantiate_partially();
+    partial_value partial_eval(ptr_table* r, index_type p);
+    partial_value partial_eval();
+    bool initial_value();
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    void print(std::ostream& s, bool neg) const;
+    void print(std::ostream& s) const { print(s, false); };
+  };
+  struct CAtom : public Atom {
+    symbol_pair_vec neq;
+    CAtom(Atom* a) : Atom(a), neq(symbol_pair(0, 0), 0) { };
+    CAtom(CAtom* s) : Atom(s), neq(s->neq) { };
+    CAtom(const Atom* a, symbol_pair_vec& u);
+    CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool instance_of(CAtom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(CAtom* a, symbol_pair_vec& u);
+    void print(std::ostream& s);
+  };
+  typedef lvector<CAtom*> catom_vec;
+  struct FTerm : AtomBase {
+    ObjectFunctionSymbol* fun;
+    FTerm(ObjectFunctionSymbol* f) : fun(f) { };
+    bool equals(FTerm& a);
+    void print(std::ostream& s) const;
+  };
+  struct OInitAtom : AtomBase {
+    ObjectFunctionSymbol* fun;
+    Symbol* val;
+    OInitAtom(ObjectFunctionSymbol* f) : fun(f), val(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<OInitAtom*> obj_init_atom_vec;
+  struct FInitAtom : AtomBase {
+    FunctionSymbol* fun;
+    hsps::rational val;
+    Instance::resource_ref res;
+    FInitAtom(FunctionSymbol* f) : fun(f), val(0) { };
+    FInitAtom(FChangeAtom* a);
+    bool is_static() const { return fun->is_static(); };
+    void print(std::ostream& s);
+  };
+  typedef lvector<FInitAtom*> fun_init_atom_vec;
+  struct Expression;
+  typedef lvector<Expression*> exp_vec;
+  struct Expression {
+    expression_class exp_class;
+    Expression(expression_class c) : exp_class(c) { };
+    static bool print_nary;
+    bool is_static();
+    bool is_constant();
+    bool is_integral();
+    hsps::rational eval_static();
+    bool eval_partial(hsps::rational& val);
+    interval eval_bounds();
+    hsps::rational eval_init();
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    hsps::rational eval_delta(Symbol* preference, hsps::rational p_value, hsps::rational d_value);
+    Expression* copy();
+    Expression* simplify();
+    void collect_constants(exp_vec& c);
+    void mark_functions_in_condition();
+    hsps::rational integrify();
+    void substitute_for_time(Expression* e);
+    Expression* substitute_for_preference(Symbol* n, Expression* e);
+    bool equals(Expression* e);
+    void print_sum(std::ostream& s, bool grnd);
+    void print_product(std::ostream& s, bool grnd);
+    void print(std::ostream& s, bool grnd);
+  };
+  struct ListExpression : public Expression {
+    Symbol* sym;
+    ListExpression* rest;
+    ListExpression(Symbol* s, ListExpression* r) :
+      Expression(exp_list), sym(s), rest(r) { };
+    bool match(AtomBase* atom);
+  };
+  struct FunctionExpression : public Expression {
+    FunctionSymbol* fun;
+    ListExpression* args;
+    FunctionExpression(FunctionSymbol* f, ListExpression* a) :
+      Expression(exp_fun), fun(f), args(a) { };
+    bool match(FChangeAtom* atom);
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    FChangeAtom* make_atom_base();
+  };
+  struct ConstantExpression : public Expression {
+    hsps::rational val;
+    ConstantExpression(hsps::rational v) :
+      Expression(exp_const), val(v) { };
+  };
+  struct TimeExpression : public Expression {
+    Expression* time_exp;
+    TimeExpression() :
+      Expression(exp_time), time_exp(0) { };
+    TimeExpression(Expression* e) :
+      Expression(exp_time), time_exp(e) { };
+  };
+  struct BinaryExpression : public Expression {
+    Expression* first;
+    Expression* second;
+    BinaryExpression(expression_class c, Expression* e1, Expression* e2) :
+      Expression(c), first(e1), second(e2) { };
+  };
+  struct PreferenceExpression : public Expression {
+    Symbol* name;
+    PreferenceExpression(Symbol* n) :
+      Expression(exp_preference), name(n) { };
+  };
+  struct Relation {
+    relation_type rel;
+    mode_keyword at;
+    Expression* first;
+    Expression* second;
+    Relation(relation_type r, Expression* e1, Expression* e2) :
+      rel(r), at(md_none), first(e1), second(e2) { };
+    Relation(relation_type r, mode_keyword m, Expression* e1, Expression* e2) :
+      rel(r), at(m), first(e1), second(e2) { };
+    Expression* match_gteq_constant(FChangeAtom* atom);
+    FunctionExpression* match_lteq_fun(FChangeAtom* atom);
+    bool is_static();
+    partial_value partial_eval();
+    void print(std::ostream& s, bool grnd);
+  };
+  typedef lvector<Relation*> relation_vec;
+  struct FChangeAtom : AtomBase {
+    FunctionSymbol* fun;
+    Expression* val;
+    FChangeAtom(FunctionSymbol* f) :
+      fun(f), val(0) { };
+    FChangeAtom(FunctionSymbol* f, mode_keyword t) :
+      AtomBase(t), fun(f), val(0) { };
+    FChangeAtom(FChangeAtom* a, hsps::rational v) :
+      AtomBase(a), fun(a->fun), val(new ConstantExpression(v)) { };
+    bool equals(FChangeAtom& a);
+    bool fluent_equals(FChangeAtom& a);
+    bool fluent_and_mode_equals(FChangeAtom& a);
+    FChangeAtom* find_fluent_equals(ch_atom_vec& vec);
+    Instance::Resource* find_resource(Instance& ins);
+    void print(std::ostream& s);
+  };
+  struct Formula {
+    formula_class fc;
+    Formula(formula_class c) : fc(c) { };
+    void rename_variables_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_variables_2(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_2(PDDL_Base::symbol_pair_vec& sub);
+    Formula* simplify();
+    void write_otter(std::ostream& s) const;
+    void print(std::ostream& s) const;
+    void untype(PDDL_Base* base);
+  };
+  typedef lvector<Formula*> formula_vec;
+  struct AFormula : public Formula, public Atom {
+    AFormula(Atom* a) :
+      Formula(fc_atom), Atom(a) { };
+    AFormula(PredicateSymbol* p) :
+      Formula(fc_atom), Atom(p) { };
+    AFormula(PredicateSymbol* p, variable_vec& a) :
+      Formula(fc_atom), Atom(p, a, false) { };
+    void print(std::ostream& s) const;
+    void write_otter(std::ostream& s) const;
+  };
+  struct EqFormula : public Formula {
+    Symbol* t1;
+    Symbol* t2;
+    EqFormula(Symbol* s1, Symbol* s2) :
+      Formula(fc_equality), t1(s1), t2(s2) { };
+    void write_otter(std::ostream& s) const;
+  };
+  struct NFormula : public Formula {
+    Formula* f;
+    NFormula(Formula* g) : Formula(fc_negation), f(g) { };
+  };
+  struct BFormula : public Formula {
+    Formula* f1;
+    Formula* f2;
+    BFormula(formula_class c, Formula* g1, Formula* g2) :
+      Formula(c), f1(g1), f2(g2) { };
+  };
+  struct CFormula : public Formula {
+    formula_vec parts;
+    CFormula(formula_class c) : Formula(c), parts(0, 0) { };
+    CFormula(formula_class c, Formula* f1, Formula* f2) :
+      Formula(c), parts(0, 0)
+    {
+      parts.append(f1);
+      parts.append(f2);
+    };
+    void add(Formula* f) { parts.append(f); };
+    void add(formula_vec& f) { parts.append(f); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct QFormula : public Formula {
+    variable_vec vars;
+    Formula* f;
+    QFormula(formula_class c) : Formula(c), vars(0, 0), f(0) { };
+    QFormula(formula_class c, Formula* g) : Formula(c), vars(0, 0), f(g) { };
+    QFormula(formula_class c, variable_vec& v, Formula* g) :
+      Formula(c), vars(0, 0), f(g)
+    {
+      for (index_type k = 0; k < v.length(); k++) vars.append(v[k]);
+    };
+    void add(PDDL_Base::VariableSymbol* v) { vars.append(v); };
+    void add(PDDL_Base::variable_vec& v) { vars.append(v); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct TypeConstraint {
+    VariableSymbol* var;
+    TypeSymbol* typ;
+    TypeConstraint(VariableSymbol* v, TypeSymbol* t) : var(v), typ(t) { };
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+  };
+  typedef lvector<TypeConstraint*> type_constraint_vec;
+  struct Context {
+    variable_vec param;
+    atom_vec pos_con;
+    atom_vec neg_con;
+    type_constraint_vec type_con;
+    Context() : param(0, 0), pos_con(0, 0), neg_con(0, 0), type_con(0, 0) { };
+    Context(const Context* c) : param(c->param), pos_con(c->pos_con),
+  neg_con(c->neg_con), type_con(c->type_con) { };
+    bool context_is_static() const;
+    bool occurs_in_context(Symbol* s);
+    void clear_arguments();
+    void set_mode(mode_keyword m);
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+    void print_assignment(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct DKEL_Item : public Context {
+    char* item_name;
+    Symbol* name;
+    string_set item_tags;
+    bool defined_in_problem;
+    bool included;
+    DKEL_Item(char* name) : item_name(name), name(0),
+  defined_in_problem(false), included(true) { };
+    DKEL_Item(const DKEL_Item* i) : Context(i), item_name(i->item_name),
+  name(i->name), item_tags(i->item_tags),
+  defined_in_problem(i->defined_in_problem), included(i->included) { };
+    bool item_is_included(string_set& ex_tags, string_set& req_tags);
+    void print_begin(std::ostream& s);
+    void print_end(std::ostream& s);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SetOf : public Context {
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    SetOf() : pos_atoms(0, 0), neg_atoms(0, 0) { };
+    SetOf(const SetOf* s)
+      : Context(s), pos_atoms(s->pos_atoms), neg_atoms(s->neg_atoms)
+    { };
+    SetOf(Atom* a)
+    { pos_atoms.append(a); };
+    SetOf(Atom* a, bool n)
+    { if (n) neg_atoms.append(a); else pos_atoms.append(a); };
+    bool is_static() const;
+    void set_mode(mode_keyword m);
+    partial_value partial_eval(bool as_disjunction = false);
+    partial_value partial_eval(index_type p, bool as_disjunction = false);
+    void instantiate_as_set(Instance& ins, index_set& s);
+    void instantiate_as_effect(Instance& ins, index_set& s_add,
+          index_set& s_del);
+    void instantiate_conditional(Instance& ins, rule_set& s_pos,
+     rule_set& s_neg);
+    SetOf* instantiate_partially();
+    void compile(atom_vec& pos_ins, atom_vec& neg_ins, index_type p);
+    void compile_non_static(atom_set_vec& ins, index_type p);
+    void print(std::ostream& s);
+    void print_as_disjunction(std::ostream& s);
+    void build_set(Instance& ins, index_set& s, index_type p);
+    void build_effect(Instance& ins, index_set& s_add, index_set& s_del,
+        index_type p);
+    void build_conditional(Instance& ins, rule_set& s_pos, rule_set& s_neg,
+      index_type p);
+  };
+  struct QCNumericEffect : public Context {
+    FChangeAtom* atom;
+    QCNumericEffect() : atom(0) { };
+    QCNumericEffect(FChangeAtom* a) : atom(a) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<QCNumericEffect*> qc_numeric_effect_vec;
+  enum set_constraint_keyword { sc_at_least, sc_at_most, sc_exactly };
+  struct SetConstraint : public DKEL_Item {
+    set_constraint_keyword sc_type;
+    index_type sc_count;
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    atom_set_vec atom_sets;
+    SetConstraint() : DKEL_Item(":invariant"), sc_type(sc_at_least),
+  sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0), atom_sets(0, 0) { };
+    SetConstraint(const DKEL_Item* item) : DKEL_Item(item),
+  sc_type(sc_at_least), sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0),
+  atom_sets(0, 0) { };
+    void build(Instance& ins, index_type p);
+    void instantiate(Instance& ins);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InvariantFormula : public DKEL_Item {
+    Formula* f;
+    InvariantFormula(Formula* g)
+      : DKEL_Item(":invariant"), f(g) { };
+    InvariantFormula(const DKEL_Item* item, Formula* g)
+      : DKEL_Item(item), f(g) { };
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct Reference : public AtomBase {
+    Symbol* name;
+    bool neg;
+    bool has_args;
+    index_set index;
+    Reference(Symbol* n) : name(n), neg(false), has_args(true) { };
+    Reference(Symbol* n, bool ng, bool ha)
+      : name(n), neg(ng), has_args(ha) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    void* find_action();
+    void find(const name_vec& names, index_set& ind);
+    Reference* instantiate_partially();
+    void print(std::ostream& s);
+  };
+  struct IrrelevantItem : public DKEL_Item {
+    Reference* entity;
+    IrrelevantItem() : DKEL_Item(":irrelevant"), entity(0) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    IrrelevantItem* instantiate_partially();
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SequentialTaskNet : public Context {
+    ref_vec tasks;
+    ActionSymbol* abs_act;
+    SequentialTaskNet() : tasks(0, 0), abs_act(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<SequentialTaskNet*> task_net_vec;
+  struct SetSymbol : public Symbol {
+    ptr_table set_table;
+    lvector<index_set*> sets;
+    name_vec names;
+    SetSymbol(char* n) : Symbol(sym_set, n), sets(0, 0), names(0, 0) { };
+  };
+  struct SetName : public AtomBase {
+    SetSymbol* sym;
+    SetName(SetSymbol* s) : sym(s) { };
+    index_set* find();
+    SetName* instantiate_partially();
+    void print(std::ostream& s);
+    void print_instance(std::ostream& s);
+  };
+  struct ActionSymbol : public ParamSymbol {
+    atom_vec pos_pre;
+    atom_vec neg_pre;
+    atom_set_vec set_pre;
+    atom_set_vec dis_pre;
+    relation_vec num_pre;
+    atom_vec adds;
+    atom_vec dels;
+    atom_set_vec set_eff;
+    atom_vec cons;
+    atom_set_vec cond_eff;
+    atom_vec locks;
+    atom_vec enables;
+    ch_atom_vec reqs;
+    ch_atom_vec incs;
+    ch_atom_vec decs;
+    ch_atom_vec fass;
+    qc_numeric_effect_vec qc_incs;
+    qc_numeric_effect_vec qc_decs;
+    qc_numeric_effect_vec qc_fass;
+    Expression* dmin;
+    Expression* dmax;
+    irrelevant_vec irr_ins;
+    ref_vec refs;
+    task_net_vec exps;
+    ptr_table instances;
+    SetName* part;
+    const char* assoc;
+    ActionSymbol(char* n) : ParamSymbol(sym_action, n), pos_pre(0, 0),
+  neg_pre(0, 0), set_pre(0, 0), dis_pre(0, 0), num_pre(0, 0),
+  adds(0, 0), dels(0, 0), set_eff(0, 0), cons(0, 0), cond_eff(0, 0),
+  locks(0, 0), enables(0, 0), reqs(0, 0), incs(0, 0), decs(0, 0),
+  fass(0, 0), qc_incs(0, 0), qc_decs(0, 0), qc_fass(0, 0), dmin(0),
+  dmax(0), irr_ins(0, 0), refs(0, 0), exps(0, 0), part(0), assoc(0) { };
+    void build(Instance& ins, index_type p, Expression* cost_exp);
+    Instance::Action& build_action(Instance& ins,
+       PDDL_Name* name,
+       index_type& count,
+       const index_set& pre,
+       const index_set& add,
+       const index_set& del,
+       const index_set& lck,
+       const index_cost_vec& r_use,
+       const index_cost_vec& r_cons,
+       hsps::rational dmin,
+       hsps::rational dmax,
+       hsps::rational dur,
+       hsps::rational cost);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          index_vec& s,
+          index_type p);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc);
+    void build_actions_with_dc_and_ce(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          const rule_set& pce,
+          const rule_set& nce,
+          const bool_vec& ece);
+    index_type param_index(VariableSymbol* p);
+    void get_param_inequalities(symbol_pair_vec& neq);
+    void set_arguments(const symbol_vec& args);
+    void set_arguments(const ptr_table::key_vec& args);
+    void clear_arguments();
+    void* find_instance();
+    bool is_abstract();
+    void post_process();
+    void instantiate(Instance& ins, Expression* cost_exp);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InputPlanStep {
+    Reference* act;
+    hsps::rational start_time;
+    InputPlanStep() : act(0), start_time(0) { };
+    InputPlanStep(Reference* a, hsps::rational t) : act(a), start_time(t) { };
+  };
+  struct InputPlan {
+    Symbol* name;
+    bool is_opt;
+    lvector<InputPlanStep*> steps;
+    InputPlan() : name(0), is_opt(false), steps(0, 0) { };
+    bool export_to_instance(Instance& ins, const index_vec& map, Plan& p);
+    void print(std::ostream& s);
+  };
+  struct HTableEntry {
+    atom_vec atoms;
+    bool_vec neg;
+    hsps::rational cost;
+    bool opt;
+    HTableEntry() : atoms(0, 0), neg(false, 0), cost(0), opt(false) { };
+  };
+  struct SimpleReferenceSet : public Context {
+    Reference* ref;
+    SimpleReferenceSet(Reference* r) : ref(r) { };
+    bool build(const name_vec& names, index_set& set, index_type p);
+    void print(std::ostream& s);
+  };
+  typedef lvector<SimpleReferenceSet*> refs_vec;
+  struct ReferenceSet : public Context {
+    refs_vec refs;
+    Symbol* name;
+    ReferenceSet() : refs(0, 0), name(0) { };
+    void add(SimpleReferenceSet* ref) { refs.append(ref); };
+    void build(const name_vec& names, index_set_vec& sets, index_type p);
+    void print(std::ostream& s);
+  };
+  struct CPG {
+    atom_vec atoms;
+    index_vec atom_first_arg;
+    bool_vec neg;
+    symbol_vec args;
+    type_vec arg_types;
+    CPG() : atoms(0, 0), neg(false, 0), args(0, 0), arg_types(0, 0) { };
+    CPG(CPG& g, index_vec& s);
+    void make_key(ptr_table::key_vec& key);
+    void make_typed_key(ptr_table::key_vec& key);
+    void make_parameters(variable_vec& params);
+    ListExpression* make_argument_list(index_type first);
+    void add_asserting_effects(ActionSymbol* act,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          bool strict);
+    void add_destroying_effects(ActionSymbol* act,
+    ParamSymbol* pf,
+    PredicateSymbol* p,
+    bool p_val,
+    PredicateSymbol* g,
+    FunctionSymbol* f,
+    Expression* f_val,
+    bool strict);
+    bool initial_value();
+    void add_asserting_effects(index_type c_atom,
+          ActionSymbol* act,
+          index_type c_eff,
+          bool_vec& sat,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          symbol_pair_vec& eq,
+          symbol_pair_vec& neq,
+          bool strict);
+    void add_propositional_effect(ActionSymbol* act,
+      PredicateSymbol* p, bool p_val,
+      index_type c_atom, Atom* a_eff,
+      bool strict);
+    void add_fluent_effect(ActionSymbol* act,
+      FunctionSymbol* f, Expression* f_val,
+      index_type c_atom, Atom* a_eff);
+    void add_effect_conditions(Context* e, ParamSymbol* pf, bool_vec& sat,
+          symbol_vec& subs, symbol_pair_vec& eq,
+          symbol_pair_vec& neq);
+  };
+  enum goal_class { goal_pos_atom, goal_neg_atom, goal_relation, goal_task,
+      goal_conjunction, goal_disjunction, goal_forall,
+      goal_exists, goal_always, goal_sometime,
+      goal_at_most_once, goal_within, goal_always_within,
+      goal_sometime_before, goal_sometime_after };
+  struct Goal {
+    goal_class g_class;
+    Goal(goal_class c) : g_class(c) { };
+    bool is_state();
+    bool is_propositional();
+    bool is_singular();
+    bool makeCPG(CPG& g);
+    bool makeCPG(CPG& g, index_vec& s);
+    void instantiate(Instance& ins, hsps::rational deadline);
+    void instantiate(Instance& ins, index_set& set, Symbol* p, index_type i);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Goal*> goal_vec;
+  struct AtomicGoal : public Goal {
+    Atom* atom;
+    AtomicGoal(Atom* a, bool neg)
+      : Goal(neg ? goal_neg_atom : goal_pos_atom), atom(a) { };
+    void print(std::ostream& s);
+  };
+  struct NumericGoal : public Goal {
+    Relation* rel;
+    NumericGoal(Relation* r) : Goal(goal_relation), rel(r) { };
+    void print(std::ostream& s);
+  };
+  struct TaskGoal : public Goal {
+    Reference* task;
+    TaskGoal(Reference* r) : Goal(goal_task), task(r) { };
+    void print(std::ostream& s);
+  };
+  struct ConjunctiveGoal : public Goal {
+    goal_vec goals;
+    ConjunctiveGoal() : Goal(goal_conjunction), goals(0, 0) { };
+    ConjunctiveGoal(goal_class gc) : Goal(gc), goals(0, 0) { };
+    void print(std::ostream& s);
+  };
+  struct DisjunctiveGoal : public ConjunctiveGoal {
+    DisjunctiveGoal() : ConjunctiveGoal(goal_disjunction) { };
+    void print(std::ostream& s);
+  };
+  struct QuantifiedGoal : public Goal, public Context {
+    Goal* goal;
+    QuantifiedGoal() : Goal(goal_forall), goal(0) { };
+    QuantifiedGoal(goal_class gc) : Goal(gc), goal(0) { };
+    void print(std::ostream& s);
+  };
+  struct SimpleSequenceGoal : public Goal {
+    Goal* constraint;
+    SimpleSequenceGoal(goal_class c, Goal* g) : Goal(c), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredSequenceGoal : public Goal {
+    Goal* trigger;
+    Goal* constraint;
+    TriggeredSequenceGoal(goal_class c, Goal* t, Goal* g)
+      : Goal(c), trigger(t), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct DeadlineGoal : public Goal {
+    Goal* goal;
+    hsps::rational at;
+    DeadlineGoal(hsps::rational t, Goal* g) : Goal(goal_within), goal(g), at(t) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredDeadlineGoal : public Goal {
+    Goal* trigger;
+    Goal* goal;
+    hsps::rational delay;
+    TriggeredDeadlineGoal(Goal* t, hsps::rational d, Goal* g)
+      : Goal(goal_always_within), trigger(t), delay(d), goal(g) { };
+    void print(std::ostream& s);
+  };
+  struct Preference {
+    Symbol* name;
+    Goal* goal;
+    Preference() : name(0), goal(0) { };
+    Preference(Symbol* n) : name(n), goal(0) { };
+    Preference(Symbol* n, Goal* g) : name(n), goal(g) { };
+    bool is_state() { return goal->is_state(); };
+    bool is_propositional() { return goal->is_propositional(); };
+    hsps::rational value(metric_class metric_type, Expression* m);
+    void instantiate(SoftInstance& ins,
+       metric_class metric_type,
+       Expression* m);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Preference*> preference_vec;
+  char* domain_name;
+  char* problem_name;
+  char* domain_file;
+  char* problem_file;
+  bool ready_to_instantiate;
+  char* problem_file_basename();
+  char* enum_problem_filename(const char* s, index_type i);
+  StringTable& tab;
+  type_vec dom_types;
+  type_vec dom_base_types;
+  TypeSymbol* dom_top_type;
+  symbol_vec dom_constants;
+  PredicateSymbol* dom_eq_pred;
+  PredicateSymbol* dom_assign_pred;
+  Symbol* dom_undefined_obj;
+  static PredicateSymbol* current_eq_predicate;
+  lvector<PredicateSymbol*> dom_predicates;
+  lvector<ObjectFunctionSymbol*> dom_object_functions;
+  lvector<FunctionSymbol*> dom_functions;
+  lvector<ActionSymbol*> dom_actions;
+  lvector<SetConstraint*> dom_sc_invariants;
+  lvector<InvariantFormula*> dom_f_invariants;
+  lvector<IrrelevantItem*> dom_irrelevant;
+  atom_vec dom_init;
+  obj_init_atom_vec dom_obj_init;
+  fun_init_atom_vec dom_fun_init;
+  goal_vec dom_goals;
+  preference_vec dom_preferences;
+  ref_vec goal_tasks;
+  metric_class metric_type;
+  Expression* metric;
+  hsps::rational serial_length;
+  hsps::rational parallel_length;
+  lvector<InputPlan*> input_plans;
+  lvector<HTableEntry*> h_table;
+  lvector<ReferenceSet*> input_sets;
+  lvector<SetSymbol*> partitions;
+  static ActionSymbol* src_action_symbol(ptr_pair* p);
+  TypeSymbol* find_type(const char* name);
+  PredicateSymbol* find_predicate(const char* name);
+  FunctionSymbol* find_function(const char* name);
+  bool find_initial_fact(const char* pname, const symbol_vec& arg);
+  hsps::rational find_function_value(const char* fname, const symbol_vec& arg);
+  index_type find_element_satisfying(const symbol_vec& elements,
+         const char* pname,
+         symbol_vec& arg,
+         index_type element_arg_p);
+  void find_elements_satisfying(const symbol_vec& elements,
+    const char* pname,
+    symbol_vec& arg,
+    index_type element_arg_p,
+    index_set& sats);
+  Atom* goal_to_atom(Goal* g);
+  bool goal_to_atom_vec(Goal* g, atom_vec& av);
+  PDDL_Base(StringTable& t);
+  ~PDDL_Base();
+  void set_variable_type(variable_vec& vec, TypeSymbol* t);
+  void set_variable_type(variable_vec& vec, const TypeSet& t);
+  void set_type_type(type_vec& vec, TypeSymbol* t);
+  void set_constant_type(symbol_vec& vec, TypeSymbol* t);
+  void clear_context(variable_vec& vec);
+  void clear_context(variable_vec& vec, index_type n_min, index_type n_max);
+  bool merge_type_vectors(type_vec& v0, type_vec& v1);
+  void make_parameters(type_vec& t, const char* prefix, variable_vec& v);
+  Atom* make_atom_from_prop(ptr_pair& src, bool& neg);
+  Symbol* gensym(symbol_class c, const char* p, const TypeSet& t);
+  Symbol* gensym(symbol_class c, const char* p, TypeSymbol* t);
+  Symbol* gensym_i(symbol_class c, const char* p, index_type i, TypeSymbol* t);
+  Symbol* gensym_s(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t);
+  Symbol* gensym_n(symbol_class c, const char* p, const Name* n, TypeSymbol* t);
+  void new_variable_substitution(Atom* a,
+     symbol_pair_vec& u,
+     symbol_pair_vec& new_u);
+  Atom* new_meta_atom(PredicateSymbol* p);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& u);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+  void extend_cc(CAtom* l, catom_vec& m, catom_vec& nm,
+   lvector< swapable_pair<catom_vec> >& x,
+   index_type d);
+  void find_cc();
+  void post_process();
+  void instantiate(Instance& ins);
+  void instantiate_soft(SoftInstance& ins);
+  void instantiate_atom_set(Instance& ins, atom_vec& a, index_set& s);
+  index_type n_plans() const { return input_plans.length(); };
+  bool export_plan(index_type i, Instance& ins, const index_vec& map, Plan& p);
+  bool export_plan(index_type i, Instance& ins, Plan& p);
+  void export_heuristic(Instance& ins,
+   const index_vec& map,
+   bool opt_maximize,
+   Heuristic& h);
+  void export_sets(const name_vec& names, index_set_vec& sets);
+  void export_action_partitions(name_vec& names, index_set_vec& sets);
+  void lift_DKEL_Items(const Instance& ins);
+  PredicateSymbol* find_type_predicate(Symbol* type_sym);
+  void untype();
+  void compile_preferences();
+  void compile_constraints_1();
+  void compile_constraints_2();
+  void select_preferences(const bool_vec& sel);
+  void metric_to_goal(hsps::rational bound);
+  void compile_set_conditions_and_effects();
+  void compile_object_functions();
+  Expression* replace_violations_1(Expression* exp,
+       CPG* cpg[],
+       FunctionSymbol* f_violated[]);
+  Goal* compile_constraint_1(Goal* g, index_type i, const Symbol* n,
+        symbol_vec& aut_states, index_type n_ra);
+  AtomicGoal* make_automaton_type_a(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_e(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_o(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sb(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sa(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  void make_automaton_transition(Symbol* s_from,
+     Symbol* s_to,
+     bool is_accept,
+     CPG* f, bool neg_f,
+     CPG* g, bool neg_g,
+     PredicateSymbol* p_state,
+     PredicateSymbol* p_accept,
+     PredicateSymbol* p_synch);
+  void add_precondition_formula(ActionSymbol* a, CPG* f, bool is_neg);
+  Goal* compile_constraint_2(Goal* g, const Symbol* n);
+  Goal* compile_always_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_sometime_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_at_most_once_constraint(SimpleSequenceGoal* g,
+     const Symbol* n);
+  Goal* compile_sometime_before_constraint(TriggeredSequenceGoal* g,
+        const Symbol* n);
+  void compile_set_conditions_and_effects(ActionSymbol* act);
+  void compile_set_conditions_and_effects(ActionSymbol* act,
+       variable_vec& i_param,
+       variable_vec& d_param,
+       index_type p);
+  Atom* make_binding_atom(VariableSymbol* v);
+  void compile_object_functions(ActionSymbol* act, Symbol* undefined_value);
+  void compile_object_functions_for_validator(ActionSymbol* act);
+  Goal* compile_object_functions(Goal* g);
+  void write_declarations(std::ostream& s);
+  void write_action(std::ostream& s, ActionSymbol* act);
+  void write_set_precondition(std::ostream& s, SetOf* set);
+  void write_disjunctive_set_precondition(std::ostream& s, SetOf* set);
+  void write_set_effect(std::ostream& s, SetOf* set);
+  void write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn);
+  void write_objects(std::ostream& s, bool defined_in_problem);
+  void write_init(std::ostream& s);
+  void write_goal(std::ostream& s);
+  void write_metric(std::ostream& s);
+  void write_dkel_items(std::ostream& s, bool defined_in_problem);
+  void write_domain_begin(std::ostream& s);
+  void write_problem_begin(std::ostream& s);
+  void write_end(std::ostream& s);
+  void write_dkel_domain(std::ostream& s, bool leave_open);
+  void write_dkel_problem(std::ostream& s, bool leave_open);
+  void write_plans(std::ostream& s);
+  void write_heuristic_table(std::ostream& s);
+  void write_sets(std::ostream& s);
+  void print(std::ostream& s);
+};
+class InstanceName : public Name {
+  char* domain_name;
+  char* problem_name;
+ public:
+  InstanceName(char* d, char* p) : domain_name(d), problem_name(p) { };
+  virtual ~InstanceName() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class PDDL_Name : public Name {
+ protected:
+  bool neg;
+  PDDL_Base::Symbol* sym;
+  PDDL_Base::symbol_vec arg;
+  bool vis;
+  bool_vec avis;
+ public:
+  static char catc;
+  static bool obscure_symbol_names;
+  PDDL_Name(PDDL_Base::Symbol* s)
+    : neg(false), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, bool n)
+    : neg(n), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::symbol_vec a, bool n)
+    : neg(n), sym(s), arg(a), vis(true), avis(true, a.length()) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n);
+  void add(PDDL_Base::Symbol* s);
+  void add(PDDL_Base::Symbol* s, bool v);
+  PDDL_Base::Symbol* symbol() { return sym; };
+  PDDL_Base::symbol_vec& args() { return arg; };
+  index_type argc() { return arg.length(); };
+  bool is_neg() { return neg; };
+  virtual ~PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class Numbered_PDDL_Name : public PDDL_Name {
+  index_type copy;
+ public:
+  Numbered_PDDL_Name(PDDL_Base::Symbol* sym, index_type c)
+    : PDDL_Name(sym), copy(c) { };
+  Numbered_PDDL_Name(PDDL_Name* n, index_type c);
+  virtual ~Numbered_PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+};
+}
+#include <sstream>
+typedef union {
+  hsps::StringTable::Cell* sym;
+  hsps::PDDL_Base::Expression* exp;
+  hsps::PDDL_Base::ListExpression* lst;
+  hsps::PDDL_Base::Relation* rel;
+  hsps::PDDL_Base::Goal* goal;
+  hsps::PDDL_Base::Formula* ff;
+  hsps::PDDL_Base::mode_keyword tkw;
+  hsps::PDDL_Base::relation_type rkw;
+  hsps::PDDL_Base::set_constraint_keyword sckw;
+  hsps::rational::XR rval;
+  int ival;
+  char* sval;
+} yy_PDDL_Parser_stype;
+class PDDL_Parser : public hsps::PDDL_Base
+{
+public:
+enum YY_PDDL_Parser_ENUM_TOKEN { YY_PDDL_Parser_NULL_TOKEN=0
+ ,TK_OPEN=258
+ ,TK_CLOSE=259
+ ,TK_OPEN_SQ=260
+ ,TK_CLOSE_SQ=261
+ ,TK_GREATER=262
+ ,TK_GREATEQ=263
+ ,TK_LESS=264
+ ,TK_LESSEQ=265
+ ,TK_COLON=266
+ ,TK_HASHT=267
+ ,TK_EQ=268
+ ,TK_HYPHEN=269
+ ,TK_PLUS=270
+ ,TK_MUL=271
+ ,TK_DIV=272
+ ,TK_UMINUS=273
+ ,TK_NEW_SYMBOL=274
+ ,TK_OBJ_SYMBOL=275
+ ,TK_TYPE_SYMBOL=276
+ ,TK_PRED_SYMBOL=277
+ ,TK_OBJFUN_SYMBOL=278
+ ,TK_FUN_SYMBOL=279
+ ,TK_VAR_SYMBOL=280
+ ,TK_ACTION_SYMBOL=281
+ ,TK_MISC_SYMBOL=282
+ ,TK_KEYWORD=283
+ ,TK_NEW_VAR_SYMBOL=284
+ ,TK_PREFERENCE_SYMBOL=285
+ ,TK_SET_SYMBOL=286
+ ,TK_FLOAT=287
+ ,TK_INT=288
+ ,TK_STRING=289
+ ,KW_REQS=290
+ ,KW_CONSTANTS=291
+ ,KW_PREDS=292
+ ,KW_FUNS=293
+ ,KW_TYPES=294
+ ,KW_DEFINE=295
+ ,KW_DOMAIN=296
+ ,KW_ACTION=297
+ ,KW_PROCESS=298
+ ,KW_EVENT=299
+ ,KW_ARGS=300
+ ,KW_PRE=301
+ ,KW_COND=302
+ ,KW_AT_START=303
+ ,KW_AT_END=304
+ ,KW_OVER_ALL=305
+ ,KW_EFFECT=306
+ ,KW_INVARIANT=307
+ ,KW_DURATION=308
+ ,KW_AND=309
+ ,KW_OR=310
+ ,KW_EXISTS=311
+ ,KW_FORALL=312
+ ,KW_IMPLY=313
+ ,KW_NOT=314
+ ,KW_WHEN=315
+ ,KW_EITHER=316
+ ,KW_PROBLEM=317
+ ,KW_FORDOMAIN=318
+ ,KW_OBJECTS=319
+ ,KW_INIT=320
+ ,KW_GOAL=321
+ ,KW_LENGTH=322
+ ,KW_SERIAL=323
+ ,KW_PARALLEL=324
+ ,KW_METRIC=325
+ ,KW_MINIMIZE=326
+ ,KW_MAXIMIZE=327
+ ,KW_DURATION_VAR=328
+ ,KW_TOTAL_TIME=329
+ ,KW_INCREASE=330
+ ,KW_DECREASE=331
+ ,KW_SCALE_UP=332
+ ,KW_SCALE_DOWN=333
+ ,KW_ASSIGN=334
+ ,KW_TAG=335
+ ,KW_NAME=336
+ ,KW_VARS=337
+ ,KW_SET_CONSTRAINT=338
+ ,KW_SETOF=339
+ ,KW_AT_LEAST_N=340
+ ,KW_AT_MOST_N=341
+ ,KW_EXACTLY_N=342
+ ,KW_CONTEXT=343
+ ,KW_FORMULA=344
+ ,KW_IRRELEVANT=345
+ ,KW_PLAN=346
+ ,KW_HEURISTIC=347
+ ,KW_OPT=348
+ ,KW_INF=349
+ ,KW_FACT=350
+ ,KW_SET=351
+ ,KW_EXPANSION=352
+ ,KW_TASKS=353
+ ,KW_PREFERENCE=354
+ ,KW_VIOLATED=355
+ ,KW_WITHIN=356
+ ,KW_ASSOC=357
+ ,KW_CONSTRAINTS=358
+ ,KW_ALWAYS=359
+ ,KW_SOMETIME=360
+ ,KW_AT_MOST_ONCE=361
+ ,KW_SOMETIME_BEFORE=362
+ ,KW_SOMETIME_AFTER=363
+ ,KW_ALWAYS_WITHIN=364
+ ,KW_IFF=365
+ ,KW_FALSE=366
+ ,KW_TRUE=367
+ ,KW_NUMBER=368
+ ,KW_UNDEFINED=369
+     };
+public:
+ int yyparse(void);
+ virtual void log_error(char *msg) = 0;
+ virtual int next_token() = 0;
+ yy_PDDL_Parser_stype yylval;
+ int yynerrs;
+ int yychar;
+public:
+ int yydebug;
+public:
+ PDDL_Parser(hsps::StringTable& t);
+public:
+ public: virtual std::ostream& at_position(std::ostream& s) = 0; virtual char* current_file() = 0; bool error_flag; private: hsps::PDDL_Base::variable_vec current_param; hsps::index_vec stored_n_param; hsps::PDDL_Base::TypeSet current_type_set; hsps::index_type last_n_functions; hsps::PDDL_Base::AtomBase* current_atom; hsps::PDDL_Base::atom_base_vec current_atom_stack; hsps::PDDL_Base::Context* current_context; hsps::lvector<Context*> stored_context; hsps::PDDL_Base::DKEL_Item* current_item; hsps::lvector<ConjunctiveGoal*> current_goal; hsps::PDDL_Base::Symbol* current_preference_name; hsps::PDDL_Base::HTableEntry* current_entry; char* current_plan_file; hsps::index_type n_plans_in_current_file;
+};
+typedef struct yy_buffer_state *YY_BUFFER_STATE;
+class PDDL_Scanner
+{
+ private:
+ char *yy_c_buf_p;
+ char yy_hold_char;
+ int yy_n_chars;
+ int yy_init;
+ int yy_start;
+ int yy_did_buffer_switch_on_eof;
+ private:
+ void yy_initialize();
+ int input();
+ int yyinput() {return input();};
+ int yy_get_next_buffer();
+ void yyunput( char c, char *buf_ptr );
+ long yy_get_previous_state_ ( void );
+ long yy_try_NUL_trans_ ( long current_state_ );
+ protected:
+ YY_BUFFER_STATE YY_CURRENT_BUFFER;
+ void yyrestart ( FILE *input_file );
+ void yy_switch_to_buffer( YY_BUFFER_STATE new_buffer );
+ void yy_load_buffer_state( void );
+ YY_BUFFER_STATE yy_create_buffer( FILE *file, int size );
+ void yy_delete_buffer( YY_BUFFER_STATE b );
+ void yy_init_buffer( YY_BUFFER_STATE b, FILE *file );
+ protected:
+ virtual void yy_echo()
+  ;
+ virtual int yy_input(char *buf,int &result,int max_size)
+  ;
+ virtual void yy_fatal_error(char *msg)
+  ;
+ virtual int yy_wrap()
+  ;
+ public:
+ char *yytext;
+ int yyleng;
+ FILE *yyin;
+ FILE *yyout;
+ int next_token ( yy_PDDL_Parser_stype& val);
+ PDDL_Scanner(hsps::StringTable& t) ;
+ virtual ~PDDL_Scanner() ;
+ int yy_flex_debug;
+ public:
+ private: hsps::StringTable& _tab; bool _reset; char* _filename; int _line_no; bool _trace_line; public: void open_file(char* fname, bool trace); void close_file(); char* current_file() const { return _filename; }; int current_line() const { return _line_no; };
+};
+namespace hsps {
+class Parser : public PDDL_Parser {
+  PDDL_Scanner scanner;
+ public:
+  Parser(StringTable& t) : PDDL_Parser(t), scanner(t) { };
+  void read(char *name, bool trace);
+  virtual int next_token();
+  virtual void log_error(char* msg);
+  virtual std::ostream& at_position(std::ostream& s);
+  virtual char* current_file();
+};
+}
+namespace hsps {
+class AH : public Heuristic {
+  void max_cost_mset(index_type m, const index_set& g, index_set& s);
+  void goal_relevant_remaining_actions(const index_set& g,
+           index_set& a,
+           bool_vec& rem);
+ protected:
+  CostTable* Hmax;
+  lvector<CostTable*> H_vec;
+  Statistics& stats;
+ public:
+  static count_type Hmax_wins;
+  static count_type Hsum_wins;
+  static count_type draws;
+  static bool use_linear_scan_eval;
+  AH(Instance& i, Statistics& s);
+  virtual ~AH();
+  index_type n_additive_components() { return H_vec.length(); };
+  CostTable* additive_component(index_type i) { return H_vec[i]; };
+  CostTable* max_component() { return Hmax; };
+  void compute_additive(const ACF& cost, const index_set_vec& p, bool useH2);
+  void compute_fractional(const ACF& cost, index_set_vec& p, bool useH2);
+  void compute_max(const ACF& cost, bool useH2);
+  void disable_max();
+  void compute_with_relevance_partitioning
+    (const ACF& cost, const index_set& g);
+  void compute_with_iterative_assignment
+    (const ACF& cost, const index_set& g, index_set_vec& app,
+     bool useH2, bool fractional, const index_set& g_limit);
+  void compute_with_iterative_assignment_1
+    (const ACF& cost, const index_set& g,
+     bool useH2, bool fractional, bool optimal,
+     const index_set& g_limit);
+  void compute_with_iterative_assignment_2
+    (const ACF& cost, const index_set& g, bool useH2, bool fractional,
+     const index_set& g_limit);
+  void compute_with_layered_partitioning
+    (const ACF& cost, const index_set& g);
+  void compute_layered_action_partition
+    (index_type m, const index_set& g, index_set_vec& p, index_type pg,
+     bool_vec& rem);
+  void compute_with_new_decomposition
+    (const ACF& cost, const index_set& g, bool useH2);
+  void compute_bottom_up_2
+    (const ACF& cost, const index_set& g, index_type p_max, bool useH2);
+  void compute_bottom_up
+    (const ACF& cost, const index_set& g, bool do_glue, bool useH2);
+  void compute_with_k_cuts
+    (const ACF& cost, const index_set& g, index_type k, bool useH2);
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual void write_eval(const index_set& s, std::ostream& st,
+     char* p = 0, bool e = true);
+  virtual void write_eval(const bool_vec& s, std::ostream& st,
+     char* p = 0, bool e = true);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+};
+}
+namespace hsps {
+class AtomSet {
+ protected:
+  Instance& instance;
+  bool_vec set;
+  index_type size;
+  index_type count();
+ private:
+  hsps::rational split(index_set g, index_type p, index_type n_out, index_type limit,
+       StateFactory& f, State* sp, Search& s, hsps::rational bound);
+  hsps::rational split_random(index_set g, index_type p, index_type n_out,
+       index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+ public:
+  static index_type max_set_size_encountered;
+  AtomSet(Instance& i);
+  AtomSet(Instance& i, const index_set& g);
+  AtomSet(Instance& i, const bool_vec& g);
+  AtomSet(const AtomSet& s);
+  ~AtomSet();
+  index_type atom_set_size() { return size; };
+  void add(const index_set& s);
+  void add(const bool_vec& s);
+  void del(const index_set& s);
+  void del(const bool_vec& s);
+  bool is_init_all();
+  bool is_init_some();
+  bool is_goal_all();
+  bool is_goal_some();
+  index_vec& copy_to(index_vec& s);
+  bool_vec& copy_to(bool_vec& s);
+  hsps::rational split(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound);
+  hsps::rational split_random(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+  int compare(const AtomSet& s);
+  index_type hash();
+};
+class AtomSetState : public AtomSet, public State {
+ protected:
+  Heuristic& heuristic;
+  hsps::rational est;
+  hsps::rational eval();
+  hsps::rational eval(hsps::rational b_est);
+  hsps::rational eval_with_trace_level(int level);
+  void apply_path_max();
+ public:
+  AtomSetState(Instance& i, Heuristic& h);
+  AtomSetState(Instance& i, Heuristic& h, const index_set& g);
+  AtomSetState(Instance& i, Heuristic& h, const bool_vec& g);
+  AtomSetState(const AtomSetState& s);
+  virtual ~AtomSetState();
+  index_type atom_set_size() { return size; };
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual void write(std::ostream& s);
+  virtual void write_eval(std::ostream& s, char* p = 0, bool e = true);
+};
+}
+namespace hsps {
+class SeqRegState : public AtomSetState, public StateFactory {
+ protected:
+  const ACF& cost;
+  index_type act;
+  RegressionResourceState* res;
+  bool relevant(Instance::Action& a);
+  bool applicable(Instance::Action& a);
+  SeqRegState* apply(Instance::Action& a);
+ public:
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c)
+    : AtomSetState(i, h), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c,
+       RegressionResourceState* r)
+    : AtomSetState(i, h), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+       RegressionResourceState* r)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+       RegressionResourceState* r)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(const SeqRegState& s);
+  virtual ~SeqRegState();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void set_predecessor(State* p);
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write_plan(std::ostream& s);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual void write(std::ostream& s);
+};
+class ApxSeqRegState : public SeqRegState {
+ protected:
+  index_type limit;
+ public:
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, index_type l)
+    : SeqRegState(i, h, c), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+   index_type l)
+    : SeqRegState(i, h, c, g), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+   index_type l)
+    : SeqRegState(i, h, c, g), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, r), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, g, r), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, g, r), limit(l) { };
+  ApxSeqRegState(const ApxSeqRegState& s)
+    : SeqRegState(s), limit(s.limit) { };
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+};
+class SeqCRegState : public SeqRegState {
+ public:
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c)
+    : SeqRegState(i, h, c) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g)
+    : SeqRegState(i, h, c, g) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g)
+    : SeqRegState(i, h, c, g) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, r) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, g, r) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, g, r) { };
+  SeqCRegState(const SeqRegState& s)
+    : SeqRegState(s) { };
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual int compare(const State& s);
+  index_type hash();
+  virtual void write(std::ostream& s);
+};
+class LDSeqRegState : public SeqRegState {
+  const index_vec& plan;
+  static bool copy_as_ld;
+ public:
+  LDSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+  const index_set& g, const index_vec& p)
+    : SeqRegState(i, h, c, g), plan(p) { };
+  LDSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+  const index_vec& p, const bool_vec& g)
+    : SeqRegState(i, h, c, g), plan(p) { };
+  LDSeqRegState(const LDSeqRegState& s);
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* copy();
+  virtual int compare(const State& s);
+  virtual void write(std::ostream& s);
+};
+}
+namespace hsps {
+class ActionSequence : public index_vec, public Plan {
+ public:
+  ActionSequence() : index_vec(no_such_index, 0) { };
+  ActionSequence(const index_vec& vec) : index_vec(vec) { };
+  ActionSequence(const ActionSequence& seq) : index_vec(seq) { };
+  virtual ~ActionSequence() { };
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  virtual void output(Plan& to);
+};
+class ActionSequenceSet : public lvector<ActionSequence>, public PlanSet {
+ public:
+  ActionSequenceSet() : lvector<ActionSequence>() { };
+  virtual ~ActionSequenceSet() { };
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+};
+class CountActions
+: public lvector<count_type>, public Plan, public PlanSet
+{
+ public:
+  CountActions() : lvector<count_type>(0, 0) { };
+  CountActions(index_type n) : lvector<count_type>(0, n) { };
+  virtual ~CountActions() { };
+  void reset() { assign_value(0, length()); };
+  void reset(index_type n) { assign_value(0, n); };
+  count_type sum();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class ApxResult : public Result {
+  bool min_sol;
+  index_type sol_depth;
+ public:
+  ApxResult() : min_sol(false), sol_depth(0) { };
+  virtual ~ApxResult() { };
+  bool min_solution() { return min_sol; };
+  index_type solution_depth() { return sol_depth; };
+  virtual void solution(State& s, hsps::rational cost);
+  virtual bool more();
+};
+class Print : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  hsps::rational current_t;
+  amt_vec peak_use;
+  amt_vec res_cons;
+  count_type n_actions;
+  count_type n_plans;
+  hsps::rational sum_cost;
+ public:
+  static bool print_noops;
+  static bool decimal_time;
+  Print(Instance& i, ::std::ostream& s);
+  virtual ~Print();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintActions : public Plan, public PlanSet {
+ protected:
+  Instance& instance;
+  ::std::ostream& to;
+  char action_sep;
+  bool first_action;
+  char plan_sep;
+  bool first_plan;
+ public:
+  PrintActions(Instance& i, ::std::ostream& s);
+  PrintActions(Instance& i, ::std::ostream& s, char as);
+  PrintActions(Instance& i, ::std::ostream& s, char as, char ps);
+  virtual ~PrintActions();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintActionSetNames : public PrintActions {
+ public:
+  PrintActionSetNames(Instance& i, ::std::ostream& s)
+    : PrintActions(i, s) { };
+  PrintActionSetNames(Instance& i, ::std::ostream& s, char p)
+    : PrintActions(i, s, p) { };
+  virtual ~PrintActionSetNames() { };
+  virtual void insert(index_type act);
+};
+class PrintPDDL : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  hsps::rational start_t;
+ public:
+  PrintPDDL(Instance& i, ::std::ostream& s);
+  virtual ~PrintPDDL();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintIPC : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  bool temporal;
+  hsps::rational epsilon;
+  bool included_epsilon;
+  bool strict_separation;
+  hsps::rational start_t;
+  bool occ_current_t;
+ public:
+  PrintIPC(Instance& i, ::std::ostream& s);
+  virtual ~PrintIPC();
+  void set_epsilon(hsps::rational e, bool included, bool strict);
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintAssoc : public Plan {
+  Instance& instance;
+  ::std::ostream& to;
+ public:
+  PrintAssoc(Instance& i, ::std::ostream& s);
+  virtual ~PrintAssoc();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class Store : public Result, public ScheduleSet {
+  state_vec solutions;
+ public:
+  Store(Instance& i);
+  virtual ~Store();
+  void reset();
+  void clear();
+  virtual void solution(State& s, hsps::rational cost);
+  index_type n_solutions() { return solutions.length(); };
+  State* solution(index_type k);
+  index_type n_plans() { return length(); };
+  Schedule* plan(index_type k);
+  virtual void output(PlanSet& to);
+  virtual void output(Result& to);
+};
+class StoreFilter : public SearchResult {
+ protected:
+  Store& store;
+ public:
+  StoreFilter(Store& s) : store(s) { };
+  virtual ~StoreFilter() { };
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class StoreMinCost : public StoreFilter {
+ public:
+  StoreMinCost(Store& s) : StoreFilter(s) { };
+  virtual ~StoreMinCost() { };
+  virtual void solution(State& s, hsps::rational cost);
+};
+class StoreDistinct : public StoreFilter {
+  Instance& instance;
+ public:
+  static count_type n_discarded;
+  StoreDistinct(Instance& i, Store& s) : StoreFilter(s), instance(i) { };
+  virtual ~StoreDistinct() { };
+  virtual void solution(State& s, hsps::rational cost);
+};
+class Conflicts : public Result {
+  Instance& instance;
+  index_set nec_del;
+  index_set pos_del;
+  amt_vec min_peak;
+  amt_vec max_peak;
+  bool first;
+  bool need_to_clear;
+ public:
+  Conflicts(Instance& ins);
+  virtual ~Conflicts();
+  const index_set& nec_deleted() const { return nec_del; };
+  const index_set& pos_deleted() const { return pos_del; };
+  const amt_vec& min_peak_resource_use() const { return min_peak; };
+  const amt_vec& max_peak_resource_use() const { return max_peak; };
+  void clear();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions();
+};
+}
+namespace hsps {
+class HashTable {
+ public:
+  struct Entry {
+    State* state;
+    index_type depth;
+    hsps::rational cost;
+  };
+ private:
+  index_type size;
+  index_type nocc;
+  Entry* tab;
+  count_type hits;
+  count_type cols;
+  count_type miss;
+ public:
+  HashTable(index_type s);
+  ~HashTable();
+  void inc_occ_count() { nocc += 1; };
+  Entry& operator[](index_type i);
+  index_type index(State& s);
+  Entry* find(State& s);
+  void insert(State& s, hsps::rational v, index_type d);
+  void insert(State& s, hsps::rational v);
+  void clear();
+  double hit_ratio();
+  double HCF();
+  double TUF();
+};
+}
+namespace hsps {
+class IDA : public MultiSearchAlgorithm {
+  HashTable* ttab;
+  bool cycle_check;
+  hsps::rational current_bound;
+  count_type iteration_limit;
+  count_type iteration_count;
+  static const count_type TRACE_LEVEL_2_NOTIFY = 100000;
+ public:
+  IDA(Statistics& s, SearchResult& r);
+  IDA(Statistics& s, SearchResult& r, HashTable* t);
+  virtual ~IDA();
+  void set_iteration_limit(count_type i_max) { iteration_limit = i_max; };
+  void increase_iteration_limit(count_type i) { iteration_limit += i; };
+  count_type get_iteration_limit() { return iteration_limit; };
+  void set_cycle_check(bool cc) { cycle_check = cc; };
+  hsps::rational main(State& s, hsps::rational bound);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+  virtual hsps::rational cost() const;
+  virtual hsps::rational resume(State& s, hsps::rational b);
+};
+}
+namespace hsps {
+class Node;
+typedef Node* nodep;
+typedef lvector<nodep> node_vec;
+struct Link {
+  Node* node;
+  hsps::rational delta;
+  Link() : node(0), delta(0) { };
+  Link(Node* s, hsps::rational d) : node(s), delta(d) { };
+  Link& operator=(const Link& l);
+  bool operator==(const Link& l);
+  bool operator<(const Link& l);
+  bool operator>(const Link& l);
+  bool operator<=(const Link& l);
+  bool operator>=(const Link& l);
+};
+typedef svector<Link> link_vec;
+class Node {
+ public:
+  index_type id;
+  State* state;
+  link_vec succ;
+  bool closed;
+  hsps::rational acc;
+  hsps::rational est;
+  hsps::rational val;
+  hsps::rational opt;
+  index_type pos;
+  count_type exp;
+  Node* bp_pre;
+  hsps::rational bp_delta;
+  link_vec* all_pre;
+  Node() :
+    id(0), state(0), closed(false), acc(0), est(0), val(0), opt(POS_INF),
+    pos(no_such_index), exp(0), bp_pre(0), bp_delta(0), all_pre(0) { };
+  ~Node();
+  hsps::rational min_delta_to(Node* n);
+  bool solved() { return (opt).finite(); };
+  bool back_path_contains(Node* n);
+  void add_predecessor(Node* n, hsps::rational d);
+  void backup_costs(node_vec& p);
+  void write(std::ostream& s, const Name* p = 0);
+  void write_short(std::ostream& s, const Name* p = 0);
+  void write_graph_node(std::ostream& s);
+  void write_graph_edges(std::ostream& s);
+};
+class NodeQueue : public node_vec {
+  const node_vec::order& before;
+ public:
+  NodeQueue(const node_vec::order& b);
+  ~NodeQueue();
+  void check_queue();
+  Node* peek();
+  void enqueue(Node*);
+  Node* dequeue();
+  void shift_up(index_type i);
+  void shift_down(index_type i);
+};
+class NodeSet {
+ protected:
+  static index_type next_id;
+  node_vec roots;
+ public:
+  static bool write_state_in_graph_node;
+  virtual ~NodeSet();
+  virtual Node* insert_node(State& s) = 0;
+  virtual Node* find_node(State& s) = 0;
+  virtual void clear() = 0;
+  virtual void collect_nodes(node_vec& ns) = 0;
+  Node* insert_root_node(State& s);
+  void make_root(Node* n);
+  node_vec& root_nodes();
+  void compute_reverse_links(node_vec& v);
+  void compute_reverse_links();
+  void mark_solved_apsp();
+  void mark_solved();
+  void backup_costs();
+  void set_back_path_solution_cost(Node* n, hsps::rational c_sol);
+  void cache_pg(hsps::rational c_sol);
+  void back_path_to_sequence(Node* n, node_vec& ns);
+  State* build_path(node_vec& ns);
+  State* build_path(Node* tn);
+  void write_short(std::ostream& s, const Name* p = 0);
+  void write_graph(std::ostream& s);
+};
+class NodeSetSearchState : public State {
+  Node* node;
+  hsps::rational delta;
+  State* path;
+ public:
+  NodeSetSearchState(Node* n);
+  NodeSetSearchState(NodeSetSearchState* p, Link& l, State* s);
+  NodeSetSearchState(const NodeSetSearchState& s);
+  virtual ~NodeSetSearchState();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write(std::ostream& s);
+  virtual void write_plan(std::ostream& s);
+};
+class TreeNodeSet : public Node, public NodeSet {
+  TreeNodeSet* left;
+  TreeNodeSet* right;
+ public:
+  TreeNodeSet();
+  virtual ~TreeNodeSet();
+  virtual Node* insert_node(State& s);
+  virtual Node* find_node(State& s);
+  virtual void clear();
+  virtual void collect_nodes(node_vec& ns);
+};
+class HashNodeSet : public NodeSet {
+  index_type size;
+  TreeNodeSet** tab;
+ public:
+  HashNodeSet(index_type s);
+  virtual ~HashNodeSet();
+  virtual Node* insert_node(State& s);
+  virtual Node* find_node(State& s);
+  virtual void clear();
+  virtual void collect_nodes(node_vec& ns);
+};
+inline Link& Link::operator=(const Link& l)
+{
+  node = l.node;
+  delta = l.delta;
+  return *this;
+}
+inline bool Link::operator==(const Link& l)
+{
+  return ((node == l.node) && (delta == l.delta));
+}
+inline bool Link::operator<(const Link& l)
+{
+  return ((node < l.node) || ((node == l.node) && (delta < l.delta)));
+}
+inline bool Link::operator>(const Link& l)
+{
+  return ((node > l.node) || ((node == l.node) && (delta > l.delta)));
+}
+inline bool Link::operator<=(const Link& l)
+{
+  return ((node <= l.node) || ((node == l.node) && (delta <= l.delta)));
+}
+inline bool Link::operator>=(const Link& l)
+{
+  return ((node >= l.node) || ((node == l.node) && (delta >= l.delta)));
+}
+}
+namespace hsps {
+class NodeOrderForBFS : public node_vec::order {
+ public:
+  NodeOrderForBFS() { };
+  virtual bool operator()(const nodep& v0, const nodep& v1) const;
+};
+class BFS : public SingleSearchAlgorithm {
+  static NodeOrderForBFS b_op;
+ protected:
+  static const count_type TRACE_LEVEL_2_NOTIFY = 10000;
+  HashNodeSet graph;
+  NodeQueue queue;
+  Node* current_node;
+  hsps::rational best_node_cost;
+  count_type acc_succ;
+  count_type new_succ;
+  void update_cost(Node* n, Node* p, hsps::rational d);
+ public:
+  NodeSet& state_space() { return graph; };
+  BFS(Statistics& s, SearchResult& r);
+  BFS(Statistics& s, SearchResult& r, index_type nt_size);
+  virtual ~BFS();
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+  virtual hsps::rational resume();
+  virtual hsps::rational main();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual hsps::rational cost() const;
+  virtual bool done() const;
+};
+class BFS_PX : public BFS {
+  hsps::rational threshold;
+ public:
+  BFS_PX(Statistics& s, SearchResult& r, hsps::rational thresh)
+    : BFS(s, r), threshold(thresh) { };
+  BFS_PX(Statistics& s, SearchResult& r, index_type nt_size, hsps::rational thresh)
+    : BFS(s, r, nt_size), threshold(thresh) { };
+  virtual ~BFS_PX() { };
+  virtual hsps::rational main();
+};
+}
+namespace hsps {
+class BFHS : public SearchAlgorithm {
+ protected:
+  index_type layer_table_size;
+  HashNodeSet* previous_layer;
+  HashNodeSet* current_layer;
+  HashNodeSet* next_layer;
+  lvector<Node*> current_open;
+  lvector<Node*> next_open;
+  hsps::rational current_layer_cost;
+  hsps::rational least_over_bound;
+  count_type acc_succ;
+  count_type new_succ;
+ public:
+  BFHS(Statistics& s, SearchResult& r, index_type lt_size);
+  virtual ~BFHS();
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+  hsps::rational main(State& s);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual hsps::rational cost() const;
+  virtual bool done() const;
+};
+class BFIDA : public BFHS {
+ public:
+  BFIDA(Statistics& s, SearchResult& r, index_type lt_size);
+  virtual ~BFIDA();
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+};
+class BFHS_XD : public BFHS {
+ public:
+  BFHS_XD(Statistics& s, SearchResult& r, index_type lt_size);
+  virtual ~BFHS_XD();
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+};
+}
+namespace hsps {
+int main(int argc, char *argv[]) {
+  StringTable symbols(50, lowercase_map);
+  bool opt_H1 = false;
+  bool opt_AH = false;
+  bool opt_load_partition = false;
+  bool opt_pia1 = false;
+  bool opt_pia2a = false;
+  bool opt_round = false;
+  bool opt_find_invariants = false;
+  bool opt_apply_invariants = false;
+  bool opt_resource = false;
+  bool opt_compose_resources = false;
+  index_type composite_resource_size = 2;
+  bool opt_R2 = false;
+  bool opt_apply_cuts = true;
+  bool opt_preprocess = true;
+  bool opt_rm_irrelevant = false;
+  bool opt_print_plan = true;
+  bool opt_pddl = false;
+  bool opt_ipc = false;
+  bool opt_cc = false;
+  index_type tt_size = 100007;
+  double time_limit = 0;
+  long memory_limit = 0;
+  count_type node_limit = 0;
+  hsps::rational cost_limit = 0;
+  int verbose_level = 1;
+  Statistics parse_stats;
+  Parser* reader = new Parser(symbols);
+  for (int k = 1; k < argc; k++) {
+    if ((strcmp(argv[k],"-v") == 0) && (k < argc - 1)) {
+      verbose_level = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-print-options-max") == 0) && (k < argc - 1)) {
+      MaxValueSearch::print_options_max = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-use-strict-borrow") == 0) {
+      PDDL_Base::use_strict_borrow_definition = true;
+    }
+    else if (strcmp(argv[k],"-use-extended-borrow") == 0) {
+      PDDL_Base::use_extended_borrow_definition = true;
+    }
+    else if (strcmp(argv[k],"-dba-semantics") == 0) {
+      PDDL_Base::del_before_add_semantics = true;
+    }
+    else if (strcmp(argv[k],"-res") == 0) {
+      opt_resource = true;
+    }
+    else if (strcmp(argv[k],"-cut") == 0) {
+      opt_apply_cuts = true;
+    }
+    else if (strcmp(argv[k],"-no-cut") == 0) {
+      opt_apply_cuts = false;
+    }
+    else if (strcmp(argv[k],"-inv") == 0) {
+      opt_apply_invariants = true;
+    }
+    else if (strcmp(argv[k],"-prep") == 0) {
+      opt_preprocess = true;
+    }
+    else if (strcmp(argv[k],"-no-prep") == 0) {
+      opt_preprocess = false;
+    }
+    else if (strcmp(argv[k],"-rm") == 0) {
+      opt_rm_irrelevant = true;
+    }
+    else if (strcmp(argv[k],"-find") == 0) {
+      opt_find_invariants = true;
+    }
+    else if (strcmp(argv[k],"-no-find") == 0) {
+      opt_find_invariants = false;
+    }
+    else if ((strcmp(argv[k],"-compose") == 0) && (k < argc - 1)) {
+      opt_compose_resources = true;
+      composite_resource_size = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-1") == 0) {
+      opt_H1 = true;
+    }
+    else if (strcmp(argv[k],"-AH") == 0) {
+      opt_AH = true;
+    }
+    else if (strcmp(argv[k],"-use-lse") == 0) {
+      AH::use_linear_scan_eval = true;
+    }
+    else if (strcmp(argv[k],"-pia1") == 0) {
+      opt_pia1 = true;
+      opt_find_invariants = true;
+    }
+    else if (strcmp(argv[k],"-pia2a") == 0) {
+      opt_pia2a = true;
+    }
+    else if (strcmp(argv[k],"-load-p") == 0) {
+      opt_load_partition = true;
+    }
+    else if (strcmp(argv[k],"-R2") == 0) {
+      opt_R2 = true;
+    }
+    else if (strcmp(argv[k],"-cc") == 0) {
+      opt_cc = true;
+    }
+    else if ((strcmp(argv[k],"-tt-size") == 0) && (k < argc - 1)) {
+      tt_size = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-t") == 0) && (k < argc - 1)) {
+      time_limit = atof(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-y") == 0) && (k < argc - 1)) {
+      memory_limit = atoi(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-c") == 0) && (k < argc - 1)) {
+      cost_limit = hsps::rational::ator(argv[++k]);
+    }
+    else if ((strcmp(argv[k],"-n") == 0) && (k < argc - 1)) {
+      node_limit = atoi(argv[++k]);
+    }
+    else if (strcmp(argv[k],"-no-plan") == 0) {
+      opt_print_plan = false;
+    }
+    else if (strcmp(argv[k],"-pddl") == 0) {
+      opt_print_plan = true;
+      opt_pddl = true;
+    }
+    else if (strcmp(argv[k],"-ipc") == 0) {
+      opt_print_plan = true;
+      opt_ipc = true;
+    }
+    else if (strcmp(argv[k],"-nsn") == 0) {
+      Instance::write_atom_set_with_symbolic_names = false;
+      Instance::write_action_set_with_symbolic_names = false;
+    }
+    else if (strcmp(argv[k],"-print-rational") == 0) {
+      Print::decimal_time = false;
+    }
+    else if ((strcmp(argv[k],"-exclude") == 0) && (k < argc - 1)) {
+      char* tag = argv[++k];
+      if (strcmp(tag, "all") == 0) {
+ PDDL_Base::exclude_all_dkel_items = true;
+      }
+      else {
+ const StringTable::Cell* c = symbols.find(tag);
+ if (c) PDDL_Base::excluded_dkel_tags.insert(c->text);
+      }
+    }
+    else if ((strcmp(argv[k],"-require") == 0) && (k < argc - 1)) {
+      const StringTable::Cell* c = symbols.find(argv[++k]);
+      if (c) PDDL_Base::required_dkel_tags.insert(c->text);
+    }
+    else if (strcmp(argv[k],"-strict") == 0) {
+      hsps::PDDL_Base::best_effort = false;
+    }
+    else if (*argv[k] != '-') {
+      parse_stats.start();
+      reader->read(argv[k], false);
+      parse_stats.stop();
+    }
+  }
+  SearchAlgorithm::default_trace_level = verbose_level;
+  Heuristic::default_trace_level = verbose_level - 1;
+  Instance::default_trace_level = verbose_level - 1;
+  Preprocessor::default_trace_level = verbose_level - 1;
+  if (verbose_level < 1) opt_print_plan = false;
+  if (verbose_level <= 0) PDDL_Base::write_warnings = false;
+  if (verbose_level > 1) PDDL_Base::write_info = true;
+  SoftInstance instance;
+  Statistics stats;
+  Store result(instance);
+  stats.enable_interrupt(false);
+  if (time_limit > 0) stats.enable_time_out(time_limit, false);
+  if (memory_limit > 0) stats.enable_memory_limit(memory_limit, false);
+  stats.start();
+  std::cerr << "instantiating..." << std::endl;
+  reader->instantiate(instance);
+  reader->instantiate_soft(instance);
+  if (opt_resource && opt_compose_resources && (instance.n_resources() > 1)) {
+    mSubsetEnumerator crs(instance.n_resources(), composite_resource_size);
+    bool more = crs.first();
+    while (more) {
+      index_set s;
+      crs.current_set(s);
+      instance.create_composite_resource(s);
+      more = crs.next();
+    }
+  }
+  Preprocessor prep(instance, stats);
+  if (opt_preprocess) {
+    std::cerr << "preprocessing..." << std::endl;
+    prep.preprocess();
+    if (opt_rm_irrelevant) {
+      prep.compute_irrelevant_atoms();
+      prep.remove_irrelevant_atoms();
+      if (!instance.cross_referenced()) {
+ std::cerr << "re-cross referencing..." << std::endl;
+ instance.cross_reference();
+      }
+    }
+    instance.remap_hard_goals(prep.atom_map);
+    instance.remap_soft_goals(prep.atom_map);
+  }
+  else {
+    std::cerr << "cross referencing..." << std::endl;
+    instance.cross_reference();
+  }
+  if (opt_find_invariants) {
+    prep.bfs_find_invariants();
+  }
+  instance.verify_invariants();
+  stats.stop();
+  std::cerr << "instance " << instance.name << " built in "
+     << stats.time() << " seconds" << std::endl;
+  std::cerr << instance.n_atoms() << " atoms, "
+     << instance.n_hard() << " hard goals, "
+     << instance.n_soft() << " soft goals, "
+     << instance.n_resources() << " resources ("
+     << instance.n_reusable_resources() << " reusable, "
+     << instance.n_consumable_resources() << " consumable), "
+     << instance.n_actions() << " actions, "
+     << instance.n_invariants() << " invariants"
+     << std::endl;
+  Heuristic* h = 0;
+  CostACF f(instance);
+  stats.start();
+  if (opt_AH) {
+    std::cerr << "computing AH heuristic..." << std::endl;
+    AH* ah = new AH(instance, stats);
+    if (opt_load_partition) {
+      stats.start();
+      name_vec pnames(0, 0);
+      index_set_vec partition;
+      reader->export_action_partitions(pnames, partition);
+      instance.remap_sets(partition, prep.action_map);
+      ah->compute_additive(CostACF(instance), partition, !opt_H1);
+      stats.stop();
+    }
+    else if (opt_pia1) {
+      ah->compute_with_iterative_assignment_1
+ (f, instance.goal_atoms, !opt_H1, false, false, instance.goal_atoms);
+    }
+    else if (opt_pia2a) {
+      index_set a;
+      a.fill(instance.n_atoms());
+      ah->compute_with_iterative_assignment_2
+ (f, a, !opt_H1, false, instance.goal_atoms);
+    }
+    else {
+      ah->compute_with_iterative_assignment_2
+ (f, instance.goal_atoms, !opt_H1, false, instance.goal_atoms);
+    }
+    h = ah;
+  }
+  else if (opt_H1) {
+    CostTable* h1 = new CostTable(instance, stats);
+    h1->compute_H1(f);
+    h = h1;
+  }
+  else {
+    CostTable* h2 = new CostTable(instance, stats);
+    h2->compute_H2(f);
+    h = h2;
+  }
+  stats.stop();
+  index_type init_n = 0;
+  hsps::rational init_best = 0;
+  index_type final_n = 0;
+  hsps::rational final_best = 0;
+  index_type final_best_size = 0;
+  bool solved = false;
+  if (!stats.break_signal_raised()) {
+    std::cerr << "heuristic computed in " << stats.time() << " seconds"
+       << std::endl;
+    RegressionResourceState* rs = 0;
+    if (opt_resource && (instance.n_resources() > 0)) {
+      estimator_vec* rest = new estimator_vec(0, instance.n_resources());
+      for (index_type k = 0; k < instance.n_resources(); k++) {
+ CostTable* c = new CostTable(instance, stats);
+ if (opt_R2)
+   c->compute_H2(ResourceConsACF(instance, k));
+ else
+   c->compute_H1(ResourceConsACF(instance, k));
+ (*rest)[k] = c;
+      }
+      rs = new RegressionResourceState(instance, *rest);
+    }
+    MaxNetBenefit mnb(instance, f, stats, result, *h, tt_size, opt_cc);
+    mnb.init();
+    init_n = mnb.n_options();
+    init_best = mnb.best_option_estimated_value();
+    std::cerr << "initial best value estimate: " << init_best << std::endl;
+    std::cerr << "searching..." << std::endl;
+    final_best = mnb.main();
+    final_best_size = mnb.best_option_size();
+    solved = mnb.solved();
+  }
+  if (opt_ipc || opt_pddl || (verbose_level == 0)) {
+    if (opt_ipc) {
+      std::cout << "; Time " << Stopwatch::seconds() << std::endl;
+      std::cout << "; ParsingTime " << parse_stats.total_time() << std::endl;
+      if (solved) {
+ std::cout << "; MetricValue " << std::resetiosflags(std::ios::scientific) << ((final_best).decimal())
+    << std::endl;
+ PrintIPC print_plan(instance, std::cout);
+ result.output(print_plan);
+      }
+      else {
+ std::cout << "; Not Solved" << std::endl;
+      }
+    }
+    else if (opt_pddl) {
+      if (solved) {
+ PrintPDDL print_plan(instance, std::cout);
+ result.output(print_plan);
+      }
+    }
+    if (opt_ipc || opt_pddl)
+      std::cout << ";; stats: ";
+    std::cout << instance.name
+       << ' ' << (solved ? 1 : 0)
+       << ' ' << std::resetiosflags(std::ios::scientific) << ((init_best).decimal())
+       << ' ' << std::resetiosflags(std::ios::scientific) << ((final_best).decimal())
+       << ' ' << stats.total_nodes()
+       << ' ' << stats.total_time()
+       << ' ' << stats.peak_memory()
+       << ' ' << stats.time()
+       << ' ' << init_n
+       << ' ' << final_n
+       << ' ' << final_best_size
+       << ' ' << stats.flags()
+       << std::endl;
+  }
+  else {
+    if (solved) {
+      std::cout << "solution value: " << final_best << std::endl;
+      if (opt_print_plan) {
+ Print print_plan(instance, std::cout);
+ result.output(print_plan);
+      }
+    }
+    else {
+      std::cout << "no solution found" << std::endl;
+    }
+    stats.print_total(std::cout);
+    stats.print(std::cout, "(search) ");
+    double total_t = Stopwatch::seconds();
+    std::cout << total_t << " seconds total (" << total_t - stats.total_time()
+       << " sec. not accounted for)" << std::endl;
+    std::cout << "peak memory use: " << stats.peak_memory() << "k"
+       << std::endl;
+  }
+  return 0;
+}
+}
+int main(int argc, char *argv[])
+{
+  return hsps::main(argc, argv);
+}

--- a/pr/seq-opt-hspsf/ida.ccx
+++ b/pr/seq-opt-hspsf/ida.ccx
@@ -1,0 +1,2947 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+class HashTable {
+ public:
+  struct Entry {
+    State* state;
+    index_type depth;
+    hsps::rational cost;
+  };
+ private:
+  index_type size;
+  index_type nocc;
+  Entry* tab;
+  count_type hits;
+  count_type cols;
+  count_type miss;
+ public:
+  HashTable(index_type s);
+  ~HashTable();
+  void inc_occ_count() { nocc += 1; };
+  Entry& operator[](index_type i);
+  index_type index(State& s);
+  Entry* find(State& s);
+  void insert(State& s, hsps::rational v, index_type d);
+  void insert(State& s, hsps::rational v);
+  void clear();
+  double hit_ratio();
+  double HCF();
+  double TUF();
+};
+}
+namespace hsps {
+class IDA : public MultiSearchAlgorithm {
+  HashTable* ttab;
+  bool cycle_check;
+  hsps::rational current_bound;
+  count_type iteration_limit;
+  count_type iteration_count;
+  static const count_type TRACE_LEVEL_2_NOTIFY = 100000;
+ public:
+  IDA(Statistics& s, SearchResult& r);
+  IDA(Statistics& s, SearchResult& r, HashTable* t);
+  virtual ~IDA();
+  void set_iteration_limit(count_type i_max) { iteration_limit = i_max; };
+  void increase_iteration_limit(count_type i) { iteration_limit += i; };
+  count_type get_iteration_limit() { return iteration_limit; };
+  void set_cycle_check(bool cc) { cycle_check = cc; };
+  hsps::rational main(State& s, hsps::rational bound);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+  virtual hsps::rational cost() const;
+  virtual hsps::rational resume(State& s, hsps::rational b);
+};
+}
+namespace hsps {
+IDA::IDA(Statistics& s, SearchResult& r)
+  : MultiSearchAlgorithm(s, r),
+    ttab(0),
+    cycle_check(false),
+    current_bound(0),
+    iteration_limit(count_type_max),
+    iteration_count(0)
+{
+}
+IDA::IDA(Statistics& s, SearchResult& r, HashTable* tt)
+  : MultiSearchAlgorithm(s, r),
+    ttab(tt),
+    cycle_check(false),
+    current_bound(0),
+    iteration_limit(count_type_max),
+    iteration_count(0)
+{
+}
+IDA::~IDA()
+{
+}
+hsps::rational IDA::start(State& s, hsps::rational b)
+{
+  if (ttab) ttab->clear();
+  iteration_count = 0;
+  reset();
+  start_count();
+  hsps::rational val = main(s, b);
+  stop_count();
+  return val;
+}
+hsps::rational IDA::start(State& s)
+{
+  stats.current_lower_bound(s.est_cost());
+  return start(s, s.est_cost());
+}
+hsps::rational IDA::resume(State& s, hsps::rational b)
+{
+  start_count();
+  hsps::rational val = main(s, b);
+  stop_count();
+  return val;
+}
+hsps::rational IDA::main(State& s, hsps::rational bound)
+{
+  current_bound = bound;
+  while (!solved()) {
+    if ((current_bound).infinite()) {
+      if (trace_level > 1) {
+ std::cerr << "break on cost = +INF" << std::endl;
+      }
+      return current_bound;
+    }
+    if (current_bound > cost_limit) {
+      if (trace_level > 1) {
+ std::cerr << "break on cost > " << cost_limit << std::endl;
+      }
+      return current_bound;
+    }
+    if (iteration_count >= iteration_limit) {
+      if (trace_level > 1) {
+ std::cerr << "break on iteration count > "
+    << iteration_limit << std::endl;
+      }
+      return current_bound;
+    }
+    if (trace_level > 0) {
+      std::cerr << "bound = " << std::resetiosflags(std::ios::scientific) << ((current_bound).decimal()) << ": ";
+    }
+    stats.begin_iteration();
+    hsps::rational new_bound = new_state(s, current_bound);
+    if (break_signal_raised()) return current_bound;
+    if (!solved()) stats.current_lower_bound(new_bound);
+    result.no_more_solutions(current_bound);
+    stats.end_iteration();
+    iteration_count += 1;
+    current_bound = new_bound;
+    if ((trace_level > 0) && !solved()) {
+      std::cerr << stats;
+      if (ttab) {
+ std::cerr << ", TUF: " << ttab->TUF() << ", HCF: " << ttab->HCF();
+      }
+      std::cerr << std::endl;
+    }
+  }
+  return current_bound;
+}
+hsps::rational IDA::new_state(State& s, hsps::rational bound)
+{
+  assert(!s.is_max());
+  stats.create_node(s);
+  if (s.is_final()) {
+    if (trace_level > 1) {
+      std::cerr << "solution (cost = " << s.acc_cost()
+  << ", depth = " << s.depth() << ")" << std::endl;
+      if (trace_level > 2) {
+ std::cerr << "solution path:" << std::endl;
+ s.write_path(std::cerr);
+      }
+    }
+    set_solved(true);
+    result.solution(s, current_bound - bound);
+    return 0;
+  }
+  hsps::rational c_est = s.est_cost();
+  HashTable::Entry* entry = 0;
+  if (ttab) {
+    entry = ttab->find(s);
+    if (entry) c_est = hsps::rational::max(c_est,entry->cost);
+  }
+  if (c_est <= bound) {
+    if (cycle_check) {
+      for (State* sp = s.predecessor(); sp; sp = sp->predecessor())
+ if (s.compare(*sp) == 0) return POS_INF;
+    }
+    stats.expand_node(s);
+    if (trace_level > 2) {
+      std::cerr << "expanding " << s
+  << " (" << (s.is_max() ? "max, " : "min, ")
+  << c_est << ") at bound " << bound
+  << " and depth " << s.depth()
+  << std::endl;
+    }
+    else if (trace_level > 1) {
+      if ((stats.nodes() % TRACE_LEVEL_2_NOTIFY) == 0) {
+ std::cerr << stats;
+ if (ttab) {
+   std::cerr << ", TUF: " << ttab->TUF() << ", HCF: " << ttab->HCF();
+ }
+ std::cerr << std::endl;
+      }
+    }
+    hsps::rational val = s.expand(*this, bound);
+    if (entry) {
+      entry->cost = val;
+    }
+    else if (ttab) {
+      index_type h = ttab->index(s);
+      if ((*ttab)[h].state) {
+ if ((*ttab)[h].depth > s.depth()) {
+   delete (*ttab)[h].state;
+   (*ttab)[h].state = 0;
+ }
+      }
+      else {
+ ttab->inc_occ_count();
+      }
+      if (!(*ttab)[h].state) {
+ (*ttab)[h].state = s.copy();
+ (*ttab)[h].depth = s.depth();
+ (*ttab)[h].cost = val;
+      }
+    }
+    return val;
+  }
+  else return c_est;
+}
+hsps::rational IDA::cost() const
+{
+  return current_bound;
+}
+}

--- a/pr/seq-opt-hspsf/index_type.ccx
+++ b/pr/seq-opt-hspsf/index_type.ccx
@@ -1,0 +1,2427 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+const index_set EMPTYSET;
+index_vec_util::decreasing_index_order index_vec_util::decreasing;
+index_vec_util::increasing_index_order index_vec_util::increasing;
+void factors(index_type n, index_vec& f)
+{
+  f.set_length(0);
+  bool prime = false;
+  while (!prime) {
+    prime = true;
+    for (index_type k = 2; (k < (n/k)) && prime; k++) {
+      if ((n % k) == 0) {
+ f.append(k);
+ n = n/k;
+ prime = false;
+      }
+    }
+  }
+  if ((n > 1) || (f.length() == 0)) f.append(n);
+}
+void index_vec_util::fill(index_vec& vec, index_type max)
+{
+  vec.set_length(max);
+  for (index_type k = 0; k < max; k++) vec[k] = k;
+}
+index_type index_vec_util::min(const index_vec& vec, index_type def)
+{
+  index_type a_max = vec.arg_max();
+  if (a_max != no_such_index)
+    return vec[a_max];
+  else
+    return def;
+}
+index_type index_vec_util::max(const index_vec& vec, index_type def)
+{
+  index_type a_max = vec.arg_max();
+  if (a_max != no_such_index)
+    return vec[a_max];
+  else
+    return def;
+}
+int index_vec_util::compare(const index_vec& v0, const index_vec& v1)
+{
+  if (v0.length() < v1.length()) return -1;
+  if (v0.length() > v1.length()) return 1;
+  for (index_type k = 0; k < v0.length(); k++) {
+    if (v0[k] < v1[k]) return -1;
+    if (v0[k] > v1[k]) return 1;
+  }
+  return 0;
+}
+index_type index_vec_util::hash(const index_vec& vec)
+{
+  index_type v = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    v = ((v + (vec[k] * k)) % LARGE_PRIME);
+  return v;
+}
+int index_vec_util::compare(const index_vec& v1) const
+{
+  return compare(*this, v1);
+}
+void index_vec_util::fill(index_type max)
+{
+  fill(*this, max);
+}
+index_type index_vec_util::hash() const
+{
+  return hash(*this);
+}
+index_set::index_set(const bool* _arr, index_type n)
+{
+  for (index_type k = 0; k < n; k++)
+    if (_arr[k]) append(k);
+}
+index_set::index_set(const bool_vec& _vec)
+{
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (_vec[k]) append(k);
+}
+index_set::index_set(const index_set& s0, const index_set& s)
+{
+  for (index_type k = 0; k < s.length(); k++) {
+    assert(s[k] < s0.length());
+    append(s0[s[k]]);
+  }
+}
+index_set::index_set(const index_set& s0, const bool_vec& s)
+{
+  assert(s.length() >= s0.length());
+  for (index_type k = 0; k < s0.length(); k++) if (s[k]) {
+    append(s0[k]);
+  }
+}
+index_set::index_set(const index_set& s0, const index_vec& map)
+{
+  for (index_type k = 0; k < s0.length(); k++) {
+    assert(s0[k] < map.length());
+    if (map[s0[k]] != no_such_index)
+      insert(map[s0[k]]);
+  }
+}
+void index_set::insert(const index_type& v)
+{
+  svector<index_type>::insert(v);
+}
+void index_set::insert(const index_vec& vec)
+{
+  svector<index_type>::insert(vec);
+}
+void index_set::insert(const bool_vec& set)
+{
+  for (index_type k = 0; k < set.length(); k++)
+    if (set[k]) insert(k);
+}
+void index_set::intersect(const index_set& set)
+{
+  svector<index_type>::intersect(set);
+}
+void index_set::intersect(const bool_vec& set)
+{
+  index_type k = 0;
+  while (k < size()) {
+    if ((*this)[k] < set.length()) {
+      if (!set[(*this)[k]]) {
+ remove(k);
+      }
+      else {
+ k += 1;
+      }
+    }
+    else {
+      remove(k, length());
+    }
+  }
+}
+void index_set::subtract(const index_vec& vec)
+{
+  svector<index_type>::subtract(vec);
+}
+void index_set::subtract(const bool_vec& set)
+{
+  index_type k = 0;
+  while (k < length()) {
+    if ((*this)[k] < set.length()) {
+      if (set[k]) {
+ remove(k);
+      }
+      else {
+ k += 1;
+      }
+    }
+  }
+}
+void index_set::subtract(const index_type& v)
+{
+  svector<index_type>::subtract(v);
+}
+void index_set::fill(index_type max)
+{
+  index_vec_util::fill(*this, max);
+}
+void index_set::assign_remap
+(const index_set& set, const index_vec& map)
+{
+  clear();
+  for (index_type k = 0; k < set.length(); k++) {
+    assert(set[k] < map.length());
+    if (map[set[k]] != no_such_index)
+      insert(map[set[k]]);
+  }
+}
+void index_set::remap(const index_vec& map)
+{
+  index_set s0(*this);
+  assign_remap(s0, map);
+}
+index_type index_set::first_common_element(const index_set& vec) const
+{
+  index_pair p = svector<index_type>::first_common(vec);
+  if (p.first != no_such_index)
+    return (*this)[p.first];
+  else
+    return no_such_index;
+}
+index_type index_set::first_common_element(const index_vec& vec) const
+{
+  index_pair p = svector<index_type>::first_common(vec);
+  if (p.first != no_such_index)
+    return (*this)[p.first];
+  else
+    return no_such_index;
+}
+bool index_set::have_common_element(const index_set& vec) const
+{
+  return (first_common_element(vec) != no_such_index);
+}
+bool index_set::have_common_element(const bool_vec& set) const
+{
+  return (first_common_element(set) != no_such_index);
+}
+index_type index_set::first_common_element(const bool_vec vec) const
+{
+  for (index_type i = 0; i < length(); i++) {
+    if ((*this)[i] < vec.length()) {
+      if (vec[(*this)[i]])
+ return (*this)[i];
+    }
+    else {
+      return no_such_index;
+    }
+  }
+  return no_such_index;
+}
+index_type index_set::first_common_element(const bool* vec, index_type n) const
+{
+  for (index_type i = 0; i < length(); i++) {
+    if ((*this)[i] < n) {
+      if (vec[(*this)[i]])
+ return (*this)[i];
+    }
+    else {
+      return no_such_index;
+    }
+  }
+  return no_such_index;
+}
+index_type index_set::count_common(const index_set& vec) const
+{
+  return svector<index_type>::count_common(vec);
+}
+index_type index_set::count_common(const bool_vec& set) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < size(); k++)
+    if ((*this)[k] < set.length())
+      if (set[(*this)[k]]) c += 1;
+  return c;
+}
+bool* index_set::copy_to(bool* s, index_type n) const
+{
+  for (index_type k = 0; k < n; k++)
+    s[k] = false;
+  for (index_type k = 0; k < size(); k++)
+    if ((*this)[k] < n) s[(*this)[k]] = true;
+  return s;
+}
+bool_vec::bool_vec(const index_set& set, index_type l)
+  : lvector<bool>(false, l)
+{
+  for (index_type k = 0; k < set.length(); k++) {
+    if (set[k] < l) (*this)[set[k]] = true;
+  }
+}
+void bool_vec::complement()
+{
+  for (index_type i = 0; i < length(); i++) (*this)[i] = !((*this)[i]);
+}
+void bool_vec::insert(const bool_vec& vec)
+{
+  for (index_type i = 0; i < length(); i++) if (vec[i]) (*this)[i] = true;
+}
+void bool_vec::insert(const index_set& set)
+{
+  for (index_type i = 0; i < set.length(); i++) {
+    assert(set[i] < length());
+    (*this)[set[i]] = true;
+  }
+}
+void bool_vec::intersect(const bool_vec& vec)
+{
+  for (index_type i = 0; i < length(); i++) if (!vec[i]) (*this)[i] = false;
+}
+void bool_vec::intersect(const index_set& set)
+{
+  for (index_type i = 0; i < length(); i++)
+    if (!set.contains(i)) (*this)[i] = false;
+}
+void bool_vec::subtract(const bool_vec& vec)
+{
+  for (index_type i = 0; i < length(); i++) if (vec[i]) (*this)[i] = false;
+}
+void bool_vec::subtract(const index_set& set)
+{
+  for (index_type i = 0; i < set.length(); i++) {
+    assert(set[i] < length());
+    (*this)[set[i]] = false;
+  }
+}
+bool bool_vec::subset(const bool_vec& vec) const
+{
+  assert(length() == vec.length());
+  for (index_type i = 0; i < length(); i++)
+    if ((*this)[i] && !vec[i]) return false;
+  return true;
+}
+bool bool_vec::strict_subset(const bool_vec& vec) const
+{
+  assert(length() == vec.length());
+  bool strict = false;
+  for (index_type i = 0; i < length(); i++) {
+    if ((*this)[i] && !vec[i]) return false;
+    if (vec[i] && !(*this)[i]) strict = true;
+  }
+  return strict;
+}
+bool bool_vec::superset(const bool_vec& vec) const
+{
+  assert(length() == vec.length());
+  for (index_type i = 0; i < length(); i++)
+    if (!(*this)[i] && vec[i]) return false;
+  return true;
+}
+bool bool_vec::strict_superset(const bool_vec& vec) const
+{
+  assert(length() == vec.length());
+  bool strict = false;
+  for (index_type i = 0; i < length(); i++) {
+    if (!(*this)[i] && vec[i]) return false;
+    if (!vec[i] && (*this)[i]) strict = true;
+  }
+  return strict;
+}
+bool bool_vec::contains(const bool& v) const
+{
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+bool bool_vec::contains(const bool_vec& set) const
+{
+  index_type n = (set.length() > length() ? set.length() : length());
+  for (index_type k = 0; k < n; k++)
+    if (set[k] && !(*this)[k]) return false;
+  return true;
+}
+bool bool_vec::contains(const index_set& set) const
+{
+  for (index_type k = 0; k < set.length(); k++)
+    if (!(*this)[set[k]]) return false;
+  return true;
+}
+bool bool_vec::contains_any(const index_set& set) const
+{
+  for (index_type k = 0; k < set.length(); k++)
+    if ((*this)[set[k]]) return true;
+  return false;
+}
+index_type bool_vec::first_common_element(const index_set& vec) const
+{
+  return vec.first_common_element(*this);
+}
+index_type bool_vec::first_common_element(const bool_vec vec) const
+{
+  for (index_type k = 0; (k < length()) && (k < vec.length()); k++)
+    if ((*this)[k] && vec[k])
+      return k;
+  return no_such_index;
+}
+index_type bool_vec::count_common(const bool_vec& vec) const
+{
+  index_type c = 0;
+  index_type l = (size() < vec.size() ? size() : vec.size());
+  for (index_type k = 0; k < l; k++)
+    if ((*this)[k] && vec[k]) c += 1;
+  return c;
+}
+index_type bool_vec::count_common(const index_set& set) const
+{
+  return set.count_common(*this);
+}
+index_set& bool_vec::copy_to(index_set& set) const
+{
+  set.set_length(0);
+  for (index_type i = 0; i < length(); i++) if ((*this)[i]) set.insert(i);
+  return set;
+}
+index_set& bool_vec::insert_into(index_set& set) const
+{
+  for (index_type i = 0; i < length(); i++) if ((*this)[i]) set.insert(i);
+  return set;
+}
+index_set& bool_vec::subtract_from(index_set& set) const
+{
+  for (index_type i = 0; i < length(); i++) if ((*this)[i]) set.subtract(i);
+  return set;
+}
+bool* bool_vec::copy_to(bool* s, index_type n) const
+{
+  for (index_type i = 0; i < n; i++) s[i] = (*this)[i];
+}
+int bool_vec::compare(const bool_vec& vec) const
+{
+  if (length() < vec.length()) return -1;
+  if (length() > vec.length()) return 1;
+  for (index_type k = 0; k < length(); k++) {
+    if (vec[k] && !(*this)[k]) return -1;
+    if (!vec[k] && (*this)[k]) return 1;
+  }
+  return 0;
+}
+index_type bool_vec::hash() const
+{
+  index_type v = 0;
+  index_type vi = 0;
+  for (index_type k = 0; k < length(); k++) {
+    if ((*this)[k]) vi += (1 << (k % (32 - 1)));
+    if ((k % (32 - 1)) == 0) {
+      v += vi;
+      vi = 0;
+    }
+  }
+}
+void mapping::delete_index_map
+(index_type n, index_type i, index_vec& map)
+{
+  assert(i < n);
+  index_vec_util::fill(map, n);
+  map[i] = no_such_index;
+  for (index_type k = i + 1; k < n; k++)
+    map[k] = (k - 1);
+}
+bool mapping::invert_map(const index_vec& map, index_vec& inv, index_type m)
+{
+  index_type n = m;
+  for (index_type k = 0; k < map.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > n) n = map[k];
+  inv.assign_value(no_such_index, n + 1);
+  bool ok = true;
+  for (index_type k = 0; k < map.length(); k++)
+    if (map[k] != no_such_index) {
+      if (inv[map[k]] == no_such_index)
+ inv[map[k]] = k;
+      else
+ ok = false;
+    }
+  return ok;
+}
+void mapping::compose
+(const index_vec& m0, const index_vec& m1, index_vec& cm)
+{
+  cm.set_length(m0.length());
+  for (index_type k = 0; k < m0.length(); k++)
+    if (m0[k] != no_such_index) {
+      assert(m0[k] < m1.length());
+      cm[k] = m1[m0[k]];
+    }
+    else {
+      cm[k] = no_such_index;
+    }
+}
+void mapping::map_image
+(const index_vec& map, const index_vec& vec, index_vec& img)
+{
+  img.clear();
+  for (index_type k = 0; k < vec.length(); k++) {
+    assert(vec[k] < map.length());
+    if (map[vec[k]] != no_such_index)
+      img.append(map[vec[k]]);
+  }
+}
+void mapping::inverse_map_image
+(const index_vec& map, index_type v, index_set& img)
+{
+  img.clear();
+  for (index_type k = 0; k < map.length(); k++)
+    if (map[k] == v)
+      img.insert(k);
+}
+void mapping::inverse_map_image
+(const index_vec& map, const index_set& vs, index_set& img)
+{
+  img.clear();
+  for (index_type k = 0; k < map.length(); k++)
+    if (vs.contains(map[k]))
+      img.insert(k);
+}
+index_type mapping::range(const index_vec& map, index_type d)
+{
+  if (d == 0) return 0;
+  assert(map.length() >= d);
+  index_type m = 0;
+  for (index_type k = 0; k <= (d - 1); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  return m + 1;
+}
+void sparse_mapping::dense_to_sparse
+(const index_vec& dm, pair_vec sm)
+{
+  sm.clear();
+  for (index_type k = 0; k < dm.length(); k++)
+    if (dm[k] != no_such_index)
+      sm.append(index_pair(k, dm[k]));
+}
+void sparse_mapping::sparse_to_dense
+(const pair_vec& sm, index_vec dm)
+{
+  dm.clear();
+  index_type m = no_such_index;
+  for (index_type k = 0; k < sm.length(); k++)
+    if ((m == no_such_index) || (sm[k].first > m))
+      m = sm[k].first;
+  dm.assign_value(no_such_index, m);
+  for (index_type k = 0; k < sm.length(); k++)
+    if (dm[sm[k].first] == no_such_index)
+      dm[sm[k].first] = sm[k].second;
+}
+index_type sparse_mapping::map_image
+(const pair_vec& map, index_type x)
+{
+  for (index_type k = 0; k < map.length(); k++)
+    if (map[k].first == x)
+      return map[k].second;
+    else if (map[k].first > x)
+      return no_such_index;
+  return no_such_index;
+}
+void sparse_mapping::map_image
+(const pair_vec& map, const index_vec& vec, index_vec& img)
+{
+  img.clear();
+  for (index_type k = 0; k < vec.length(); k++) {
+    index_type i = map_image(map, vec[k]);
+    if (i != no_such_index)
+      img.append(i);
+  }
+}
+void sparse_mapping::inverse_map_image
+(const pair_vec& map, index_type x, index_set& img)
+{
+  img.clear();
+  for (index_type k = 0; k < map.length(); k++)
+    if (map[k].second == x)
+      img.insert(map[k].first);
+}
+void sparse_mapping::inverse_map_image
+(const pair_vec& map, const index_set& x, index_set& img)
+{
+  img.clear();
+  for (index_type k = 0; k < map.length(); k++)
+    if (x.contains(map[k].second))
+      img.insert(map[k].first);
+}
+index_type index_set_vec::minimum_cardinality() const
+{
+  if (length() == 0) return no_such_index;
+  index_type lmin = (*this)[0].length();
+  for (index_type k = 1; k < length(); k++)
+    if ((*this)[k].length() < lmin)
+      lmin = (*this)[k].length();
+  return lmin;
+}
+index_type index_set_vec::maxmimum_cardinality() const
+{
+  if (length() == 0) return no_such_index;
+  index_type lmax = (*this)[0].length();
+  for (index_type k = 1; k < length(); k++)
+    if ((*this)[k].length() > lmax)
+      lmax = (*this)[k].length();
+  return lmax;
+}
+index_type index_set_vec::selected_minimum_cardinality
+(const index_set& sel) const
+{
+  if (sel.length() == 0) return no_such_index;
+  assert(sel[0] < length());
+  index_type lmin = (*this)[sel[0]].length();
+  for (index_type k = 1; k < sel.length(); k++) {
+    assert(sel[k] < length());
+    if ((*this)[sel[k]].length() < lmin)
+      lmin = (*this)[sel[k]].length();
+  }
+  return lmin;
+}
+index_type index_set_vec::selected_maximum_cardinality
+(const index_set& sel) const
+{
+  if (sel.length() == 0) return no_such_index;
+  assert(sel[0] < length());
+  index_type lmax = (*this)[sel[0]].length();
+  for (index_type k = 1; k < sel.length(); k++) {
+    assert(sel[k] < length());
+    if ((*this)[sel[k]].length() > lmax)
+      lmax = (*this)[sel[k]].length();
+  }
+  return lmax;
+}
+index_type index_set_vec::first_minimum_cardinality_set() const
+{
+  if (length() == 0) return no_such_index;
+  index_type lmin = (*this)[0].length();
+  index_type imin = 0;
+  for (index_type k = 1; k < length(); k++)
+    if ((*this)[k].length() < lmin) {
+      lmin = (*this)[k].length();
+      imin = k;
+    }
+  return imin;
+}
+index_type index_set_vec::first_maxmimum_cardinality_set() const
+{
+  if (length() == 0) return no_such_index;
+  index_type lmax = (*this)[0].length();
+  index_type imax = 0;
+  for (index_type k = 1; k < length(); k++)
+    if ((*this)[k].length() > lmax) {
+      lmax = (*this)[k].length();
+      imax = k;
+    }
+  return imax;
+}
+index_type index_set_vec::first_superset(const index_set& set) const
+{
+  index_type k = 0;
+  while (k < length()) {
+    if ((*this)[k].contains(set))
+      return k;
+    k += 1;
+  }
+  return no_such_index;
+}
+index_type index_set_vec::first_strict_superset(const index_set& set) const
+{
+  index_type k = 0;
+  while (k < length()) {
+    if ((*this)[k].contains(set) && !set.contains((*this)[k]))
+      return k;
+    k += 1;
+  }
+  return no_such_index;
+}
+index_type index_set_vec::first_subset(const index_set& set) const
+{
+  index_type k = 0;
+  while (k < length()) {
+    if (set.contains((*this)[k]))
+      return k;
+    k += 1;
+  }
+  return no_such_index;
+}
+index_type index_set_vec::first_strict_subset(const index_set& set) const
+{
+  index_type k = 0;
+  while (k < length()) {
+    if (set.contains((*this)[k]) && !(*this)[k].contains(set))
+      return k;
+    k += 1;
+  }
+  return no_such_index;
+}
+index_set& index_set_vec::union_set(index_set& set) const
+{
+  set.clear();
+  for (index_type k = 0; k < length(); k++)
+    set.insert((*this)[k]);
+  return set;
+}
+index_set& index_set_vec::selected_union_set
+(const index_set& sel, index_set& set) const
+{
+  set.clear();
+  for (index_type k = 0; k < sel.length(); k++) {
+    assert(sel[k] < length());
+    set.insert((*this)[sel[k]]);
+  }
+  return set;
+}
+index_set& index_set_vec::intersection_set(index_set& set) const
+{
+  if (length() == 0) {
+    set.clear();
+    return set;
+  }
+  set.assign_copy((*this)[0]);
+  for (index_type k = 1; k < length(); k++)
+    set.intersect((*this)[k]);
+  return set;
+}
+void index_set_vec::append_if_not_subset(const index_set& set)
+{
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k].contains(set)) return;
+  append(set);
+}
+void index_set_vec::append_if_not_superset(const index_set& set)
+{
+  for (index_type k = 0; k < length(); k++)
+    if (set.contains((*this)[k])) return;
+  append(set);
+}
+void index_set_vec::append_if_new(const index_set& set)
+{
+  for (index_type k = 0; k < length(); k++)
+    if (set == (*this)[k]) return;
+  append(set);
+}
+void index_set_vec::insert_maximal(const index_set& set)
+{
+  for (index_type k = 0; k < length(); k++)
+    if ((*this)[k].contains(set)) return;
+  index_type r = 0;
+  index_type w = 0;
+  while (r < length()) {
+    if (!set.contains((*this)[r])) {
+      if (w < r) (*this)[w] = (*this)[r];
+      w += 1;
+    }
+    r += 1;
+  }
+  set_length(w);
+  append(set);
+}
+void index_set_vec::insert_minimal(const index_set& set)
+{
+  for (index_type k = 0; k < length(); k++)
+    if (set.contains((*this)[k])) return;
+  index_type r = 0;
+  index_type w = 0;
+  while (r < length()) {
+    if (!(*this)[r].contains(set)) {
+      if (w < r) (*this)[w] = (*this)[r];
+      w += 1;
+    }
+    r += 1;
+  }
+  set_length(w);
+  append(set);
+}
+void index_set_vec::reduce_to_maximal()
+{
+  bool_vec d(false, length());
+  for (index_type i = 0; i < length(); i++) if (!d[i])
+    for (index_type j = 0; j < length(); j++) if ((j != i) && !d[j])
+      if ((*this)[i].contains((*this)[j]))
+ d[j] = true;
+  assert(d.count(false) > 0);
+  remove(d);
+}
+void index_set_vec::reduce_to_minimal()
+{
+  bool_vec d(false, length());
+  for (index_type i = 0; i < length(); i++) if (!d[i])
+    for (index_type j = 0; j < length(); j++) if ((j != i) && !d[j])
+      if ((*this)[j].contains((*this)[i]))
+ d[j] = true;
+  assert(d.count(false) > 0);
+  remove(d);
+}
+void index_set_vec::remove_sets_size_le(index_type l)
+{
+  index_type r = 0;
+  index_type w = 0;
+  while (r < length()) {
+    if ((*this)[r].length() > l) {
+      if (w < r) (*this)[w] = (*this)[r];
+      w += 1;
+    }
+    r += 1;
+  }
+  set_length(w);
+}
+void index_set_vec::remove_empty_sets()
+{
+  index_type r = 0;
+  index_type w = 0;
+  while (r < length()) {
+    if (!(*this)[r].empty()) {
+      if (w < r) (*this)[w] = (*this)[r];
+      w += 1;
+    }
+    r += 1;
+  }
+  set_length(w);
+}
+void index_set_vec::insert_in_all(index_type i)
+{
+  for (index_type k = 0; k < length(); k++)
+    (*this)[k].insert(i);
+}
+void index_set_vec::insert_in_all(const index_set& set)
+{
+  for (index_type k = 0; k < length(); k++)
+    (*this)[k].insert(set);
+}
+void index_set_vec::subtract_from_all(index_type i)
+{
+  for (index_type k = 0; k < length(); k++)
+    (*this)[k].subtract(i);
+}
+void index_set_vec::subtract_from_all(const index_set& set)
+{
+  for (index_type k = 0; k < length(); k++)
+    (*this)[k].subtract(set);
+}
+void index_set_vec::combinations_by_union(const index_set_vec& sv)
+{
+  index_type l = length();
+  index_type k = 0;
+  while (k < sv.length()) {
+    index_type i_from = length() - l;
+    index_type i_to = length();
+    if (k < (sv.length() - 1)) {
+      for (index_type i = i_from; i < i_to; i++)
+ append((*this)[i]);
+    }
+    for (index_type i = i_from; i < i_to; i++)
+      (*this)[i].insert(sv[k]);
+    k += 1;
+  }
+  if (sv.length() == 0) clear();
+}
+void index_set_vec::combinations_by_union
+(const index_set_vec& sv1, const index_set_vec& sv2)
+{
+  for (index_type i = 0; i < sv1.length(); i++)
+    for (index_type j = 0; j < sv2.length(); j++) {
+      append(sv1[i]);
+      (*this)[length() - 1].insert(sv2.length());
+    }
+}
+void bool_matrix::complement()
+{
+  for (index_type i = 0; i < rows(); i++)
+    for (index_type j = 0; j < columns(); j++)
+      (*this)[i][j] = !((*this)[i][j]);
+}
+void bool_matrix::insert(const bool_matrix& m)
+{
+  assert(m.rows() == rows());
+  assert(m.columns() == columns());
+  for (index_type i = 0; i < rows(); i++)
+    for (index_type j = 0; j < columns(); j++)
+      if (m[i][j])
+ (*this)[i][j] = true;
+}
+void bool_matrix::intersect(const bool_matrix& m)
+{
+  assert(m.rows() == rows());
+  assert(m.columns() == columns());
+  for (index_type i = 0; i < rows(); i++)
+    for (index_type j = 0; j < columns(); j++)
+      if (!m[i][j])
+ (*this)[i][j] = false;
+}
+void bool_matrix::subtract(const bool_matrix& m)
+{
+  assert(m.rows() == rows());
+  assert(m.columns() == columns());
+  for (index_type i = 0; i < rows(); i++)
+    for (index_type j = 0; j < columns(); j++)
+      if (m[i][j])
+ (*this)[i][j] = false;
+}
+void bool_matrix::multiply(const bool_matrix& m0, const bool_matrix& m1)
+{
+  assert(m0.columns() == m1.rows());
+  set_size(m0.rows(), m1.columns());
+  for (index_type i = 0; i < rows(); i++)
+    for (index_type j = 0; j < columns(); j++) {
+      bool p = false;
+      for (index_type k = 0; (k < m0.columns()) && !p; k++)
+ if (m0[i][k] && m1[k][j]) p = true;
+      (*this)[i][j] = p;
+    }
+}
+void bool_matrix::transitive_closure()
+{
+  assert(rows() == columns());
+  for (index_type k = 0; k < rows(); k++)
+    for (index_type i = 0; i < rows(); i++)
+      if ((*this)[i][k])
+ for (index_type j = 0; j < rows(); j++)
+   if ((*this)[k][j])
+     (*this)[i][j] = true;
+}
+bool equivalence::operator()(index_type a, index_type b) const
+{
+  return (canonical(a) == canonical(b));
+}
+index_type equivalence::canonical(index_type a) const
+{
+  assert(a < length());
+  index_type x = a;
+  index_type y = (*this)[x];
+  while ((x != y) && (y != no_such_index)) {
+    x = y;
+    y = (*this)[x];
+  }
+  if (y == no_such_index) return a;
+  else return y;
+}
+void equivalence::extend(index_type a)
+{
+  for (index_type k = length(); k < a; k++) append(k);
+}
+void equivalence::merge(index_type a, index_type b)
+{
+  index_type c_a = canonical(a);
+  index_type c_b = canonical(b);
+  ((*this)[c_a]) = c_b;
+}
+void equivalence::merge(const index_set& set)
+{
+  for (index_type i = 1; i < set.length(); i++)
+    merge(set[0], set[i]);
+}
+void equivalence::merge(const index_set& sa, const index_set& sb)
+{
+  for (index_type i = 0; i < sa.length(); i++)
+    for (index_type j = 0; j < sb.length(); j++)
+      merge(sa[i], sb[j]);
+}
+void equivalence::merge(const equivalence& eq)
+{
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type i = eq.canonical(k);
+    if (i != k) merge(i, k);
+  }
+}
+void equivalence::reset()
+{
+  for (index_type k = 0; k < length(); k++) ((*this)[k]) = k;
+}
+void equivalence::reset(index_type n)
+{
+  set_length(n);
+  reset();
+}
+void equivalence::canonical_set(index_set& set) const
+{
+  index_set tmp(set);
+  set.clear();
+  for (index_type k = 0; k < tmp.length(); k++)
+    set.insert(canonical(tmp[k]));
+}
+index_type equivalence::n_squeezed() const
+{
+  index_type n = 0;
+  for (index_type k = 0; k < length(); k++) if (canonical(k) != k) n += 1;
+  return n;
+}
+index_type equivalence::n_classes() const
+{
+  index_type n = 0;
+  for (index_type k = 0; k < length(); k++) if (canonical(k) == k) n += 1;
+  return n;
+}
+void equivalence::canonical_elements(index_set& set) const
+{
+  for (index_type k = 0; k < length(); k++)
+    if (canonical(k) == k) set.insert(k);
+}
+void equivalence::class_elements(index_type c, index_set& set) const
+{
+  for (index_type k = 0; k < length(); k++)
+    if (canonical(k) == c) set.insert(k);
+}
+void equivalence::classes(index_set_vec& sets) const
+{
+  index_set c;
+  canonical_elements(c);
+  sets.assign_value(EMPTYSET, c.length());
+  for (index_type k = 0; k < c.length(); k++)
+    class_elements(c[k], sets[k]);
+}
+index_type equivalence::n_class_elements(index_type c) const
+{
+  index_type n = 0;
+  for (index_type k = 0; k < length(); k++)
+    if (canonical(k) == c) n += 1;
+  return n;
+}
+void equivalence::make_map(index_vec& map) const
+{
+  index_set ce;
+  canonical_elements(ce);
+  map.assign_value(no_such_index, length());
+  for (index_type k = 0; k < length(); k++) {
+    index_type c = canonical(k);
+    map[k] = ce.first(c);
+  }
+}
+void set_hash_function::init(index_type n)
+{
+  resize(n);
+  if (n == 0) return;
+  (*this)[0] = 1;
+  for (index_type k = 1; k < size(); k++) {
+    (*this)[k] = ((2 * (*this)[k - 1]) % LARGE_PRIME);
+  }
+}
+index_type set_hash_function::operator()(index_type& i, index_type v) const
+{
+  assert(i < size());
+  return ((v + (*this)[i]) % LARGE_PRIME);
+}
+index_type set_hash_function::operator()(const index_set& set) const
+{
+  index_type h = 0;
+  for (index_type k = 0; k < set.length(); k++) {
+    assert(set[k] < size());
+    h = ((h + (*this)[set[k]]) % LARGE_PRIME);
+  }
+  return h;
+}
+index_type set_hash_function::operator()(const bool_vec& set) const
+{
+  assert(set.size() <= size());
+  index_type h = 0;
+  for (index_type k = 0; k < set.length(); k++) {
+    if (set[k]) h = ((h + (*this)[k]) % LARGE_PRIME);
+  }
+  return h;
+}
+index_type set_hash_function::operator()(const bool* set, index_type n) const
+{
+  assert(n <= size());
+  index_type h = 0;
+  for (index_type k = 0; k < n; k++) {
+    if (set[k]) h = ((h + (*this)[k]) % LARGE_PRIME);
+  }
+  return h;
+}
+}

--- a/pr/seq-opt-hspsf/name.ccx
+++ b/pr/seq-opt-hspsf/name.ccx
@@ -1,0 +1,1674 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <sstream>
+namespace hsps {
+Name::~Name()
+{
+}
+const Name* Name::cast_to(const char* cname) const
+{
+  return 0;
+}
+::std::string Name::to_string(unsigned int c) const
+{
+  ::std::ostringstream s;
+  write(s, c);
+  return s.str();
+}
+char* Name::to_cstring(unsigned int c) const
+{
+  ::std::string s = to_string(c);
+  return strdup(s.c_str());
+}
+bool Name::equals(const Name* name) const
+{
+  return (to_string() == name->to_string());
+}
+void NameWithContext::write(::std::ostream& s, unsigned int c) const
+{
+  name->write(s, (c & ~c_off) | c_on);
+}
+void StringName::write(::std::ostream& s, unsigned int c) const
+{
+  write_string_escaped(s, _string, c);
+}
+void ConcatenatedName::write(::std::ostream& s, unsigned int c) const
+{
+  for (index_type k = 0; k < elements.length(); k++) {
+    if (k > 0) {
+      write_char_escaped(s, catc, c);
+    }
+    elements[k]->write(s, c);
+  }
+}
+void EnumName::write(::std::ostream& s, unsigned int c) const
+{
+  if (!context_is_instance(c)) s << '(';
+  write_string_escaped(s, prefix, c);
+  s << index;
+  if (!context_is_instance(c)) s << ')';
+}
+void ModName::write(::std::ostream& s, unsigned int c) const
+{
+  if (context_is_instance(c)) {
+    write_string_escaped(s, _mod, c);
+    write_char_escaped(s, '_', c);
+    _name->write(s, c);
+  }
+  else {
+    write_char_escaped(s, '(', c);
+    write_string_escaped(s, _mod, c);
+    write_char_escaped(s, ' ', c);
+    _name->write(s, c);
+    write_char_escaped(s, ')', c);
+  }
+}
+void CopyName::write(::std::ostream& s, unsigned int c) const
+{
+  write_string_escaped(s, "copy", c);
+  if (_num != no_such_index) {
+    if (context_is_instance(c)) {
+      write_char_escaped(s, '_', c);
+      s << _num;
+      write_char_escaped(s, '_', c);
+    }
+    else {
+      write_string_escaped(s, " #", c);
+      s << _num;
+      write_string_escaped(s, " of ", c);
+    }
+  }
+  else {
+    if (context_is_instance(c)) {
+      write_char_escaped(s, '_', c);
+    }
+    else {
+      write_string_escaped(s, " of ", c);
+    }
+  }
+  _name->write(s, c);
+}
+void NameAtIndex::write(::std::ostream& s, unsigned int c) const
+{
+  _name->write(s, c);
+  if (_index == no_such_index) {
+    if (context_is_instance(c)) {
+      write_string_escaped(s, "_at_no_index", c);
+    }
+    else {
+      write_string_escaped(s, " at <no index>", c);
+    }
+  }
+  else {
+    if (context_is_instance(c)) {
+      write_string_escaped(s, "_at_", c);
+    }
+    else {
+      write_string_escaped(s, " at ", c);
+    }
+    s << _index;
+  }
+}
+}

--- a/pr/seq-opt-hspsf/nodeset.ccx
+++ b/pr/seq-opt-hspsf/nodeset.ccx
@@ -1,0 +1,3418 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class Node;
+typedef Node* nodep;
+typedef lvector<nodep> node_vec;
+struct Link {
+  Node* node;
+  hsps::rational delta;
+  Link() : node(0), delta(0) { };
+  Link(Node* s, hsps::rational d) : node(s), delta(d) { };
+  Link& operator=(const Link& l);
+  bool operator==(const Link& l);
+  bool operator<(const Link& l);
+  bool operator>(const Link& l);
+  bool operator<=(const Link& l);
+  bool operator>=(const Link& l);
+};
+typedef svector<Link> link_vec;
+class Node {
+ public:
+  index_type id;
+  State* state;
+  link_vec succ;
+  bool closed;
+  hsps::rational acc;
+  hsps::rational est;
+  hsps::rational val;
+  hsps::rational opt;
+  index_type pos;
+  count_type exp;
+  Node* bp_pre;
+  hsps::rational bp_delta;
+  link_vec* all_pre;
+  Node() :
+    id(0), state(0), closed(false), acc(0), est(0), val(0), opt(POS_INF),
+    pos(no_such_index), exp(0), bp_pre(0), bp_delta(0), all_pre(0) { };
+  ~Node();
+  hsps::rational min_delta_to(Node* n);
+  bool solved() { return (opt).finite(); };
+  bool back_path_contains(Node* n);
+  void add_predecessor(Node* n, hsps::rational d);
+  void backup_costs(node_vec& p);
+  void write(std::ostream& s, const Name* p = 0);
+  void write_short(std::ostream& s, const Name* p = 0);
+  void write_graph_node(std::ostream& s);
+  void write_graph_edges(std::ostream& s);
+};
+class NodeQueue : public node_vec {
+  const node_vec::order& before;
+ public:
+  NodeQueue(const node_vec::order& b);
+  ~NodeQueue();
+  void check_queue();
+  Node* peek();
+  void enqueue(Node*);
+  Node* dequeue();
+  void shift_up(index_type i);
+  void shift_down(index_type i);
+};
+class NodeSet {
+ protected:
+  static index_type next_id;
+  node_vec roots;
+ public:
+  static bool write_state_in_graph_node;
+  virtual ~NodeSet();
+  virtual Node* insert_node(State& s) = 0;
+  virtual Node* find_node(State& s) = 0;
+  virtual void clear() = 0;
+  virtual void collect_nodes(node_vec& ns) = 0;
+  Node* insert_root_node(State& s);
+  void make_root(Node* n);
+  node_vec& root_nodes();
+  void compute_reverse_links(node_vec& v);
+  void compute_reverse_links();
+  void mark_solved_apsp();
+  void mark_solved();
+  void backup_costs();
+  void set_back_path_solution_cost(Node* n, hsps::rational c_sol);
+  void cache_pg(hsps::rational c_sol);
+  void back_path_to_sequence(Node* n, node_vec& ns);
+  State* build_path(node_vec& ns);
+  State* build_path(Node* tn);
+  void write_short(std::ostream& s, const Name* p = 0);
+  void write_graph(std::ostream& s);
+};
+class NodeSetSearchState : public State {
+  Node* node;
+  hsps::rational delta;
+  State* path;
+ public:
+  NodeSetSearchState(Node* n);
+  NodeSetSearchState(NodeSetSearchState* p, Link& l, State* s);
+  NodeSetSearchState(const NodeSetSearchState& s);
+  virtual ~NodeSetSearchState();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write(std::ostream& s);
+  virtual void write_plan(std::ostream& s);
+};
+class TreeNodeSet : public Node, public NodeSet {
+  TreeNodeSet* left;
+  TreeNodeSet* right;
+ public:
+  TreeNodeSet();
+  virtual ~TreeNodeSet();
+  virtual Node* insert_node(State& s);
+  virtual Node* find_node(State& s);
+  virtual void clear();
+  virtual void collect_nodes(node_vec& ns);
+};
+class HashNodeSet : public NodeSet {
+  index_type size;
+  TreeNodeSet** tab;
+ public:
+  HashNodeSet(index_type s);
+  virtual ~HashNodeSet();
+  virtual Node* insert_node(State& s);
+  virtual Node* find_node(State& s);
+  virtual void clear();
+  virtual void collect_nodes(node_vec& ns);
+};
+inline Link& Link::operator=(const Link& l)
+{
+  node = l.node;
+  delta = l.delta;
+  return *this;
+}
+inline bool Link::operator==(const Link& l)
+{
+  return ((node == l.node) && (delta == l.delta));
+}
+inline bool Link::operator<(const Link& l)
+{
+  return ((node < l.node) || ((node == l.node) && (delta < l.delta)));
+}
+inline bool Link::operator>(const Link& l)
+{
+  return ((node > l.node) || ((node == l.node) && (delta > l.delta)));
+}
+inline bool Link::operator<=(const Link& l)
+{
+  return ((node <= l.node) || ((node == l.node) && (delta <= l.delta)));
+}
+inline bool Link::operator>=(const Link& l)
+{
+  return ((node >= l.node) || ((node == l.node) && (delta >= l.delta)));
+}
+}
+namespace hsps {
+Node::~Node()
+{
+  if (state) delete state;
+}
+hsps::rational Node::min_delta_to(Node* n)
+{
+  hsps::rational d = POS_INF;
+  for (index_type k = 0; k < succ.length(); k++)
+    if (succ[k].node == n)
+      d = hsps::rational::min(d,succ[k].delta);
+  return d;
+}
+bool Node::back_path_contains(Node* n)
+{
+  if (n == this) return true;
+  if (bp_pre) {
+    return bp_pre->back_path_contains(n);
+  }
+  return false;
+}
+void Node::add_predecessor(Node* n, hsps::rational d)
+{
+  if (all_pre == 0) all_pre = new link_vec;
+  for (index_type k = 0; k < all_pre->length(); k++)
+    if ((*all_pre)[k].node == n) {
+      (*all_pre)[k].delta = hsps::rational::min((*all_pre)[k].delta,d);
+      return;
+    }
+  all_pre->append(Link(n, d));
+}
+void Node::backup_costs(node_vec& p)
+{
+  if (exp == 0) {
+    if (state->is_final()) {
+      opt = 0;
+      assert(est == 0);
+    }
+    else {
+      opt = POS_INF;
+    }
+    return;
+  }
+  hsps::rational e_min = POS_INF;
+  hsps::rational o_min = POS_INF;
+  p.append(this);
+  for (index_type k = 0; k < succ.length(); k++)
+    if ((succ[k].node->est + succ[k].delta) < e_min) {
+      if (p.first(succ[k].node) == no_such_index) {
+ succ[k].node->backup_costs(p);
+ e_min = hsps::rational::min(e_min,succ[k].node->est + succ[k].delta);
+ o_min = hsps::rational::min(o_min,succ[k].node->opt + succ[k].delta);
+      }
+    }
+  p.dec_length();
+  est = hsps::rational::min(e_min,est);
+  opt = hsps::rational::min(o_min,opt);
+  assert(est <= opt);
+  if (state->est_cost() > opt) {
+    std::cerr << "ERROR: INADMISSIBLE HEURISTIC!" << std::endl;
+    exit(255);
+  }
+}
+void Node::write(std::ostream& s, const Name* p)
+{
+  assert(state);
+  if (p) s << p << " ";
+  s << "NODE: " << id
+    << ' ' << state->is_max()
+    << ' ' << state->is_final()
+    << ' ' << acc
+    << ' ' << opt
+    << ' ' << est
+    << ' ' << val
+    << ' ' << exp
+    << ' ' << succ.length();
+  state->write_eval(s, " H:", false);
+  s << " STATE: " << *state
+    << std::endl;
+}
+void Node::write_short(std::ostream& s, const Name* p)
+{
+  assert(state);
+  if (p) s << p << " ";
+  s << "NODE: " << id
+    << ' ' << state->is_max()
+    << ' ' << state->is_final()
+    << ' ' << acc
+    << ' ' << opt
+    << ' ' << est
+    << ' ' << val
+    << ' ' << exp
+    << ' ' << succ.length();
+  state->write_eval(s, " H:", true);
+}
+void Node::write_graph_node(std::ostream& s)
+{
+  assert(state);
+  s << "N" << id << " [label=\"" << id << ": ";
+  if (NodeSet::write_state_in_graph_node) {
+    s << *state << " / ";
+  }
+  s << acc << " + " << est << " / " << opt << "\"";
+  if (state->is_max()) {
+    s << ",shape=box";
+  }
+  else {
+    s << ",shape=ellipse";
+  }
+  if (state->is_final()) {
+    s << ",style=filled";
+  }
+  else if (exp == 0) {
+    s << ",style=dashed";
+  }
+  s << "];" << std::endl;
+}
+void Node::write_graph_edges(std::ostream& s)
+{
+  for (index_type k = 0; k < succ.length(); k++) {
+    s << "N" << id << " -> " << " N" << succ[k].node->id << " [label=\""
+      << succ[k].delta << "\"";
+    if ((opt).finite() && ((succ[k].node->opt + succ[k].delta) == opt)) {
+      s << ",style=\"bold\"";
+    }
+    s << "];" << std::endl;
+  }
+}
+NodeQueue::NodeQueue(const node_vec::order& b)
+  : node_vec(0, 0), before(b)
+{
+}
+NodeQueue::~NodeQueue()
+{
+}
+void NodeQueue::check_queue()
+{
+  for (index_type i = 0; i < (length() / 2); i++) {
+    if ((((i+1)*2) - 1) < length()) {
+      if (before((*this)[(((i+1)*2) - 1)], (*this)[i])) {
+ std::cerr << "error in queue:";
+ for (index_type k = 0; k < length(); k++)
+   std::cerr << " #" << (*this)[k]->id << ":" << (*this)[k]->val;
+ std::cerr << " at position " << i << " / " << (((i+1)*2) - 1)
+    << std::endl;
+ exit(255);
+      }
+    }
+    if (((i+1)*2) < length()) {
+      if (before((*this)[((i+1)*2)], (*this)[i])) {
+ std::cerr << "error in queue:";
+ for (index_type k = 0; k < length(); k++)
+   std::cerr << " #" << (*this)[k]->id << ":" << (*this)[k]->val;
+ std::cerr << " at position " << i << " / " << ((i+1)*2)
+    << std::endl;
+ exit(255);
+      }
+    }
+  }
+}
+void NodeQueue::shift_up(index_type i) {
+  while (!(i == 0)) {
+    if (before((*this)[i], (*this)[(((i+1) >> 1) - 1)])) {
+      swap(i, (((i+1) >> 1) - 1));
+      (*this)[i]->pos = i;
+      (*this)[(((i+1) >> 1) - 1)]->pos = (((i+1) >> 1) - 1);
+      i = (((i+1) >> 1) - 1);
+    }
+    else return;
+  }
+}
+void NodeQueue::shift_down(index_type i) {
+  index_type j;
+  while (i < (length() / 2)) {
+    assert((((i+1)*2) - 1) < length());
+    if ((((i+1)*2) - 1) == (length() - 1)) {
+      j = (((i+1)*2) - 1);
+    }
+    else {
+      assert(((i+1)*2) < length());
+      if (before((*this)[(((i+1)*2) - 1)], (*this)[((i+1)*2)]))
+ j = (((i+1)*2) - 1);
+      else
+ j = ((i+1)*2);
+    }
+    if (before((*this)[j], (*this)[i])) {
+      swap(i, j);
+      (*this)[i]->pos = i;
+      (*this)[j]->pos = j;
+      i = j;
+    }
+    else return;
+  }
+}
+void NodeQueue::enqueue(Node* n)
+{
+  append(n);
+  n->pos = length() - 1;
+  shift_up(length() - 1);
+}
+Node* NodeQueue::dequeue()
+{
+  if (length() == 0) {
+    return 0;
+  }
+  Node* n = (*this)[0];
+  n->pos = no_such_index;
+  if (length() > 1) {
+    (*this)[0] = (*this)[length() - 1];
+    (*this)[0]->pos = 0;
+    dec_length();
+    shift_down(0);
+  }
+  else {
+    clear();
+  }
+  return n;
+}
+Node* NodeQueue::peek()
+{
+  if (length() == 0) return 0;
+  return (*this)[0];
+}
+index_type NodeSet::next_id = 1;
+bool NodeSet::write_state_in_graph_node = true;
+NodeSet::~NodeSet()
+{
+}
+void NodeSet::back_path_to_sequence(Node* n, node_vec& ns)
+{
+  if (n->bp_pre) {
+    back_path_to_sequence(n->bp_pre, ns);
+  }
+  ns.append(n);
+}
+void NodeSet::set_back_path_solution_cost(Node* n, hsps::rational c_sol)
+{
+  n->opt = c_sol;
+  if (n->bp_pre) {
+    set_back_path_solution_cost(n->bp_pre, c_sol + n->bp_delta);
+  }
+}
+State* NodeSet::build_path(node_vec& ns)
+{
+  if (ns.length() == 0) return 0;
+  assert(ns[0]->state);
+  State* s = ns[0]->state->copy();
+  for (index_type k = 1; k < ns.length(); k++) {
+    assert(ns[k]->state);
+    Transitions ts(s, ns[k]->state, ns[k]->acc - ns[k - 1]->acc);
+    if (ts.length() == 0) {
+      std::cerr << "error: can't make path from node sequence:" << std::endl;
+      for (index_type i = 0; i < ns.length(); i++) {
+ std::cerr << i << ". ";
+ ns[i]->write(std::cerr);
+      }
+      std::cerr << "- no transition from " << k - 1 << " to " << k
+  << std::endl;
+      exit(255);
+    }
+    s = ts[0]->copy();
+  }
+  return s;
+}
+State* NodeSet::build_path(Node* tn)
+{
+  node_vec ns(0, 0);
+  back_path_to_sequence(tn, ns);
+  return build_path(ns);
+}
+Node* NodeSet::insert_root_node(State& s)
+{
+  Node* n = insert_node(s);
+  make_root(n);
+  return n;
+}
+void NodeSet::make_root(Node* n)
+{
+  if (roots.first(n) == no_such_index)
+    roots.append(n);
+}
+node_vec& NodeSet::root_nodes()
+{
+  return roots;
+}
+void NodeSet::cache_pg(hsps::rational c_sol)
+{
+  node_vec v(0, 0);
+  collect_nodes(v);
+  for (index_type k = 0; k < v.length(); k++) if (v[k]->closed) {
+    if ((v[k]->opt).finite()) {
+      v[k]->state->store(v[k]->opt, true);
+    }
+    else {
+      v[k]->state->store(c_sol - v[k]->acc, false);
+    }
+  }
+}
+void NodeSet::mark_solved_apsp()
+{
+  node_vec v(0, 0);
+  collect_nodes(v);
+  index_type n = v.length();
+  hsps::rational** d = new hsps::rational*[n];
+  for (index_type i = 0; i < n; i++)
+    d[i] = new hsps::rational[n];
+  std::cerr << "initializing..." << std::endl;
+  for (index_type i = 0; i < n; i++)
+    for (index_type j = 0; j < n; i++)
+      d[i][j] = POS_INF;
+  std::cerr << "adding links..." << std::endl;
+  for (index_type k = 0; k < v.length(); k++)
+    for (index_type i = 0; i < v[k]->succ.length(); i++) {
+      index_type p = v.first(v[k]->succ[i].node);
+      assert(p != no_such_index);
+      d[k][p] = hsps::rational::min(d[k][p],v[k]->succ[i].delta);
+    }
+  std::cerr << "computing shortest paths..." << std::endl;
+  for (index_type k = 0; k < n; k++)
+    for (index_type i = 0; i < n; i++)
+      for (index_type j = 0; j < n; i++)
+ d[i][j] = hsps::rational::min(d[i][j],d[i][k] + d[k][j]);
+  std::cerr << "initializing..." << std::endl;
+  for (index_type k = 0; k < v.length(); k++)
+    v[k]->opt = POS_INF;
+  std::cerr << "computing min distances..." << std::endl;
+  for (index_type k = 0; k < v.length(); k++) if (v[k]->state->is_final()) {
+    v[k]->opt = 0;
+    for (index_type i = 0; i < v.length(); i++)
+      v[i]->opt = hsps::rational::min(v[i]->opt,d[i][k]);
+  }
+}
+class NodeOrderByOpt : public node_vec::order {
+public:
+  NodeOrderByOpt() { };
+  virtual bool operator()(const nodep& v0, const nodep& v1) const;
+};
+bool NodeOrderByOpt::operator()(const nodep& v0, const nodep& v1) const
+{
+  if (v0->opt < v1->opt) return true;
+  return false;
+}
+void NodeSet::compute_reverse_links(node_vec& v)
+{
+  for (index_type k = 0; k < v.length(); k++)
+    for (index_type i = 0; i < v[k]->succ.length(); i++)
+      v[k]->succ[i].node->add_predecessor(v[k], v[k]->succ[i].delta);
+}
+void NodeSet::compute_reverse_links()
+{
+  node_vec v(0, 0);
+  collect_nodes(v);
+  compute_reverse_links(v);
+}
+void NodeSet::mark_solved()
+{
+  node_vec v(0, 0);
+  collect_nodes(v);
+  compute_reverse_links(v);
+  NodeOrderByOpt opt_is_less;
+  NodeQueue q(opt_is_less);
+  for (index_type k = 0; k < v.length(); k++) {
+    if (v[k]->state->is_final()) {
+      v[k]->opt = 0;
+      q.enqueue(v[k]);
+    }
+    else {
+      v[k]->opt = POS_INF;
+    }
+  }
+  index_type nn = v.length();
+  index_type i = 0;
+  while (!q.empty() > 0) {
+    Node* n = q.dequeue();
+    if (n->all_pre) {
+      for (index_type k = 0; k < n->all_pre->length(); k++) {
+ hsps::rational d = (*(n->all_pre))[k].delta;
+ if ((n->opt + d) < (*(n->all_pre))[k].node->opt) {
+   (*(n->all_pre))[k].node->opt = n->opt + d;
+   q.enqueue((*(n->all_pre))[k].node);
+ }
+      }
+    }
+    i += 1;
+  }
+}
+void NodeSet::backup_costs()
+{
+  node_vec p(0, 0);
+  collect_nodes(p);
+  for (index_type k = 0; k < p.length(); k++)
+    p[k]->opt = POS_INF;
+  for (index_type k = 0; k < roots.length(); k++) {
+    p.clear();
+    roots[k]->backup_costs(p);
+  }
+}
+void NodeSet::write_short(std::ostream& s, const Name* p)
+{
+  node_vec v(0, 0);
+  collect_nodes(v);
+  for (index_type k = 0; k < v.length(); k++) {
+    v[k]->write_short(s, p);
+  }
+}
+void NodeSet::write_graph(std::ostream& s)
+{
+  node_vec v(0, 0);
+  collect_nodes(v);
+  s << "digraph BFS_SEARCH_SPACE {" << std::endl;
+  s << "node [width=0,height=0,shape=box];" << std::endl;
+  for (index_type k = 0; k < v.length(); k++) {
+    v[k]->write_graph_node(s);
+  }
+  for (index_type k = 0; k < v.length(); k++) {
+    v[k]->write_graph_edges(s);
+  }
+  s << "}" << std::endl;
+}
+NodeSetSearchState::NodeSetSearchState(Node* n)
+  : delta(0), node(n), path(0)
+{
+  assert(node);
+  assert(node->state);
+  assert(node->state->predecessor() == 0);
+  assert(node->state->delta_cost() == 0);
+  path = node->state->copy();
+}
+NodeSetSearchState::NodeSetSearchState
+(NodeSetSearchState* p, Link& l, State* s)
+  : delta(l.delta), node(l.node), path(s)
+{
+  assert(node);
+  assert(node->state);
+  assert(node->state->compare(*s) == 0);
+  set_predecessor(p);
+}
+NodeSetSearchState::NodeSetSearchState(const NodeSetSearchState& s)
+  : State(s), delta(s.delta), node(s.node), path(s.path->copy())
+{
+}
+NodeSetSearchState::~NodeSetSearchState()
+{
+}
+hsps::rational NodeSetSearchState::delta_cost()
+{
+  return delta;
+}
+hsps::rational NodeSetSearchState::est_cost()
+{
+  return node->est;
+}
+bool NodeSetSearchState::is_final()
+{
+  return node->state->is_final();
+}
+bool NodeSetSearchState::is_max()
+{
+  return node->state->is_max();
+}
+hsps::rational NodeSetSearchState::expand(Search& s, hsps::rational bound)
+{
+  hsps::rational v = POS_INF;
+  for (index_type k = 0; k < node->succ.length(); k++) {
+    if ((node->succ[k].delta + node->succ[k].node->opt) <= bound) {
+      Transitions* ts =
+ new Transitions(path, node->succ[k].node->state, node->succ[k].delta);
+      if (ts->length() == 0) {
+ std::cerr << "error: no transition found from node #"
+    << node->id
+    << " (" << node->state << ") to successor node #"
+    << node->succ[k].node->id
+    << " (" << node->succ[k].node->state << ") with delta = "
+    << node->succ[k].delta
+    << std::endl;
+ exit(255);
+      }
+      for (index_type i = 0; i < ts->length(); i++) {
+ NodeSetSearchState* new_ns =
+   new NodeSetSearchState(this, node->succ[k], (*ts)[i]);
+ v = hsps::rational::min(s.new_state(*new_ns, bound),v);
+ delete new_ns;
+ if (s.done()) return v;
+      }
+      delete ts;
+    }
+  }
+  return v;
+}
+void NodeSetSearchState::store(hsps::rational cost, bool opt)
+{
+  node->state->store(cost, opt);
+}
+void NodeSetSearchState::reevaluate()
+{
+  node->state->reevaluate();
+  node->est = node->state->est_cost();
+}
+int NodeSetSearchState::compare(const State& s)
+{
+  const NodeSetSearchState& ns = (const NodeSetSearchState&)s;
+  if (node->id < ns.node->id) {
+    return -1;
+  }
+  else if (node->id > ns.node->id) {
+    return 1;
+  }
+  return 0;
+}
+index_type NodeSetSearchState::hash()
+{
+  return node->id;
+}
+State* NodeSetSearchState::copy()
+{
+  return new NodeSetSearchState(*this);
+}
+void NodeSetSearchState::insert(Plan& p)
+{
+  path->insert(p);
+}
+void NodeSetSearchState::insert_path(Plan& p)
+{
+  path->insert_path(p);
+}
+void NodeSetSearchState::write(std::ostream& s)
+{
+  node->write_short(s);
+}
+void NodeSetSearchState::write_plan(std::ostream& s)
+{
+  path->write_plan(s);
+}
+TreeNodeSet::TreeNodeSet()
+  : left(0), right(0)
+{
+  id = next_id++;
+}
+TreeNodeSet::~TreeNodeSet()
+{
+  clear();
+}
+Node* TreeNodeSet::insert_node(State& s)
+{
+  if (!state) return this;
+  int d = state->compare(s);
+  if (d < 0) {
+    if (!right) right = new TreeNodeSet();
+    return right->insert_node(s);
+  }
+  else if (d > 0) {
+    if (!left) left = new TreeNodeSet();
+    return left->insert_node(s);
+  }
+  else return this;
+}
+Node* TreeNodeSet::find_node(State& s)
+{
+  if (!state) return 0;
+  int d = state->compare(s);
+  if (d < 0) {
+    if (!right) return 0;
+    else return right->find_node(s);
+  }
+  else if (d > 0) {
+    if (!left) return 0;
+    else return left->find_node(s);
+  }
+  else return this;
+}
+void TreeNodeSet::clear()
+{
+  if (state) {
+    delete state;
+    state = 0;
+  }
+  if (left) {
+    delete left;
+    left = 0;
+  }
+  if (right) {
+    delete right;
+    right = 0;
+  }
+}
+void TreeNodeSet::collect_nodes(node_vec& ns)
+{
+  ns.append(this);
+  if (left) {
+    left->collect_nodes(ns);
+  }
+  if (right) {
+    right->collect_nodes(ns);
+  }
+}
+HashNodeSet::HashNodeSet(index_type s)
+  : size(s), tab(0)
+{
+  tab = new TreeNodeSet*[size];
+  for (index_type k = 0; k < size; k++) tab[k] = 0;
+}
+HashNodeSet::~HashNodeSet() {
+  clear();
+  delete tab;
+}
+Node* HashNodeSet::insert_node(State& s)
+{
+  index_type i = (s.hash() % size);
+  if (tab[i]) {
+    return tab[i]->insert_node(s);
+  }
+  else {
+    tab[i] = new TreeNodeSet();
+    return tab[i];
+  }
+}
+Node* HashNodeSet::find_node(State& s)
+{
+  index_type i = (s.hash() % size);
+  if (tab[i]) {
+    return tab[i]->find_node(s);
+  }
+  else {
+    return 0;
+  }
+}
+void HashNodeSet::clear()
+{
+  for (index_type k = 0; k < size; k++) if (tab[k]) {
+    delete tab[k];
+    tab[k] = 0;
+  }
+}
+void HashNodeSet::collect_nodes(node_vec& ns)
+{
+  for (index_type k = 0; k < size; k++) {
+    if (tab[k]) tab[k]->collect_nodes(ns);
+  }
+}
+}

--- a/pr/seq-opt-hspsf/numeric_type.ccx
+++ b/pr/seq-opt-hspsf/numeric_type.ccx
@@ -1,0 +1,2220 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+
+class rational {
+  long nm;
+  long dv;
+
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+
+  rational(const rational& r);
+
+  struct XR {
+    long x_nm;
+    long x_dv;
+
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+
+  rational operator=(const rational r);
+  rational operator=(long n);
+
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+
+  double decimal() const;
+};
+
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+
+
+
+
+
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+
+inline rational::rational()
+  : nm(0), dv(1) { }
+
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+
+
+
+
+
+
+
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+
+inline long rational::numerator() const { return nm; }
+
+inline long rational::divisor() const { return dv; }
+
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+
+inline rational rational::round(const rational r, long d_max)
+{
+
+
+
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+
+
+
+    s.reduce();
+
+
+
+  }
+  return s;
+}
+
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+
+inline rational rational::operator=(const rational r)
+{
+
+
+
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+
+inline rational rational::operator=(long n)
+{
+
+
+
+  nm = n;
+  dv = 1;
+  return *this;
+}
+
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+
+inline double rational::decimal() const { return nm/(double)dv; };
+
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+
+inline rational operator+(const rational r0, const rational r1)
+{
+
+
+
+
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+  void swap();
+};
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+  void sort_ascending();
+  void sort_descending();
+};
+typedef comparable_pair<index_type> index_pair;
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+class index_set;
+class bool_vec;
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+namespace hsps {
+cost_vec_util::decreasing_cost_order cost_vec_util::decreasing;
+cost_vec_util::increasing_cost_order cost_vec_util::increasing;
+hsps::rational cost_vec_util::max(const cost_vec& v)
+{
+  index_type i = v.arg_max();
+  return (i == no_such_index ? NEG_INF : v[i]);
+}
+hsps::rational cost_vec_util::min(const cost_vec& v)
+{
+  index_type i = v.arg_min();
+  return (i == no_such_index ? NEG_INF : v[i]);
+}
+}

--- a/pr/seq-opt-hspsf/parser.ccx
+++ b/pr/seq-opt-hspsf/parser.ccx
@@ -1,0 +1,6980 @@
+
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <stdio.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+  void swap();
+};
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+#include <stdio.h>
+#include <stdlib.h>
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class PDDL_Name;
+class PDDL_Base {
+ public:
+  static bool use_default_function_value;
+  static hsps::rational default_function_value;
+  static bool use_strict_borrow_definition;
+  static bool use_extended_borrow_definition;
+  static bool del_before_add_semantics;
+  static bool compact_resource_effects;
+  static bool compile_away_disjunctive_preconditions;
+  static bool check_precondition_consistency;
+  static bool compile_away_conditional_effects;
+  static bool compile_away_plan_constraints;
+  static bool compile_away_object_functions;
+  static bool compile_for_validator;
+  static bool create_all_atoms;
+  static bool create_all_actions;
+  static bool number_multiple_action_instances;
+  static bool exclude_all_dkel_items;
+  static string_set excluded_dkel_tags;
+  static string_set required_dkel_tags;
+  static bool strict_set_export;
+  static bool best_effort;
+  static bool write_PDDL31;
+  static bool write_warnings;
+  static bool write_info;
+  static bool write_trace;
+  static bool trace_print_context;
+  static bool name_instance_by_problem_file;
+  static const char* instance_name_prefix;
+  enum symbol_class {
+    sym_object,
+    sym_typename,
+    sym_predicate,
+    sym_object_function,
+    sym_function,
+    sym_action,
+    sym_variable,
+    sym_misc,
+    sym_preference,
+    sym_set,
+    sym_meta_variable
+  };
+  enum metric_class {
+    metric_none,
+    metric_makespan,
+    metric_minimize,
+    metric_maximize
+  };
+  enum mode_keyword {
+    md_none,
+    md_start,
+    md_end,
+    md_all,
+    md_init,
+    md_pos_goal,
+    md_neg_goal
+  };
+  enum partial_value { p_false, p_true, p_unknown };
+  enum expression_class {
+    exp_fun,
+    exp_list,
+    exp_const,
+    exp_add,
+    exp_sub,
+    exp_mul,
+    exp_div,
+    exp_time,
+    exp_preference
+  };
+  enum relation_type {
+    rel_equal,
+    rel_greater,
+    rel_greater_equal,
+    rel_less,
+    rel_less_equal
+  };
+  enum formula_class { fc_false,
+         fc_true,
+         fc_atom,
+         fc_equality,
+         fc_negation,
+         fc_conjunction,
+         fc_disjunction,
+         fc_equivalence,
+         fc_implication,
+         fc_universal,
+         fc_existential,
+         fc_list
+  };
+  struct Symbol;
+  struct TypeSymbol;
+  struct Atom;
+  struct FTerm;
+  struct FChangeAtom;
+  struct SetOf;
+  struct ListExpression;
+  struct ActionSymbol;
+  struct Reference;
+  struct IrrelevantItem;
+  typedef lvector<TypeSymbol*> type_vec;
+  typedef lvector<Atom*> atom_vec;
+  typedef lvector<FChangeAtom*> ch_atom_vec;
+  typedef lvector<SetOf*> atom_set_vec;
+  typedef lvector<Reference*> ref_vec;
+  typedef lvector<IrrelevantItem*> irrelevant_vec;
+  struct TypeSet : public type_vec {
+    TypeSet() : type_vec(0, 0) { };
+    TypeSet(const TypeSet& s) : type_vec(s) { };
+    TypeSet(TypeSymbol* t) : type_vec(t, 1) { };
+    index_type n_elements() const;
+    Symbol* get_element(index_type n);
+    bool is_object() const;
+    bool subtype_or_equal(const TypeSet& s) const;
+    bool subtype_or_equal(TypeSymbol* t) const;
+    void print(std::ostream& s) const;
+    void write_type(std::ostream& s) const;
+  };
+  struct Symbol {
+    symbol_class sym_class;
+    char* print_name;
+    TypeSet sym_types;
+    bool defined_in_problem;
+    bool visible;
+    Symbol(symbol_class c, char* n)
+      : sym_class(c), print_name(n), defined_in_problem(false), visible(true) { };
+    Symbol(char* n)
+      : sym_class(sym_object), print_name(n), defined_in_problem(false), visible(true) { };
+    void print(std::ostream& s) const;
+  };
+  typedef zero_init_pair<Symbol*> symbol_pair;
+  typedef lvector<Symbol*> symbol_vec;
+  typedef svector<Symbol*> symbol_set;
+  typedef lvector<symbol_pair> symbol_pair_vec;
+  static bool extend_substitution(Symbol* out, Symbol* in, symbol_pair_vec& u);
+  static bool print_substitution(std::ostream& s, const symbol_pair_vec& u);
+  static bool print_inequality(std::ostream& s, const symbol_pair_vec& neq);
+  static bool substitution_violates_inequality(const symbol_pair_vec& neq,
+            const symbol_pair_vec& u);
+  static index_type find_matching_atom(Atom* a, atom_vec& v);
+  static index_type find_matching_atom(Atom* a, mode_keyword m, atom_vec& v);
+  static index_type find_matching_fluent_atom
+    (FChangeAtom* a, mode_keyword m, ch_atom_vec& v);
+  struct TypeSymbol : public Symbol {
+    symbol_vec elements;
+    bool is_base_type;
+    TypeSymbol(char* n) : Symbol(sym_typename, n), elements(0, 0),
+  is_base_type(false) { };
+    void add_element(Symbol* e);
+    bool is_object() const { return (strcmp(print_name, "object") == 0); };
+    bool subtype_or_equal(TypeSymbol* t) const;
+    bool subtype_or_equal(const TypeSet& t) const;
+    void print(std::ostream& s) const;
+  };
+  struct VariableSymbol : public Symbol {
+    Symbol* value;
+    FTerm* binding;
+    VariableSymbol(char* n) : Symbol(sym_variable, n), value(0), binding(0) {};
+    bool equality_type_check(Symbol* s);
+    void print(std::ostream& s);
+  };
+  typedef lvector<VariableSymbol*> variable_vec;
+  struct ParamSymbol : public Symbol {
+    variable_vec param;
+    ParamSymbol(symbol_class c, char* n) : Symbol(c, n), param(0, 0) { };
+  };
+  struct PredicateSymbol : public ParamSymbol {
+    bool pos_pre;
+    bool neg_pre;
+    bool added;
+    bool deleted;
+    bool locked;
+    bool modded;
+    ptr_table init;
+    ptr_table pos_goal;
+    ptr_table neg_goal;
+    ptr_table pos_prop;
+    ptr_table neg_prop;
+    irrelevant_vec irr_ins;
+    PredicateSymbol(char* n) : ParamSymbol(sym_predicate, n),
+  pos_pre(false), neg_pre(false), added(false), deleted(false),
+  locked(false), modded(false), irr_ins(0, 0) { };
+    bool is_static() const { return !modded; };
+    bool is_equality() const { return (strcmp(print_name, "=") == 0); };
+    void instantiate(Instance& ins);
+    void initialise_missing(const symbol_vec& p,
+       atom_vec* created,
+       index_type i = 0);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+  };
+  struct ObjectFunctionSymbol : public ParamSymbol {
+    bool modded;
+    ptr_table init;
+    ObjectFunctionSymbol(char* n)
+      : ParamSymbol(sym_object_function, n), modded(false) { };
+    bool is_static() const { return !modded; };
+    void print(std::ostream& s);
+  };
+  struct FunctionSymbol : public ParamSymbol {
+    bool modified;
+    bool integral;
+    bool linear;
+    bool conditioned;
+    bool increased;
+    bool decreased;
+    bool assigned;
+    bool borrowed;
+    ptr_table init;
+    FunctionSymbol(char* n) : ParamSymbol(sym_function, n),
+  modified(false), integral(true), linear(true), conditioned(false),
+  increased(false), decreased(false), assigned(false), borrowed(false)
+    { };
+    bool is_static() const
+    { return !modified; };
+    bool is_reusable() const
+    { return borrowed && !increased && !decreased && !assigned; };
+    bool is_consumable() const
+    { return !borrowed && !increased && decreased && !assigned; };
+    interval eval_init_bounds(ptr_table* p, index_type i, ListExpression* r);
+    void print(std::ostream& s);
+  };
+  struct AtomBase {
+    symbol_vec param;
+    mode_keyword at;
+    hsps::rational at_time;
+    AtomBase() : param(0, 0), at(md_none), at_time(0) { };
+    AtomBase(mode_keyword t) : param(0, 0), at(t), at_time(0) { };
+    AtomBase(AtomBase* b);
+    bool equals(AtomBase& b);
+    void free_variables(variable_vec& v);
+    bool occurs(Symbol* s);
+    void fill_in_args(AtomBase* b);
+    void collect_bound_variables(variable_vec& v);
+    void insert(ptr_table& t);
+    static bool print_bindings;
+    void print(std::ostream& s) const;
+    void print_instance(std::ostream& s);
+  };
+  typedef lvector<AtomBase*> atom_base_vec;
+  struct Atom : AtomBase {
+    PredicateSymbol* pred;
+    Atom(PredicateSymbol* p) : pred(p) { };
+    Atom(PredicateSymbol* p, mode_keyword t) : AtomBase(t), pred(p) { };
+    Atom(PredicateSymbol* p, variable_vec& a, bool as_value)
+      : pred(p)
+    {
+      param.set_length(a.length());
+      for (index_type k = 0; k < a.length(); k++)
+ param[k] = (as_value ? a[k]->value : a[k]);
+    };
+    Atom(PredicateSymbol* p, Symbol* a0)
+      : pred(p)
+    {
+      param.append(a0);
+    };
+    Atom(Atom* a) : AtomBase(a), pred(a->pred) { };
+    bool equals(Atom& a);
+    bool is_static() const {
+      return ((at == md_init) ||
+       (at == md_pos_goal) ||
+       (at == md_neg_goal) ||
+       pred->is_static());
+    };
+    bool check();
+    Instance::Atom* find_prop(Instance& ins, bool neg, bool create);
+    void build(Instance& ins, bool neg, index_type p);
+    Atom* instantiate_partially();
+    partial_value partial_eval(ptr_table* r, index_type p);
+    partial_value partial_eval();
+    bool initial_value();
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    void print(std::ostream& s, bool neg) const;
+    void print(std::ostream& s) const { print(s, false); };
+  };
+  struct CAtom : public Atom {
+    symbol_pair_vec neq;
+    CAtom(Atom* a) : Atom(a), neq(symbol_pair(0, 0), 0) { };
+    CAtom(CAtom* s) : Atom(s), neq(s->neq) { };
+    CAtom(const Atom* a, symbol_pair_vec& u);
+    CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool instance_of(CAtom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(CAtom* a, symbol_pair_vec& u);
+    void print(std::ostream& s);
+  };
+  typedef lvector<CAtom*> catom_vec;
+  struct FTerm : AtomBase {
+    ObjectFunctionSymbol* fun;
+    FTerm(ObjectFunctionSymbol* f) : fun(f) { };
+    bool equals(FTerm& a);
+    void print(std::ostream& s) const;
+  };
+  struct OInitAtom : AtomBase {
+    ObjectFunctionSymbol* fun;
+    Symbol* val;
+    OInitAtom(ObjectFunctionSymbol* f) : fun(f), val(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<OInitAtom*> obj_init_atom_vec;
+  struct FInitAtom : AtomBase {
+    FunctionSymbol* fun;
+    hsps::rational val;
+    Instance::resource_ref res;
+    FInitAtom(FunctionSymbol* f) : fun(f), val(0) { };
+    FInitAtom(FChangeAtom* a);
+    bool is_static() const { return fun->is_static(); };
+    void print(std::ostream& s);
+  };
+  typedef lvector<FInitAtom*> fun_init_atom_vec;
+  struct Expression;
+  typedef lvector<Expression*> exp_vec;
+  struct Expression {
+    expression_class exp_class;
+    Expression(expression_class c) : exp_class(c) { };
+    static bool print_nary;
+    bool is_static();
+    bool is_constant();
+    bool is_integral();
+    hsps::rational eval_static();
+    bool eval_partial(hsps::rational& val);
+    interval eval_bounds();
+    hsps::rational eval_init();
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    hsps::rational eval_delta(Symbol* preference, hsps::rational p_value, hsps::rational d_value);
+    Expression* copy();
+    Expression* simplify();
+    void collect_constants(exp_vec& c);
+    void mark_functions_in_condition();
+    hsps::rational integrify();
+    void substitute_for_time(Expression* e);
+    Expression* substitute_for_preference(Symbol* n, Expression* e);
+    bool equals(Expression* e);
+    void print_sum(std::ostream& s, bool grnd);
+    void print_product(std::ostream& s, bool grnd);
+    void print(std::ostream& s, bool grnd);
+  };
+  struct ListExpression : public Expression {
+    Symbol* sym;
+    ListExpression* rest;
+    ListExpression(Symbol* s, ListExpression* r) :
+      Expression(exp_list), sym(s), rest(r) { };
+    bool match(AtomBase* atom);
+  };
+  struct FunctionExpression : public Expression {
+    FunctionSymbol* fun;
+    ListExpression* args;
+    FunctionExpression(FunctionSymbol* f, ListExpression* a) :
+      Expression(exp_fun), fun(f), args(a) { };
+    bool match(FChangeAtom* atom);
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    FChangeAtom* make_atom_base();
+  };
+  struct ConstantExpression : public Expression {
+    hsps::rational val;
+    ConstantExpression(hsps::rational v) :
+      Expression(exp_const), val(v) { };
+  };
+  struct TimeExpression : public Expression {
+    Expression* time_exp;
+    TimeExpression() :
+      Expression(exp_time), time_exp(0) { };
+    TimeExpression(Expression* e) :
+      Expression(exp_time), time_exp(e) { };
+  };
+  struct BinaryExpression : public Expression {
+    Expression* first;
+    Expression* second;
+    BinaryExpression(expression_class c, Expression* e1, Expression* e2) :
+      Expression(c), first(e1), second(e2) { };
+  };
+  struct PreferenceExpression : public Expression {
+    Symbol* name;
+    PreferenceExpression(Symbol* n) :
+      Expression(exp_preference), name(n) { };
+  };
+  struct Relation {
+    relation_type rel;
+    mode_keyword at;
+    Expression* first;
+    Expression* second;
+    Relation(relation_type r, Expression* e1, Expression* e2) :
+      rel(r), at(md_none), first(e1), second(e2) { };
+    Relation(relation_type r, mode_keyword m, Expression* e1, Expression* e2) :
+      rel(r), at(m), first(e1), second(e2) { };
+    Expression* match_gteq_constant(FChangeAtom* atom);
+    FunctionExpression* match_lteq_fun(FChangeAtom* atom);
+    bool is_static();
+    partial_value partial_eval();
+    void print(std::ostream& s, bool grnd);
+  };
+  typedef lvector<Relation*> relation_vec;
+  struct FChangeAtom : AtomBase {
+    FunctionSymbol* fun;
+    Expression* val;
+    FChangeAtom(FunctionSymbol* f) :
+      fun(f), val(0) { };
+    FChangeAtom(FunctionSymbol* f, mode_keyword t) :
+      AtomBase(t), fun(f), val(0) { };
+    FChangeAtom(FChangeAtom* a, hsps::rational v) :
+      AtomBase(a), fun(a->fun), val(new ConstantExpression(v)) { };
+    bool equals(FChangeAtom& a);
+    bool fluent_equals(FChangeAtom& a);
+    bool fluent_and_mode_equals(FChangeAtom& a);
+    FChangeAtom* find_fluent_equals(ch_atom_vec& vec);
+    Instance::Resource* find_resource(Instance& ins);
+    void print(std::ostream& s);
+  };
+  struct Formula {
+    formula_class fc;
+    Formula(formula_class c) : fc(c) { };
+    void rename_variables_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_variables_2(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_2(PDDL_Base::symbol_pair_vec& sub);
+    Formula* simplify();
+    void write_otter(std::ostream& s) const;
+    void print(std::ostream& s) const;
+    void untype(PDDL_Base* base);
+  };
+  typedef lvector<Formula*> formula_vec;
+  struct AFormula : public Formula, public Atom {
+    AFormula(Atom* a) :
+      Formula(fc_atom), Atom(a) { };
+    AFormula(PredicateSymbol* p) :
+      Formula(fc_atom), Atom(p) { };
+    AFormula(PredicateSymbol* p, variable_vec& a) :
+      Formula(fc_atom), Atom(p, a, false) { };
+    void print(std::ostream& s) const;
+    void write_otter(std::ostream& s) const;
+  };
+  struct EqFormula : public Formula {
+    Symbol* t1;
+    Symbol* t2;
+    EqFormula(Symbol* s1, Symbol* s2) :
+      Formula(fc_equality), t1(s1), t2(s2) { };
+    void write_otter(std::ostream& s) const;
+  };
+  struct NFormula : public Formula {
+    Formula* f;
+    NFormula(Formula* g) : Formula(fc_negation), f(g) { };
+  };
+  struct BFormula : public Formula {
+    Formula* f1;
+    Formula* f2;
+    BFormula(formula_class c, Formula* g1, Formula* g2) :
+      Formula(c), f1(g1), f2(g2) { };
+  };
+  struct CFormula : public Formula {
+    formula_vec parts;
+    CFormula(formula_class c) : Formula(c), parts(0, 0) { };
+    CFormula(formula_class c, Formula* f1, Formula* f2) :
+      Formula(c), parts(0, 0)
+    {
+      parts.append(f1);
+      parts.append(f2);
+    };
+    void add(Formula* f) { parts.append(f); };
+    void add(formula_vec& f) { parts.append(f); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct QFormula : public Formula {
+    variable_vec vars;
+    Formula* f;
+    QFormula(formula_class c) : Formula(c), vars(0, 0), f(0) { };
+    QFormula(formula_class c, Formula* g) : Formula(c), vars(0, 0), f(g) { };
+    QFormula(formula_class c, variable_vec& v, Formula* g) :
+      Formula(c), vars(0, 0), f(g)
+    {
+      for (index_type k = 0; k < v.length(); k++) vars.append(v[k]);
+    };
+    void add(PDDL_Base::VariableSymbol* v) { vars.append(v); };
+    void add(PDDL_Base::variable_vec& v) { vars.append(v); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct TypeConstraint {
+    VariableSymbol* var;
+    TypeSymbol* typ;
+    TypeConstraint(VariableSymbol* v, TypeSymbol* t) : var(v), typ(t) { };
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+  };
+  typedef lvector<TypeConstraint*> type_constraint_vec;
+  struct Context {
+    variable_vec param;
+    atom_vec pos_con;
+    atom_vec neg_con;
+    type_constraint_vec type_con;
+    Context() : param(0, 0), pos_con(0, 0), neg_con(0, 0), type_con(0, 0) { };
+    Context(const Context* c) : param(c->param), pos_con(c->pos_con),
+  neg_con(c->neg_con), type_con(c->type_con) { };
+    bool context_is_static() const;
+    bool occurs_in_context(Symbol* s);
+    void clear_arguments();
+    void set_mode(mode_keyword m);
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+    void print_assignment(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct DKEL_Item : public Context {
+    char* item_name;
+    Symbol* name;
+    string_set item_tags;
+    bool defined_in_problem;
+    bool included;
+    DKEL_Item(char* name) : item_name(name), name(0),
+  defined_in_problem(false), included(true) { };
+    DKEL_Item(const DKEL_Item* i) : Context(i), item_name(i->item_name),
+  name(i->name), item_tags(i->item_tags),
+  defined_in_problem(i->defined_in_problem), included(i->included) { };
+    bool item_is_included(string_set& ex_tags, string_set& req_tags);
+    void print_begin(std::ostream& s);
+    void print_end(std::ostream& s);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SetOf : public Context {
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    SetOf() : pos_atoms(0, 0), neg_atoms(0, 0) { };
+    SetOf(const SetOf* s)
+      : Context(s), pos_atoms(s->pos_atoms), neg_atoms(s->neg_atoms)
+    { };
+    SetOf(Atom* a)
+    { pos_atoms.append(a); };
+    SetOf(Atom* a, bool n)
+    { if (n) neg_atoms.append(a); else pos_atoms.append(a); };
+    bool is_static() const;
+    void set_mode(mode_keyword m);
+    partial_value partial_eval(bool as_disjunction = false);
+    partial_value partial_eval(index_type p, bool as_disjunction = false);
+    void instantiate_as_set(Instance& ins, index_set& s);
+    void instantiate_as_effect(Instance& ins, index_set& s_add,
+          index_set& s_del);
+    void instantiate_conditional(Instance& ins, rule_set& s_pos,
+     rule_set& s_neg);
+    SetOf* instantiate_partially();
+    void compile(atom_vec& pos_ins, atom_vec& neg_ins, index_type p);
+    void compile_non_static(atom_set_vec& ins, index_type p);
+    void print(std::ostream& s);
+    void print_as_disjunction(std::ostream& s);
+    void build_set(Instance& ins, index_set& s, index_type p);
+    void build_effect(Instance& ins, index_set& s_add, index_set& s_del,
+        index_type p);
+    void build_conditional(Instance& ins, rule_set& s_pos, rule_set& s_neg,
+      index_type p);
+  };
+  struct QCNumericEffect : public Context {
+    FChangeAtom* atom;
+    QCNumericEffect() : atom(0) { };
+    QCNumericEffect(FChangeAtom* a) : atom(a) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<QCNumericEffect*> qc_numeric_effect_vec;
+  enum set_constraint_keyword { sc_at_least, sc_at_most, sc_exactly };
+  struct SetConstraint : public DKEL_Item {
+    set_constraint_keyword sc_type;
+    index_type sc_count;
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    atom_set_vec atom_sets;
+    SetConstraint() : DKEL_Item(":invariant"), sc_type(sc_at_least),
+  sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0), atom_sets(0, 0) { };
+    SetConstraint(const DKEL_Item* item) : DKEL_Item(item),
+  sc_type(sc_at_least), sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0),
+  atom_sets(0, 0) { };
+    void build(Instance& ins, index_type p);
+    void instantiate(Instance& ins);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InvariantFormula : public DKEL_Item {
+    Formula* f;
+    InvariantFormula(Formula* g)
+      : DKEL_Item(":invariant"), f(g) { };
+    InvariantFormula(const DKEL_Item* item, Formula* g)
+      : DKEL_Item(item), f(g) { };
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct Reference : public AtomBase {
+    Symbol* name;
+    bool neg;
+    bool has_args;
+    index_set index;
+    Reference(Symbol* n) : name(n), neg(false), has_args(true) { };
+    Reference(Symbol* n, bool ng, bool ha)
+      : name(n), neg(ng), has_args(ha) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    void* find_action();
+    void find(const name_vec& names, index_set& ind);
+    Reference* instantiate_partially();
+    void print(std::ostream& s);
+  };
+  struct IrrelevantItem : public DKEL_Item {
+    Reference* entity;
+    IrrelevantItem() : DKEL_Item(":irrelevant"), entity(0) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    IrrelevantItem* instantiate_partially();
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SequentialTaskNet : public Context {
+    ref_vec tasks;
+    ActionSymbol* abs_act;
+    SequentialTaskNet() : tasks(0, 0), abs_act(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<SequentialTaskNet*> task_net_vec;
+  struct SetSymbol : public Symbol {
+    ptr_table set_table;
+    lvector<index_set*> sets;
+    name_vec names;
+    SetSymbol(char* n) : Symbol(sym_set, n), sets(0, 0), names(0, 0) { };
+  };
+  struct SetName : public AtomBase {
+    SetSymbol* sym;
+    SetName(SetSymbol* s) : sym(s) { };
+    index_set* find();
+    SetName* instantiate_partially();
+    void print(std::ostream& s);
+    void print_instance(std::ostream& s);
+  };
+  struct ActionSymbol : public ParamSymbol {
+    atom_vec pos_pre;
+    atom_vec neg_pre;
+    atom_set_vec set_pre;
+    atom_set_vec dis_pre;
+    relation_vec num_pre;
+    atom_vec adds;
+    atom_vec dels;
+    atom_set_vec set_eff;
+    atom_vec cons;
+    atom_set_vec cond_eff;
+    atom_vec locks;
+    atom_vec enables;
+    ch_atom_vec reqs;
+    ch_atom_vec incs;
+    ch_atom_vec decs;
+    ch_atom_vec fass;
+    qc_numeric_effect_vec qc_incs;
+    qc_numeric_effect_vec qc_decs;
+    qc_numeric_effect_vec qc_fass;
+    Expression* dmin;
+    Expression* dmax;
+    irrelevant_vec irr_ins;
+    ref_vec refs;
+    task_net_vec exps;
+    ptr_table instances;
+    SetName* part;
+    const char* assoc;
+    ActionSymbol(char* n) : ParamSymbol(sym_action, n), pos_pre(0, 0),
+  neg_pre(0, 0), set_pre(0, 0), dis_pre(0, 0), num_pre(0, 0),
+  adds(0, 0), dels(0, 0), set_eff(0, 0), cons(0, 0), cond_eff(0, 0),
+  locks(0, 0), enables(0, 0), reqs(0, 0), incs(0, 0), decs(0, 0),
+  fass(0, 0), qc_incs(0, 0), qc_decs(0, 0), qc_fass(0, 0), dmin(0),
+  dmax(0), irr_ins(0, 0), refs(0, 0), exps(0, 0), part(0), assoc(0) { };
+    void build(Instance& ins, index_type p, Expression* cost_exp);
+    Instance::Action& build_action(Instance& ins,
+       PDDL_Name* name,
+       index_type& count,
+       const index_set& pre,
+       const index_set& add,
+       const index_set& del,
+       const index_set& lck,
+       const index_cost_vec& r_use,
+       const index_cost_vec& r_cons,
+       hsps::rational dmin,
+       hsps::rational dmax,
+       hsps::rational dur,
+       hsps::rational cost);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          index_vec& s,
+          index_type p);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc);
+    void build_actions_with_dc_and_ce(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          const rule_set& pce,
+          const rule_set& nce,
+          const bool_vec& ece);
+    index_type param_index(VariableSymbol* p);
+    void get_param_inequalities(symbol_pair_vec& neq);
+    void set_arguments(const symbol_vec& args);
+    void set_arguments(const ptr_table::key_vec& args);
+    void clear_arguments();
+    void* find_instance();
+    bool is_abstract();
+    void post_process();
+    void instantiate(Instance& ins, Expression* cost_exp);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InputPlanStep {
+    Reference* act;
+    hsps::rational start_time;
+    InputPlanStep() : act(0), start_time(0) { };
+    InputPlanStep(Reference* a, hsps::rational t) : act(a), start_time(t) { };
+  };
+  struct InputPlan {
+    Symbol* name;
+    bool is_opt;
+    lvector<InputPlanStep*> steps;
+    InputPlan() : name(0), is_opt(false), steps(0, 0) { };
+    bool export_to_instance(Instance& ins, const index_vec& map, Plan& p);
+    void print(std::ostream& s);
+  };
+  struct HTableEntry {
+    atom_vec atoms;
+    bool_vec neg;
+    hsps::rational cost;
+    bool opt;
+    HTableEntry() : atoms(0, 0), neg(false, 0), cost(0), opt(false) { };
+  };
+  struct SimpleReferenceSet : public Context {
+    Reference* ref;
+    SimpleReferenceSet(Reference* r) : ref(r) { };
+    bool build(const name_vec& names, index_set& set, index_type p);
+    void print(std::ostream& s);
+  };
+  typedef lvector<SimpleReferenceSet*> refs_vec;
+  struct ReferenceSet : public Context {
+    refs_vec refs;
+    Symbol* name;
+    ReferenceSet() : refs(0, 0), name(0) { };
+    void add(SimpleReferenceSet* ref) { refs.append(ref); };
+    void build(const name_vec& names, index_set_vec& sets, index_type p);
+    void print(std::ostream& s);
+  };
+  struct CPG {
+    atom_vec atoms;
+    index_vec atom_first_arg;
+    bool_vec neg;
+    symbol_vec args;
+    type_vec arg_types;
+    CPG() : atoms(0, 0), neg(false, 0), args(0, 0), arg_types(0, 0) { };
+    CPG(CPG& g, index_vec& s);
+    void make_key(ptr_table::key_vec& key);
+    void make_typed_key(ptr_table::key_vec& key);
+    void make_parameters(variable_vec& params);
+    ListExpression* make_argument_list(index_type first);
+    void add_asserting_effects(ActionSymbol* act,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          bool strict);
+    void add_destroying_effects(ActionSymbol* act,
+    ParamSymbol* pf,
+    PredicateSymbol* p,
+    bool p_val,
+    PredicateSymbol* g,
+    FunctionSymbol* f,
+    Expression* f_val,
+    bool strict);
+    bool initial_value();
+    void add_asserting_effects(index_type c_atom,
+          ActionSymbol* act,
+          index_type c_eff,
+          bool_vec& sat,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          symbol_pair_vec& eq,
+          symbol_pair_vec& neq,
+          bool strict);
+    void add_propositional_effect(ActionSymbol* act,
+      PredicateSymbol* p, bool p_val,
+      index_type c_atom, Atom* a_eff,
+      bool strict);
+    void add_fluent_effect(ActionSymbol* act,
+      FunctionSymbol* f, Expression* f_val,
+      index_type c_atom, Atom* a_eff);
+    void add_effect_conditions(Context* e, ParamSymbol* pf, bool_vec& sat,
+          symbol_vec& subs, symbol_pair_vec& eq,
+          symbol_pair_vec& neq);
+  };
+  enum goal_class { goal_pos_atom, goal_neg_atom, goal_relation, goal_task,
+      goal_conjunction, goal_disjunction, goal_forall,
+      goal_exists, goal_always, goal_sometime,
+      goal_at_most_once, goal_within, goal_always_within,
+      goal_sometime_before, goal_sometime_after };
+  struct Goal {
+    goal_class g_class;
+    Goal(goal_class c) : g_class(c) { };
+    bool is_state();
+    bool is_propositional();
+    bool is_singular();
+    bool makeCPG(CPG& g);
+    bool makeCPG(CPG& g, index_vec& s);
+    void instantiate(Instance& ins, hsps::rational deadline);
+    void instantiate(Instance& ins, index_set& set, Symbol* p, index_type i);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Goal*> goal_vec;
+  struct AtomicGoal : public Goal {
+    Atom* atom;
+    AtomicGoal(Atom* a, bool neg)
+      : Goal(neg ? goal_neg_atom : goal_pos_atom), atom(a) { };
+    void print(std::ostream& s);
+  };
+  struct NumericGoal : public Goal {
+    Relation* rel;
+    NumericGoal(Relation* r) : Goal(goal_relation), rel(r) { };
+    void print(std::ostream& s);
+  };
+  struct TaskGoal : public Goal {
+    Reference* task;
+    TaskGoal(Reference* r) : Goal(goal_task), task(r) { };
+    void print(std::ostream& s);
+  };
+  struct ConjunctiveGoal : public Goal {
+    goal_vec goals;
+    ConjunctiveGoal() : Goal(goal_conjunction), goals(0, 0) { };
+    ConjunctiveGoal(goal_class gc) : Goal(gc), goals(0, 0) { };
+    void print(std::ostream& s);
+  };
+  struct DisjunctiveGoal : public ConjunctiveGoal {
+    DisjunctiveGoal() : ConjunctiveGoal(goal_disjunction) { };
+    void print(std::ostream& s);
+  };
+  struct QuantifiedGoal : public Goal, public Context {
+    Goal* goal;
+    QuantifiedGoal() : Goal(goal_forall), goal(0) { };
+    QuantifiedGoal(goal_class gc) : Goal(gc), goal(0) { };
+    void print(std::ostream& s);
+  };
+  struct SimpleSequenceGoal : public Goal {
+    Goal* constraint;
+    SimpleSequenceGoal(goal_class c, Goal* g) : Goal(c), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredSequenceGoal : public Goal {
+    Goal* trigger;
+    Goal* constraint;
+    TriggeredSequenceGoal(goal_class c, Goal* t, Goal* g)
+      : Goal(c), trigger(t), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct DeadlineGoal : public Goal {
+    Goal* goal;
+    hsps::rational at;
+    DeadlineGoal(hsps::rational t, Goal* g) : Goal(goal_within), goal(g), at(t) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredDeadlineGoal : public Goal {
+    Goal* trigger;
+    Goal* goal;
+    hsps::rational delay;
+    TriggeredDeadlineGoal(Goal* t, hsps::rational d, Goal* g)
+      : Goal(goal_always_within), trigger(t), delay(d), goal(g) { };
+    void print(std::ostream& s);
+  };
+  struct Preference {
+    Symbol* name;
+    Goal* goal;
+    Preference() : name(0), goal(0) { };
+    Preference(Symbol* n) : name(n), goal(0) { };
+    Preference(Symbol* n, Goal* g) : name(n), goal(g) { };
+    bool is_state() { return goal->is_state(); };
+    bool is_propositional() { return goal->is_propositional(); };
+    hsps::rational value(metric_class metric_type, Expression* m);
+    void instantiate(SoftInstance& ins,
+       metric_class metric_type,
+       Expression* m);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Preference*> preference_vec;
+  char* domain_name;
+  char* problem_name;
+  char* domain_file;
+  char* problem_file;
+  bool ready_to_instantiate;
+  char* problem_file_basename();
+  char* enum_problem_filename(const char* s, index_type i);
+  StringTable& tab;
+  type_vec dom_types;
+  type_vec dom_base_types;
+  TypeSymbol* dom_top_type;
+  symbol_vec dom_constants;
+  PredicateSymbol* dom_eq_pred;
+  PredicateSymbol* dom_assign_pred;
+  Symbol* dom_undefined_obj;
+  static PredicateSymbol* current_eq_predicate;
+  lvector<PredicateSymbol*> dom_predicates;
+  lvector<ObjectFunctionSymbol*> dom_object_functions;
+  lvector<FunctionSymbol*> dom_functions;
+  lvector<ActionSymbol*> dom_actions;
+  lvector<SetConstraint*> dom_sc_invariants;
+  lvector<InvariantFormula*> dom_f_invariants;
+  lvector<IrrelevantItem*> dom_irrelevant;
+  atom_vec dom_init;
+  obj_init_atom_vec dom_obj_init;
+  fun_init_atom_vec dom_fun_init;
+  goal_vec dom_goals;
+  preference_vec dom_preferences;
+  ref_vec goal_tasks;
+  metric_class metric_type;
+  Expression* metric;
+  hsps::rational serial_length;
+  hsps::rational parallel_length;
+  lvector<InputPlan*> input_plans;
+  lvector<HTableEntry*> h_table;
+  lvector<ReferenceSet*> input_sets;
+  lvector<SetSymbol*> partitions;
+  static ActionSymbol* src_action_symbol(ptr_pair* p);
+  TypeSymbol* find_type(const char* name);
+  PredicateSymbol* find_predicate(const char* name);
+  FunctionSymbol* find_function(const char* name);
+  bool find_initial_fact(const char* pname, const symbol_vec& arg);
+  hsps::rational find_function_value(const char* fname, const symbol_vec& arg);
+  index_type find_element_satisfying(const symbol_vec& elements,
+         const char* pname,
+         symbol_vec& arg,
+         index_type element_arg_p);
+  void find_elements_satisfying(const symbol_vec& elements,
+    const char* pname,
+    symbol_vec& arg,
+    index_type element_arg_p,
+    index_set& sats);
+  Atom* goal_to_atom(Goal* g);
+  bool goal_to_atom_vec(Goal* g, atom_vec& av);
+  PDDL_Base(StringTable& t);
+  ~PDDL_Base();
+  void set_variable_type(variable_vec& vec, TypeSymbol* t);
+  void set_variable_type(variable_vec& vec, const TypeSet& t);
+  void set_type_type(type_vec& vec, TypeSymbol* t);
+  void set_constant_type(symbol_vec& vec, TypeSymbol* t);
+  void clear_context(variable_vec& vec);
+  void clear_context(variable_vec& vec, index_type n_min, index_type n_max);
+  bool merge_type_vectors(type_vec& v0, type_vec& v1);
+  void make_parameters(type_vec& t, const char* prefix, variable_vec& v);
+  Atom* make_atom_from_prop(ptr_pair& src, bool& neg);
+  Symbol* gensym(symbol_class c, const char* p, const TypeSet& t);
+  Symbol* gensym(symbol_class c, const char* p, TypeSymbol* t);
+  Symbol* gensym_i(symbol_class c, const char* p, index_type i, TypeSymbol* t);
+  Symbol* gensym_s(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t);
+  Symbol* gensym_n(symbol_class c, const char* p, const Name* n, TypeSymbol* t);
+  void new_variable_substitution(Atom* a,
+     symbol_pair_vec& u,
+     symbol_pair_vec& new_u);
+  Atom* new_meta_atom(PredicateSymbol* p);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& u);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+  void extend_cc(CAtom* l, catom_vec& m, catom_vec& nm,
+   lvector< swapable_pair<catom_vec> >& x,
+   index_type d);
+  void find_cc();
+  void post_process();
+  void instantiate(Instance& ins);
+  void instantiate_soft(SoftInstance& ins);
+  void instantiate_atom_set(Instance& ins, atom_vec& a, index_set& s);
+  index_type n_plans() const { return input_plans.length(); };
+  bool export_plan(index_type i, Instance& ins, const index_vec& map, Plan& p);
+  bool export_plan(index_type i, Instance& ins, Plan& p);
+  void export_heuristic(Instance& ins,
+   const index_vec& map,
+   bool opt_maximize,
+   Heuristic& h);
+  void export_sets(const name_vec& names, index_set_vec& sets);
+  void export_action_partitions(name_vec& names, index_set_vec& sets);
+  void lift_DKEL_Items(const Instance& ins);
+  PredicateSymbol* find_type_predicate(Symbol* type_sym);
+  void untype();
+  void compile_preferences();
+  void compile_constraints_1();
+  void compile_constraints_2();
+  void select_preferences(const bool_vec& sel);
+  void metric_to_goal(hsps::rational bound);
+  void compile_set_conditions_and_effects();
+  void compile_object_functions();
+  Expression* replace_violations_1(Expression* exp,
+       CPG* cpg[],
+       FunctionSymbol* f_violated[]);
+  Goal* compile_constraint_1(Goal* g, index_type i, const Symbol* n,
+        symbol_vec& aut_states, index_type n_ra);
+  AtomicGoal* make_automaton_type_a(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_e(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_o(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sb(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sa(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  void make_automaton_transition(Symbol* s_from,
+     Symbol* s_to,
+     bool is_accept,
+     CPG* f, bool neg_f,
+     CPG* g, bool neg_g,
+     PredicateSymbol* p_state,
+     PredicateSymbol* p_accept,
+     PredicateSymbol* p_synch);
+  void add_precondition_formula(ActionSymbol* a, CPG* f, bool is_neg);
+  Goal* compile_constraint_2(Goal* g, const Symbol* n);
+  Goal* compile_always_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_sometime_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_at_most_once_constraint(SimpleSequenceGoal* g,
+     const Symbol* n);
+  Goal* compile_sometime_before_constraint(TriggeredSequenceGoal* g,
+        const Symbol* n);
+  void compile_set_conditions_and_effects(ActionSymbol* act);
+  void compile_set_conditions_and_effects(ActionSymbol* act,
+       variable_vec& i_param,
+       variable_vec& d_param,
+       index_type p);
+  Atom* make_binding_atom(VariableSymbol* v);
+  void compile_object_functions(ActionSymbol* act, Symbol* undefined_value);
+  void compile_object_functions_for_validator(ActionSymbol* act);
+  Goal* compile_object_functions(Goal* g);
+  void write_declarations(std::ostream& s);
+  void write_action(std::ostream& s, ActionSymbol* act);
+  void write_set_precondition(std::ostream& s, SetOf* set);
+  void write_disjunctive_set_precondition(std::ostream& s, SetOf* set);
+  void write_set_effect(std::ostream& s, SetOf* set);
+  void write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn);
+  void write_objects(std::ostream& s, bool defined_in_problem);
+  void write_init(std::ostream& s);
+  void write_goal(std::ostream& s);
+  void write_metric(std::ostream& s);
+  void write_dkel_items(std::ostream& s, bool defined_in_problem);
+  void write_domain_begin(std::ostream& s);
+  void write_problem_begin(std::ostream& s);
+  void write_end(std::ostream& s);
+  void write_dkel_domain(std::ostream& s, bool leave_open);
+  void write_dkel_problem(std::ostream& s, bool leave_open);
+  void write_plans(std::ostream& s);
+  void write_heuristic_table(std::ostream& s);
+  void write_sets(std::ostream& s);
+  void print(std::ostream& s);
+};
+class InstanceName : public Name {
+  char* domain_name;
+  char* problem_name;
+ public:
+  InstanceName(char* d, char* p) : domain_name(d), problem_name(p) { };
+  virtual ~InstanceName() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class PDDL_Name : public Name {
+ protected:
+  bool neg;
+  PDDL_Base::Symbol* sym;
+  PDDL_Base::symbol_vec arg;
+  bool vis;
+  bool_vec avis;
+ public:
+  static char catc;
+  static bool obscure_symbol_names;
+  PDDL_Name(PDDL_Base::Symbol* s)
+    : neg(false), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, bool n)
+    : neg(n), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::symbol_vec a, bool n)
+    : neg(n), sym(s), arg(a), vis(true), avis(true, a.length()) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n);
+  void add(PDDL_Base::Symbol* s);
+  void add(PDDL_Base::Symbol* s, bool v);
+  PDDL_Base::Symbol* symbol() { return sym; };
+  PDDL_Base::symbol_vec& args() { return arg; };
+  index_type argc() { return arg.length(); };
+  bool is_neg() { return neg; };
+  virtual ~PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class Numbered_PDDL_Name : public PDDL_Name {
+  index_type copy;
+ public:
+  Numbered_PDDL_Name(PDDL_Base::Symbol* sym, index_type c)
+    : PDDL_Name(sym), copy(c) { };
+  Numbered_PDDL_Name(PDDL_Name* n, index_type c);
+  virtual ~Numbered_PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+};
+}
+#include <sstream>
+typedef union {
+  hsps::StringTable::Cell* sym;
+  hsps::PDDL_Base::Expression* exp;
+  hsps::PDDL_Base::ListExpression* lst;
+  hsps::PDDL_Base::Relation* rel;
+  hsps::PDDL_Base::Goal* goal;
+  hsps::PDDL_Base::Formula* ff;
+  hsps::PDDL_Base::mode_keyword tkw;
+  hsps::PDDL_Base::relation_type rkw;
+  hsps::PDDL_Base::set_constraint_keyword sckw;
+  hsps::rational::XR rval;
+  int ival;
+  char* sval;
+} yy_PDDL_Parser_stype;
+class PDDL_Parser : public hsps::PDDL_Base
+{
+public:
+enum YY_PDDL_Parser_ENUM_TOKEN { YY_PDDL_Parser_NULL_TOKEN=0
+ ,TK_OPEN=258
+ ,TK_CLOSE=259
+ ,TK_OPEN_SQ=260
+ ,TK_CLOSE_SQ=261
+ ,TK_GREATER=262
+ ,TK_GREATEQ=263
+ ,TK_LESS=264
+ ,TK_LESSEQ=265
+ ,TK_COLON=266
+ ,TK_HASHT=267
+ ,TK_EQ=268
+ ,TK_HYPHEN=269
+ ,TK_PLUS=270
+ ,TK_MUL=271
+ ,TK_DIV=272
+ ,TK_UMINUS=273
+ ,TK_NEW_SYMBOL=274
+ ,TK_OBJ_SYMBOL=275
+ ,TK_TYPE_SYMBOL=276
+ ,TK_PRED_SYMBOL=277
+ ,TK_OBJFUN_SYMBOL=278
+ ,TK_FUN_SYMBOL=279
+ ,TK_VAR_SYMBOL=280
+ ,TK_ACTION_SYMBOL=281
+ ,TK_MISC_SYMBOL=282
+ ,TK_KEYWORD=283
+ ,TK_NEW_VAR_SYMBOL=284
+ ,TK_PREFERENCE_SYMBOL=285
+ ,TK_SET_SYMBOL=286
+ ,TK_FLOAT=287
+ ,TK_INT=288
+ ,TK_STRING=289
+ ,KW_REQS=290
+ ,KW_CONSTANTS=291
+ ,KW_PREDS=292
+ ,KW_FUNS=293
+ ,KW_TYPES=294
+ ,KW_DEFINE=295
+ ,KW_DOMAIN=296
+ ,KW_ACTION=297
+ ,KW_PROCESS=298
+ ,KW_EVENT=299
+ ,KW_ARGS=300
+ ,KW_PRE=301
+ ,KW_COND=302
+ ,KW_AT_START=303
+ ,KW_AT_END=304
+ ,KW_OVER_ALL=305
+ ,KW_EFFECT=306
+ ,KW_INVARIANT=307
+ ,KW_DURATION=308
+ ,KW_AND=309
+ ,KW_OR=310
+ ,KW_EXISTS=311
+ ,KW_FORALL=312
+ ,KW_IMPLY=313
+ ,KW_NOT=314
+ ,KW_WHEN=315
+ ,KW_EITHER=316
+ ,KW_PROBLEM=317
+ ,KW_FORDOMAIN=318
+ ,KW_OBJECTS=319
+ ,KW_INIT=320
+ ,KW_GOAL=321
+ ,KW_LENGTH=322
+ ,KW_SERIAL=323
+ ,KW_PARALLEL=324
+ ,KW_METRIC=325
+ ,KW_MINIMIZE=326
+ ,KW_MAXIMIZE=327
+ ,KW_DURATION_VAR=328
+ ,KW_TOTAL_TIME=329
+ ,KW_INCREASE=330
+ ,KW_DECREASE=331
+ ,KW_SCALE_UP=332
+ ,KW_SCALE_DOWN=333
+ ,KW_ASSIGN=334
+ ,KW_TAG=335
+ ,KW_NAME=336
+ ,KW_VARS=337
+ ,KW_SET_CONSTRAINT=338
+ ,KW_SETOF=339
+ ,KW_AT_LEAST_N=340
+ ,KW_AT_MOST_N=341
+ ,KW_EXACTLY_N=342
+ ,KW_CONTEXT=343
+ ,KW_FORMULA=344
+ ,KW_IRRELEVANT=345
+ ,KW_PLAN=346
+ ,KW_HEURISTIC=347
+ ,KW_OPT=348
+ ,KW_INF=349
+ ,KW_FACT=350
+ ,KW_SET=351
+ ,KW_EXPANSION=352
+ ,KW_TASKS=353
+ ,KW_PREFERENCE=354
+ ,KW_VIOLATED=355
+ ,KW_WITHIN=356
+ ,KW_ASSOC=357
+ ,KW_CONSTRAINTS=358
+ ,KW_ALWAYS=359
+ ,KW_SOMETIME=360
+ ,KW_AT_MOST_ONCE=361
+ ,KW_SOMETIME_BEFORE=362
+ ,KW_SOMETIME_AFTER=363
+ ,KW_ALWAYS_WITHIN=364
+ ,KW_IFF=365
+ ,KW_FALSE=366
+ ,KW_TRUE=367
+ ,KW_NUMBER=368
+ ,KW_UNDEFINED=369
+     };
+public:
+ int yyparse(void);
+ virtual void log_error(char *msg) = 0;
+ virtual int next_token() = 0;
+ yy_PDDL_Parser_stype yylval;
+ int yynerrs;
+ int yychar;
+public:
+ int yydebug;
+public:
+ PDDL_Parser(hsps::StringTable& t);
+public:
+ public: virtual std::ostream& at_position(std::ostream& s) = 0; virtual char* current_file() = 0; bool error_flag; private: hsps::PDDL_Base::variable_vec current_param; hsps::index_vec stored_n_param; hsps::PDDL_Base::TypeSet current_type_set; hsps::index_type last_n_functions; hsps::PDDL_Base::AtomBase* current_atom; hsps::PDDL_Base::atom_base_vec current_atom_stack; hsps::PDDL_Base::Context* current_context; hsps::lvector<Context*> stored_context; hsps::PDDL_Base::DKEL_Item* current_item; hsps::lvector<ConjunctiveGoal*> current_goal; hsps::PDDL_Base::Symbol* current_preference_name; hsps::PDDL_Base::HTableEntry* current_entry; char* current_plan_file; hsps::index_type n_plans_in_current_file;
+};
+typedef struct yy_buffer_state *YY_BUFFER_STATE;
+class PDDL_Scanner
+{
+ private:
+ char *yy_c_buf_p;
+ char yy_hold_char;
+ int yy_n_chars;
+ int yy_init;
+ int yy_start;
+ int yy_did_buffer_switch_on_eof;
+ private:
+ void yy_initialize();
+ int input();
+ int yyinput() {return input();};
+ int yy_get_next_buffer();
+ void yyunput( char c, char *buf_ptr );
+ long yy_get_previous_state_ ( void );
+ long yy_try_NUL_trans_ ( long current_state_ );
+ protected:
+ YY_BUFFER_STATE YY_CURRENT_BUFFER;
+ void yyrestart ( FILE *input_file );
+ void yy_switch_to_buffer( YY_BUFFER_STATE new_buffer );
+ void yy_load_buffer_state( void );
+ YY_BUFFER_STATE yy_create_buffer( FILE *file, int size );
+ void yy_delete_buffer( YY_BUFFER_STATE b );
+ void yy_init_buffer( YY_BUFFER_STATE b, FILE *file );
+ protected:
+ virtual void yy_echo()
+  ;
+ virtual int yy_input(char *buf,int &result,int max_size)
+  ;
+ virtual void yy_fatal_error(char *msg)
+  ;
+ virtual int yy_wrap()
+  ;
+ public:
+ char *yytext;
+ int yyleng;
+ FILE *yyin;
+ FILE *yyout;
+ int next_token ( yy_PDDL_Parser_stype& val);
+ PDDL_Scanner(hsps::StringTable& t) ;
+ virtual ~PDDL_Scanner() ;
+ int yy_flex_debug;
+ public:
+ private: hsps::StringTable& _tab; bool _reset; char* _filename; int _line_no; bool _trace_line; public: void open_file(char* fname, bool trace); void close_file(); char* current_file() const { return _filename; }; int current_line() const { return _line_no; };
+};
+namespace hsps {
+class Parser : public PDDL_Parser {
+  PDDL_Scanner scanner;
+ public:
+  Parser(StringTable& t) : PDDL_Parser(t), scanner(t) { };
+  void read(char *name, bool trace);
+  virtual int next_token();
+  virtual void log_error(char* msg);
+  virtual std::ostream& at_position(std::ostream& s);
+  virtual char* current_file();
+};
+}
+namespace hsps {
+void Parser::read(char *name, bool trace) {
+  yydebug = trace;
+  scanner.open_file(name, trace);
+  error_flag = false;
+  int res = yyparse();
+  scanner.close_file();
+  if (error_flag || (res > 0)) {
+    std::cerr << "res = " << res << std::endl;
+    exit(255);
+  }
+}
+int Parser::next_token() {
+  return scanner.next_token(yylval);
+}
+void Parser::log_error(char* msg) {
+  at_position(std::cerr << "error ") << msg << std::endl;
+  error_flag = true;
+}
+std::ostream& Parser::at_position(std::ostream& s) {
+  if (scanner.current_file()) {
+    return s << "at " << scanner.current_file() << ":"
+      << scanner.current_line() << ": ";
+  }
+  else {
+    return s << "at " << scanner.current_line() << ": ";
+  }
+}
+char* Parser::current_file()
+{
+  return scanner.current_file();
+}
+}

--- a/pr/seq-opt-hspsf/plan
+++ b/pr/seq-opt-hspsf/plan
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./hsp_f -strict -dba-semantics -rm -cost -rAH -use-lse -bfs -v 0 -ipc $1 $2 > $3

--- a/pr/seq-opt-hspsf/plans.ccx
+++ b/pr/seq-opt-hspsf/plans.ccx
@@ -1,0 +1,7428 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+namespace hsps {
+class ActionSequence : public index_vec, public Plan {
+ public:
+  ActionSequence() : index_vec(no_such_index, 0) { };
+  ActionSequence(const index_vec& vec) : index_vec(vec) { };
+  ActionSequence(const ActionSequence& seq) : index_vec(seq) { };
+  virtual ~ActionSequence() { };
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  virtual void output(Plan& to);
+};
+class ActionSequenceSet : public lvector<ActionSequence>, public PlanSet {
+ public:
+  ActionSequenceSet() : lvector<ActionSequence>() { };
+  virtual ~ActionSequenceSet() { };
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+};
+class CountActions
+: public lvector<count_type>, public Plan, public PlanSet
+{
+ public:
+  CountActions() : lvector<count_type>(0, 0) { };
+  CountActions(index_type n) : lvector<count_type>(0, n) { };
+  virtual ~CountActions() { };
+  void reset() { assign_value(0, length()); };
+  void reset(index_type n) { assign_value(0, n); };
+  count_type sum();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class ApxResult : public Result {
+  bool min_sol;
+  index_type sol_depth;
+ public:
+  ApxResult() : min_sol(false), sol_depth(0) { };
+  virtual ~ApxResult() { };
+  bool min_solution() { return min_sol; };
+  index_type solution_depth() { return sol_depth; };
+  virtual void solution(State& s, hsps::rational cost);
+  virtual bool more();
+};
+class Print : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  hsps::rational current_t;
+  amt_vec peak_use;
+  amt_vec res_cons;
+  count_type n_actions;
+  count_type n_plans;
+  hsps::rational sum_cost;
+ public:
+  static bool print_noops;
+  static bool decimal_time;
+  Print(Instance& i, ::std::ostream& s);
+  virtual ~Print();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintActions : public Plan, public PlanSet {
+ protected:
+  Instance& instance;
+  ::std::ostream& to;
+  char action_sep;
+  bool first_action;
+  char plan_sep;
+  bool first_plan;
+ public:
+  PrintActions(Instance& i, ::std::ostream& s);
+  PrintActions(Instance& i, ::std::ostream& s, char as);
+  PrintActions(Instance& i, ::std::ostream& s, char as, char ps);
+  virtual ~PrintActions();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintActionSetNames : public PrintActions {
+ public:
+  PrintActionSetNames(Instance& i, ::std::ostream& s)
+    : PrintActions(i, s) { };
+  PrintActionSetNames(Instance& i, ::std::ostream& s, char p)
+    : PrintActions(i, s, p) { };
+  virtual ~PrintActionSetNames() { };
+  virtual void insert(index_type act);
+};
+class PrintPDDL : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  hsps::rational start_t;
+ public:
+  PrintPDDL(Instance& i, ::std::ostream& s);
+  virtual ~PrintPDDL();
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintIPC : public Plan, public PlanSet {
+  Instance& instance;
+  ::std::ostream& to;
+  bool temporal;
+  hsps::rational epsilon;
+  bool included_epsilon;
+  bool strict_separation;
+  hsps::rational start_t;
+  bool occ_current_t;
+ public:
+  PrintIPC(Instance& i, ::std::ostream& s);
+  virtual ~PrintIPC();
+  void set_epsilon(hsps::rational e, bool included, bool strict);
+  virtual Plan* new_plan();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class PrintAssoc : public Plan {
+  Instance& instance;
+  ::std::ostream& to;
+ public:
+  PrintAssoc(Instance& i, ::std::ostream& s);
+  virtual ~PrintAssoc();
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+};
+class Store : public Result, public ScheduleSet {
+  state_vec solutions;
+ public:
+  Store(Instance& i);
+  virtual ~Store();
+  void reset();
+  void clear();
+  virtual void solution(State& s, hsps::rational cost);
+  index_type n_solutions() { return solutions.length(); };
+  State* solution(index_type k);
+  index_type n_plans() { return length(); };
+  Schedule* plan(index_type k);
+  virtual void output(PlanSet& to);
+  virtual void output(Result& to);
+};
+class StoreFilter : public SearchResult {
+ protected:
+  Store& store;
+ public:
+  StoreFilter(Store& s) : store(s) { };
+  virtual ~StoreFilter() { };
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class StoreMinCost : public StoreFilter {
+ public:
+  StoreMinCost(Store& s) : StoreFilter(s) { };
+  virtual ~StoreMinCost() { };
+  virtual void solution(State& s, hsps::rational cost);
+};
+class StoreDistinct : public StoreFilter {
+  Instance& instance;
+ public:
+  static count_type n_discarded;
+  StoreDistinct(Instance& i, Store& s) : StoreFilter(s), instance(i) { };
+  virtual ~StoreDistinct() { };
+  virtual void solution(State& s, hsps::rational cost);
+};
+class Conflicts : public Result {
+  Instance& instance;
+  index_set nec_del;
+  index_set pos_del;
+  amt_vec min_peak;
+  amt_vec max_peak;
+  bool first;
+  bool need_to_clear;
+ public:
+  Conflicts(Instance& ins);
+  virtual ~Conflicts();
+  const index_set& nec_deleted() const { return nec_del; };
+  const index_set& pos_deleted() const { return pos_del; };
+  const amt_vec& min_peak_resource_use() const { return min_peak; };
+  const amt_vec& max_peak_resource_use() const { return max_peak; };
+  void clear();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions();
+};
+}
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class PDDL_Name;
+class PDDL_Base {
+ public:
+  static bool use_default_function_value;
+  static hsps::rational default_function_value;
+  static bool use_strict_borrow_definition;
+  static bool use_extended_borrow_definition;
+  static bool del_before_add_semantics;
+  static bool compact_resource_effects;
+  static bool compile_away_disjunctive_preconditions;
+  static bool check_precondition_consistency;
+  static bool compile_away_conditional_effects;
+  static bool compile_away_plan_constraints;
+  static bool compile_away_object_functions;
+  static bool compile_for_validator;
+  static bool create_all_atoms;
+  static bool create_all_actions;
+  static bool number_multiple_action_instances;
+  static bool exclude_all_dkel_items;
+  static string_set excluded_dkel_tags;
+  static string_set required_dkel_tags;
+  static bool strict_set_export;
+  static bool best_effort;
+  static bool write_PDDL31;
+  static bool write_warnings;
+  static bool write_info;
+  static bool write_trace;
+  static bool trace_print_context;
+  static bool name_instance_by_problem_file;
+  static const char* instance_name_prefix;
+  enum symbol_class {
+    sym_object,
+    sym_typename,
+    sym_predicate,
+    sym_object_function,
+    sym_function,
+    sym_action,
+    sym_variable,
+    sym_misc,
+    sym_preference,
+    sym_set,
+    sym_meta_variable
+  };
+  enum metric_class {
+    metric_none,
+    metric_makespan,
+    metric_minimize,
+    metric_maximize
+  };
+  enum mode_keyword {
+    md_none,
+    md_start,
+    md_end,
+    md_all,
+    md_init,
+    md_pos_goal,
+    md_neg_goal
+  };
+  enum partial_value { p_false, p_true, p_unknown };
+  enum expression_class {
+    exp_fun,
+    exp_list,
+    exp_const,
+    exp_add,
+    exp_sub,
+    exp_mul,
+    exp_div,
+    exp_time,
+    exp_preference
+  };
+  enum relation_type {
+    rel_equal,
+    rel_greater,
+    rel_greater_equal,
+    rel_less,
+    rel_less_equal
+  };
+  enum formula_class { fc_false,
+         fc_true,
+         fc_atom,
+         fc_equality,
+         fc_negation,
+         fc_conjunction,
+         fc_disjunction,
+         fc_equivalence,
+         fc_implication,
+         fc_universal,
+         fc_existential,
+         fc_list
+  };
+  struct Symbol;
+  struct TypeSymbol;
+  struct Atom;
+  struct FTerm;
+  struct FChangeAtom;
+  struct SetOf;
+  struct ListExpression;
+  struct ActionSymbol;
+  struct Reference;
+  struct IrrelevantItem;
+  typedef lvector<TypeSymbol*> type_vec;
+  typedef lvector<Atom*> atom_vec;
+  typedef lvector<FChangeAtom*> ch_atom_vec;
+  typedef lvector<SetOf*> atom_set_vec;
+  typedef lvector<Reference*> ref_vec;
+  typedef lvector<IrrelevantItem*> irrelevant_vec;
+  struct TypeSet : public type_vec {
+    TypeSet() : type_vec(0, 0) { };
+    TypeSet(const TypeSet& s) : type_vec(s) { };
+    TypeSet(TypeSymbol* t) : type_vec(t, 1) { };
+    index_type n_elements() const;
+    Symbol* get_element(index_type n);
+    bool is_object() const;
+    bool subtype_or_equal(const TypeSet& s) const;
+    bool subtype_or_equal(TypeSymbol* t) const;
+    void print(std::ostream& s) const;
+    void write_type(std::ostream& s) const;
+  };
+  struct Symbol {
+    symbol_class sym_class;
+    char* print_name;
+    TypeSet sym_types;
+    bool defined_in_problem;
+    bool visible;
+    Symbol(symbol_class c, char* n)
+      : sym_class(c), print_name(n), defined_in_problem(false), visible(true) { };
+    Symbol(char* n)
+      : sym_class(sym_object), print_name(n), defined_in_problem(false), visible(true) { };
+    void print(std::ostream& s) const;
+  };
+  typedef zero_init_pair<Symbol*> symbol_pair;
+  typedef lvector<Symbol*> symbol_vec;
+  typedef svector<Symbol*> symbol_set;
+  typedef lvector<symbol_pair> symbol_pair_vec;
+  static bool extend_substitution(Symbol* out, Symbol* in, symbol_pair_vec& u);
+  static bool print_substitution(std::ostream& s, const symbol_pair_vec& u);
+  static bool print_inequality(std::ostream& s, const symbol_pair_vec& neq);
+  static bool substitution_violates_inequality(const symbol_pair_vec& neq,
+            const symbol_pair_vec& u);
+  static index_type find_matching_atom(Atom* a, atom_vec& v);
+  static index_type find_matching_atom(Atom* a, mode_keyword m, atom_vec& v);
+  static index_type find_matching_fluent_atom
+    (FChangeAtom* a, mode_keyword m, ch_atom_vec& v);
+  struct TypeSymbol : public Symbol {
+    symbol_vec elements;
+    bool is_base_type;
+    TypeSymbol(char* n) : Symbol(sym_typename, n), elements(0, 0),
+  is_base_type(false) { };
+    void add_element(Symbol* e);
+    bool is_object() const { return (strcmp(print_name, "object") == 0); };
+    bool subtype_or_equal(TypeSymbol* t) const;
+    bool subtype_or_equal(const TypeSet& t) const;
+    void print(std::ostream& s) const;
+  };
+  struct VariableSymbol : public Symbol {
+    Symbol* value;
+    FTerm* binding;
+    VariableSymbol(char* n) : Symbol(sym_variable, n), value(0), binding(0) {};
+    bool equality_type_check(Symbol* s);
+    void print(std::ostream& s);
+  };
+  typedef lvector<VariableSymbol*> variable_vec;
+  struct ParamSymbol : public Symbol {
+    variable_vec param;
+    ParamSymbol(symbol_class c, char* n) : Symbol(c, n), param(0, 0) { };
+  };
+  struct PredicateSymbol : public ParamSymbol {
+    bool pos_pre;
+    bool neg_pre;
+    bool added;
+    bool deleted;
+    bool locked;
+    bool modded;
+    ptr_table init;
+    ptr_table pos_goal;
+    ptr_table neg_goal;
+    ptr_table pos_prop;
+    ptr_table neg_prop;
+    irrelevant_vec irr_ins;
+    PredicateSymbol(char* n) : ParamSymbol(sym_predicate, n),
+  pos_pre(false), neg_pre(false), added(false), deleted(false),
+  locked(false), modded(false), irr_ins(0, 0) { };
+    bool is_static() const { return !modded; };
+    bool is_equality() const { return (strcmp(print_name, "=") == 0); };
+    void instantiate(Instance& ins);
+    void initialise_missing(const symbol_vec& p,
+       atom_vec* created,
+       index_type i = 0);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+  };
+  struct ObjectFunctionSymbol : public ParamSymbol {
+    bool modded;
+    ptr_table init;
+    ObjectFunctionSymbol(char* n)
+      : ParamSymbol(sym_object_function, n), modded(false) { };
+    bool is_static() const { return !modded; };
+    void print(std::ostream& s);
+  };
+  struct FunctionSymbol : public ParamSymbol {
+    bool modified;
+    bool integral;
+    bool linear;
+    bool conditioned;
+    bool increased;
+    bool decreased;
+    bool assigned;
+    bool borrowed;
+    ptr_table init;
+    FunctionSymbol(char* n) : ParamSymbol(sym_function, n),
+  modified(false), integral(true), linear(true), conditioned(false),
+  increased(false), decreased(false), assigned(false), borrowed(false)
+    { };
+    bool is_static() const
+    { return !modified; };
+    bool is_reusable() const
+    { return borrowed && !increased && !decreased && !assigned; };
+    bool is_consumable() const
+    { return !borrowed && !increased && decreased && !assigned; };
+    interval eval_init_bounds(ptr_table* p, index_type i, ListExpression* r);
+    void print(std::ostream& s);
+  };
+  struct AtomBase {
+    symbol_vec param;
+    mode_keyword at;
+    hsps::rational at_time;
+    AtomBase() : param(0, 0), at(md_none), at_time(0) { };
+    AtomBase(mode_keyword t) : param(0, 0), at(t), at_time(0) { };
+    AtomBase(AtomBase* b);
+    bool equals(AtomBase& b);
+    void free_variables(variable_vec& v);
+    bool occurs(Symbol* s);
+    void fill_in_args(AtomBase* b);
+    void collect_bound_variables(variable_vec& v);
+    void insert(ptr_table& t);
+    static bool print_bindings;
+    void print(std::ostream& s) const;
+    void print_instance(std::ostream& s);
+  };
+  typedef lvector<AtomBase*> atom_base_vec;
+  struct Atom : AtomBase {
+    PredicateSymbol* pred;
+    Atom(PredicateSymbol* p) : pred(p) { };
+    Atom(PredicateSymbol* p, mode_keyword t) : AtomBase(t), pred(p) { };
+    Atom(PredicateSymbol* p, variable_vec& a, bool as_value)
+      : pred(p)
+    {
+      param.set_length(a.length());
+      for (index_type k = 0; k < a.length(); k++)
+ param[k] = (as_value ? a[k]->value : a[k]);
+    };
+    Atom(PredicateSymbol* p, Symbol* a0)
+      : pred(p)
+    {
+      param.append(a0);
+    };
+    Atom(Atom* a) : AtomBase(a), pred(a->pred) { };
+    bool equals(Atom& a);
+    bool is_static() const {
+      return ((at == md_init) ||
+       (at == md_pos_goal) ||
+       (at == md_neg_goal) ||
+       pred->is_static());
+    };
+    bool check();
+    Instance::Atom* find_prop(Instance& ins, bool neg, bool create);
+    void build(Instance& ins, bool neg, index_type p);
+    Atom* instantiate_partially();
+    partial_value partial_eval(ptr_table* r, index_type p);
+    partial_value partial_eval();
+    bool initial_value();
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    void print(std::ostream& s, bool neg) const;
+    void print(std::ostream& s) const { print(s, false); };
+  };
+  struct CAtom : public Atom {
+    symbol_pair_vec neq;
+    CAtom(Atom* a) : Atom(a), neq(symbol_pair(0, 0), 0) { };
+    CAtom(CAtom* s) : Atom(s), neq(s->neq) { };
+    CAtom(const Atom* a, symbol_pair_vec& u);
+    CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool instance_of(CAtom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(CAtom* a, symbol_pair_vec& u);
+    void print(std::ostream& s);
+  };
+  typedef lvector<CAtom*> catom_vec;
+  struct FTerm : AtomBase {
+    ObjectFunctionSymbol* fun;
+    FTerm(ObjectFunctionSymbol* f) : fun(f) { };
+    bool equals(FTerm& a);
+    void print(std::ostream& s) const;
+  };
+  struct OInitAtom : AtomBase {
+    ObjectFunctionSymbol* fun;
+    Symbol* val;
+    OInitAtom(ObjectFunctionSymbol* f) : fun(f), val(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<OInitAtom*> obj_init_atom_vec;
+  struct FInitAtom : AtomBase {
+    FunctionSymbol* fun;
+    hsps::rational val;
+    Instance::resource_ref res;
+    FInitAtom(FunctionSymbol* f) : fun(f), val(0) { };
+    FInitAtom(FChangeAtom* a);
+    bool is_static() const { return fun->is_static(); };
+    void print(std::ostream& s);
+  };
+  typedef lvector<FInitAtom*> fun_init_atom_vec;
+  struct Expression;
+  typedef lvector<Expression*> exp_vec;
+  struct Expression {
+    expression_class exp_class;
+    Expression(expression_class c) : exp_class(c) { };
+    static bool print_nary;
+    bool is_static();
+    bool is_constant();
+    bool is_integral();
+    hsps::rational eval_static();
+    bool eval_partial(hsps::rational& val);
+    interval eval_bounds();
+    hsps::rational eval_init();
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    hsps::rational eval_delta(Symbol* preference, hsps::rational p_value, hsps::rational d_value);
+    Expression* copy();
+    Expression* simplify();
+    void collect_constants(exp_vec& c);
+    void mark_functions_in_condition();
+    hsps::rational integrify();
+    void substitute_for_time(Expression* e);
+    Expression* substitute_for_preference(Symbol* n, Expression* e);
+    bool equals(Expression* e);
+    void print_sum(std::ostream& s, bool grnd);
+    void print_product(std::ostream& s, bool grnd);
+    void print(std::ostream& s, bool grnd);
+  };
+  struct ListExpression : public Expression {
+    Symbol* sym;
+    ListExpression* rest;
+    ListExpression(Symbol* s, ListExpression* r) :
+      Expression(exp_list), sym(s), rest(r) { };
+    bool match(AtomBase* atom);
+  };
+  struct FunctionExpression : public Expression {
+    FunctionSymbol* fun;
+    ListExpression* args;
+    FunctionExpression(FunctionSymbol* f, ListExpression* a) :
+      Expression(exp_fun), fun(f), args(a) { };
+    bool match(FChangeAtom* atom);
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    FChangeAtom* make_atom_base();
+  };
+  struct ConstantExpression : public Expression {
+    hsps::rational val;
+    ConstantExpression(hsps::rational v) :
+      Expression(exp_const), val(v) { };
+  };
+  struct TimeExpression : public Expression {
+    Expression* time_exp;
+    TimeExpression() :
+      Expression(exp_time), time_exp(0) { };
+    TimeExpression(Expression* e) :
+      Expression(exp_time), time_exp(e) { };
+  };
+  struct BinaryExpression : public Expression {
+    Expression* first;
+    Expression* second;
+    BinaryExpression(expression_class c, Expression* e1, Expression* e2) :
+      Expression(c), first(e1), second(e2) { };
+  };
+  struct PreferenceExpression : public Expression {
+    Symbol* name;
+    PreferenceExpression(Symbol* n) :
+      Expression(exp_preference), name(n) { };
+  };
+  struct Relation {
+    relation_type rel;
+    mode_keyword at;
+    Expression* first;
+    Expression* second;
+    Relation(relation_type r, Expression* e1, Expression* e2) :
+      rel(r), at(md_none), first(e1), second(e2) { };
+    Relation(relation_type r, mode_keyword m, Expression* e1, Expression* e2) :
+      rel(r), at(m), first(e1), second(e2) { };
+    Expression* match_gteq_constant(FChangeAtom* atom);
+    FunctionExpression* match_lteq_fun(FChangeAtom* atom);
+    bool is_static();
+    partial_value partial_eval();
+    void print(std::ostream& s, bool grnd);
+  };
+  typedef lvector<Relation*> relation_vec;
+  struct FChangeAtom : AtomBase {
+    FunctionSymbol* fun;
+    Expression* val;
+    FChangeAtom(FunctionSymbol* f) :
+      fun(f), val(0) { };
+    FChangeAtom(FunctionSymbol* f, mode_keyword t) :
+      AtomBase(t), fun(f), val(0) { };
+    FChangeAtom(FChangeAtom* a, hsps::rational v) :
+      AtomBase(a), fun(a->fun), val(new ConstantExpression(v)) { };
+    bool equals(FChangeAtom& a);
+    bool fluent_equals(FChangeAtom& a);
+    bool fluent_and_mode_equals(FChangeAtom& a);
+    FChangeAtom* find_fluent_equals(ch_atom_vec& vec);
+    Instance::Resource* find_resource(Instance& ins);
+    void print(std::ostream& s);
+  };
+  struct Formula {
+    formula_class fc;
+    Formula(formula_class c) : fc(c) { };
+    void rename_variables_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_variables_2(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_2(PDDL_Base::symbol_pair_vec& sub);
+    Formula* simplify();
+    void write_otter(std::ostream& s) const;
+    void print(std::ostream& s) const;
+    void untype(PDDL_Base* base);
+  };
+  typedef lvector<Formula*> formula_vec;
+  struct AFormula : public Formula, public Atom {
+    AFormula(Atom* a) :
+      Formula(fc_atom), Atom(a) { };
+    AFormula(PredicateSymbol* p) :
+      Formula(fc_atom), Atom(p) { };
+    AFormula(PredicateSymbol* p, variable_vec& a) :
+      Formula(fc_atom), Atom(p, a, false) { };
+    void print(std::ostream& s) const;
+    void write_otter(std::ostream& s) const;
+  };
+  struct EqFormula : public Formula {
+    Symbol* t1;
+    Symbol* t2;
+    EqFormula(Symbol* s1, Symbol* s2) :
+      Formula(fc_equality), t1(s1), t2(s2) { };
+    void write_otter(std::ostream& s) const;
+  };
+  struct NFormula : public Formula {
+    Formula* f;
+    NFormula(Formula* g) : Formula(fc_negation), f(g) { };
+  };
+  struct BFormula : public Formula {
+    Formula* f1;
+    Formula* f2;
+    BFormula(formula_class c, Formula* g1, Formula* g2) :
+      Formula(c), f1(g1), f2(g2) { };
+  };
+  struct CFormula : public Formula {
+    formula_vec parts;
+    CFormula(formula_class c) : Formula(c), parts(0, 0) { };
+    CFormula(formula_class c, Formula* f1, Formula* f2) :
+      Formula(c), parts(0, 0)
+    {
+      parts.append(f1);
+      parts.append(f2);
+    };
+    void add(Formula* f) { parts.append(f); };
+    void add(formula_vec& f) { parts.append(f); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct QFormula : public Formula {
+    variable_vec vars;
+    Formula* f;
+    QFormula(formula_class c) : Formula(c), vars(0, 0), f(0) { };
+    QFormula(formula_class c, Formula* g) : Formula(c), vars(0, 0), f(g) { };
+    QFormula(formula_class c, variable_vec& v, Formula* g) :
+      Formula(c), vars(0, 0), f(g)
+    {
+      for (index_type k = 0; k < v.length(); k++) vars.append(v[k]);
+    };
+    void add(PDDL_Base::VariableSymbol* v) { vars.append(v); };
+    void add(PDDL_Base::variable_vec& v) { vars.append(v); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct TypeConstraint {
+    VariableSymbol* var;
+    TypeSymbol* typ;
+    TypeConstraint(VariableSymbol* v, TypeSymbol* t) : var(v), typ(t) { };
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+  };
+  typedef lvector<TypeConstraint*> type_constraint_vec;
+  struct Context {
+    variable_vec param;
+    atom_vec pos_con;
+    atom_vec neg_con;
+    type_constraint_vec type_con;
+    Context() : param(0, 0), pos_con(0, 0), neg_con(0, 0), type_con(0, 0) { };
+    Context(const Context* c) : param(c->param), pos_con(c->pos_con),
+  neg_con(c->neg_con), type_con(c->type_con) { };
+    bool context_is_static() const;
+    bool occurs_in_context(Symbol* s);
+    void clear_arguments();
+    void set_mode(mode_keyword m);
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+    void print_assignment(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct DKEL_Item : public Context {
+    char* item_name;
+    Symbol* name;
+    string_set item_tags;
+    bool defined_in_problem;
+    bool included;
+    DKEL_Item(char* name) : item_name(name), name(0),
+  defined_in_problem(false), included(true) { };
+    DKEL_Item(const DKEL_Item* i) : Context(i), item_name(i->item_name),
+  name(i->name), item_tags(i->item_tags),
+  defined_in_problem(i->defined_in_problem), included(i->included) { };
+    bool item_is_included(string_set& ex_tags, string_set& req_tags);
+    void print_begin(std::ostream& s);
+    void print_end(std::ostream& s);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SetOf : public Context {
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    SetOf() : pos_atoms(0, 0), neg_atoms(0, 0) { };
+    SetOf(const SetOf* s)
+      : Context(s), pos_atoms(s->pos_atoms), neg_atoms(s->neg_atoms)
+    { };
+    SetOf(Atom* a)
+    { pos_atoms.append(a); };
+    SetOf(Atom* a, bool n)
+    { if (n) neg_atoms.append(a); else pos_atoms.append(a); };
+    bool is_static() const;
+    void set_mode(mode_keyword m);
+    partial_value partial_eval(bool as_disjunction = false);
+    partial_value partial_eval(index_type p, bool as_disjunction = false);
+    void instantiate_as_set(Instance& ins, index_set& s);
+    void instantiate_as_effect(Instance& ins, index_set& s_add,
+          index_set& s_del);
+    void instantiate_conditional(Instance& ins, rule_set& s_pos,
+     rule_set& s_neg);
+    SetOf* instantiate_partially();
+    void compile(atom_vec& pos_ins, atom_vec& neg_ins, index_type p);
+    void compile_non_static(atom_set_vec& ins, index_type p);
+    void print(std::ostream& s);
+    void print_as_disjunction(std::ostream& s);
+    void build_set(Instance& ins, index_set& s, index_type p);
+    void build_effect(Instance& ins, index_set& s_add, index_set& s_del,
+        index_type p);
+    void build_conditional(Instance& ins, rule_set& s_pos, rule_set& s_neg,
+      index_type p);
+  };
+  struct QCNumericEffect : public Context {
+    FChangeAtom* atom;
+    QCNumericEffect() : atom(0) { };
+    QCNumericEffect(FChangeAtom* a) : atom(a) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<QCNumericEffect*> qc_numeric_effect_vec;
+  enum set_constraint_keyword { sc_at_least, sc_at_most, sc_exactly };
+  struct SetConstraint : public DKEL_Item {
+    set_constraint_keyword sc_type;
+    index_type sc_count;
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    atom_set_vec atom_sets;
+    SetConstraint() : DKEL_Item(":invariant"), sc_type(sc_at_least),
+  sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0), atom_sets(0, 0) { };
+    SetConstraint(const DKEL_Item* item) : DKEL_Item(item),
+  sc_type(sc_at_least), sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0),
+  atom_sets(0, 0) { };
+    void build(Instance& ins, index_type p);
+    void instantiate(Instance& ins);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InvariantFormula : public DKEL_Item {
+    Formula* f;
+    InvariantFormula(Formula* g)
+      : DKEL_Item(":invariant"), f(g) { };
+    InvariantFormula(const DKEL_Item* item, Formula* g)
+      : DKEL_Item(item), f(g) { };
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct Reference : public AtomBase {
+    Symbol* name;
+    bool neg;
+    bool has_args;
+    index_set index;
+    Reference(Symbol* n) : name(n), neg(false), has_args(true) { };
+    Reference(Symbol* n, bool ng, bool ha)
+      : name(n), neg(ng), has_args(ha) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    void* find_action();
+    void find(const name_vec& names, index_set& ind);
+    Reference* instantiate_partially();
+    void print(std::ostream& s);
+  };
+  struct IrrelevantItem : public DKEL_Item {
+    Reference* entity;
+    IrrelevantItem() : DKEL_Item(":irrelevant"), entity(0) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    IrrelevantItem* instantiate_partially();
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SequentialTaskNet : public Context {
+    ref_vec tasks;
+    ActionSymbol* abs_act;
+    SequentialTaskNet() : tasks(0, 0), abs_act(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<SequentialTaskNet*> task_net_vec;
+  struct SetSymbol : public Symbol {
+    ptr_table set_table;
+    lvector<index_set*> sets;
+    name_vec names;
+    SetSymbol(char* n) : Symbol(sym_set, n), sets(0, 0), names(0, 0) { };
+  };
+  struct SetName : public AtomBase {
+    SetSymbol* sym;
+    SetName(SetSymbol* s) : sym(s) { };
+    index_set* find();
+    SetName* instantiate_partially();
+    void print(std::ostream& s);
+    void print_instance(std::ostream& s);
+  };
+  struct ActionSymbol : public ParamSymbol {
+    atom_vec pos_pre;
+    atom_vec neg_pre;
+    atom_set_vec set_pre;
+    atom_set_vec dis_pre;
+    relation_vec num_pre;
+    atom_vec adds;
+    atom_vec dels;
+    atom_set_vec set_eff;
+    atom_vec cons;
+    atom_set_vec cond_eff;
+    atom_vec locks;
+    atom_vec enables;
+    ch_atom_vec reqs;
+    ch_atom_vec incs;
+    ch_atom_vec decs;
+    ch_atom_vec fass;
+    qc_numeric_effect_vec qc_incs;
+    qc_numeric_effect_vec qc_decs;
+    qc_numeric_effect_vec qc_fass;
+    Expression* dmin;
+    Expression* dmax;
+    irrelevant_vec irr_ins;
+    ref_vec refs;
+    task_net_vec exps;
+    ptr_table instances;
+    SetName* part;
+    const char* assoc;
+    ActionSymbol(char* n) : ParamSymbol(sym_action, n), pos_pre(0, 0),
+  neg_pre(0, 0), set_pre(0, 0), dis_pre(0, 0), num_pre(0, 0),
+  adds(0, 0), dels(0, 0), set_eff(0, 0), cons(0, 0), cond_eff(0, 0),
+  locks(0, 0), enables(0, 0), reqs(0, 0), incs(0, 0), decs(0, 0),
+  fass(0, 0), qc_incs(0, 0), qc_decs(0, 0), qc_fass(0, 0), dmin(0),
+  dmax(0), irr_ins(0, 0), refs(0, 0), exps(0, 0), part(0), assoc(0) { };
+    void build(Instance& ins, index_type p, Expression* cost_exp);
+    Instance::Action& build_action(Instance& ins,
+       PDDL_Name* name,
+       index_type& count,
+       const index_set& pre,
+       const index_set& add,
+       const index_set& del,
+       const index_set& lck,
+       const index_cost_vec& r_use,
+       const index_cost_vec& r_cons,
+       hsps::rational dmin,
+       hsps::rational dmax,
+       hsps::rational dur,
+       hsps::rational cost);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          index_vec& s,
+          index_type p);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc);
+    void build_actions_with_dc_and_ce(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          const rule_set& pce,
+          const rule_set& nce,
+          const bool_vec& ece);
+    index_type param_index(VariableSymbol* p);
+    void get_param_inequalities(symbol_pair_vec& neq);
+    void set_arguments(const symbol_vec& args);
+    void set_arguments(const ptr_table::key_vec& args);
+    void clear_arguments();
+    void* find_instance();
+    bool is_abstract();
+    void post_process();
+    void instantiate(Instance& ins, Expression* cost_exp);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InputPlanStep {
+    Reference* act;
+    hsps::rational start_time;
+    InputPlanStep() : act(0), start_time(0) { };
+    InputPlanStep(Reference* a, hsps::rational t) : act(a), start_time(t) { };
+  };
+  struct InputPlan {
+    Symbol* name;
+    bool is_opt;
+    lvector<InputPlanStep*> steps;
+    InputPlan() : name(0), is_opt(false), steps(0, 0) { };
+    bool export_to_instance(Instance& ins, const index_vec& map, Plan& p);
+    void print(std::ostream& s);
+  };
+  struct HTableEntry {
+    atom_vec atoms;
+    bool_vec neg;
+    hsps::rational cost;
+    bool opt;
+    HTableEntry() : atoms(0, 0), neg(false, 0), cost(0), opt(false) { };
+  };
+  struct SimpleReferenceSet : public Context {
+    Reference* ref;
+    SimpleReferenceSet(Reference* r) : ref(r) { };
+    bool build(const name_vec& names, index_set& set, index_type p);
+    void print(std::ostream& s);
+  };
+  typedef lvector<SimpleReferenceSet*> refs_vec;
+  struct ReferenceSet : public Context {
+    refs_vec refs;
+    Symbol* name;
+    ReferenceSet() : refs(0, 0), name(0) { };
+    void add(SimpleReferenceSet* ref) { refs.append(ref); };
+    void build(const name_vec& names, index_set_vec& sets, index_type p);
+    void print(std::ostream& s);
+  };
+  struct CPG {
+    atom_vec atoms;
+    index_vec atom_first_arg;
+    bool_vec neg;
+    symbol_vec args;
+    type_vec arg_types;
+    CPG() : atoms(0, 0), neg(false, 0), args(0, 0), arg_types(0, 0) { };
+    CPG(CPG& g, index_vec& s);
+    void make_key(ptr_table::key_vec& key);
+    void make_typed_key(ptr_table::key_vec& key);
+    void make_parameters(variable_vec& params);
+    ListExpression* make_argument_list(index_type first);
+    void add_asserting_effects(ActionSymbol* act,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          bool strict);
+    void add_destroying_effects(ActionSymbol* act,
+    ParamSymbol* pf,
+    PredicateSymbol* p,
+    bool p_val,
+    PredicateSymbol* g,
+    FunctionSymbol* f,
+    Expression* f_val,
+    bool strict);
+    bool initial_value();
+    void add_asserting_effects(index_type c_atom,
+          ActionSymbol* act,
+          index_type c_eff,
+          bool_vec& sat,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          symbol_pair_vec& eq,
+          symbol_pair_vec& neq,
+          bool strict);
+    void add_propositional_effect(ActionSymbol* act,
+      PredicateSymbol* p, bool p_val,
+      index_type c_atom, Atom* a_eff,
+      bool strict);
+    void add_fluent_effect(ActionSymbol* act,
+      FunctionSymbol* f, Expression* f_val,
+      index_type c_atom, Atom* a_eff);
+    void add_effect_conditions(Context* e, ParamSymbol* pf, bool_vec& sat,
+          symbol_vec& subs, symbol_pair_vec& eq,
+          symbol_pair_vec& neq);
+  };
+  enum goal_class { goal_pos_atom, goal_neg_atom, goal_relation, goal_task,
+      goal_conjunction, goal_disjunction, goal_forall,
+      goal_exists, goal_always, goal_sometime,
+      goal_at_most_once, goal_within, goal_always_within,
+      goal_sometime_before, goal_sometime_after };
+  struct Goal {
+    goal_class g_class;
+    Goal(goal_class c) : g_class(c) { };
+    bool is_state();
+    bool is_propositional();
+    bool is_singular();
+    bool makeCPG(CPG& g);
+    bool makeCPG(CPG& g, index_vec& s);
+    void instantiate(Instance& ins, hsps::rational deadline);
+    void instantiate(Instance& ins, index_set& set, Symbol* p, index_type i);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Goal*> goal_vec;
+  struct AtomicGoal : public Goal {
+    Atom* atom;
+    AtomicGoal(Atom* a, bool neg)
+      : Goal(neg ? goal_neg_atom : goal_pos_atom), atom(a) { };
+    void print(std::ostream& s);
+  };
+  struct NumericGoal : public Goal {
+    Relation* rel;
+    NumericGoal(Relation* r) : Goal(goal_relation), rel(r) { };
+    void print(std::ostream& s);
+  };
+  struct TaskGoal : public Goal {
+    Reference* task;
+    TaskGoal(Reference* r) : Goal(goal_task), task(r) { };
+    void print(std::ostream& s);
+  };
+  struct ConjunctiveGoal : public Goal {
+    goal_vec goals;
+    ConjunctiveGoal() : Goal(goal_conjunction), goals(0, 0) { };
+    ConjunctiveGoal(goal_class gc) : Goal(gc), goals(0, 0) { };
+    void print(std::ostream& s);
+  };
+  struct DisjunctiveGoal : public ConjunctiveGoal {
+    DisjunctiveGoal() : ConjunctiveGoal(goal_disjunction) { };
+    void print(std::ostream& s);
+  };
+  struct QuantifiedGoal : public Goal, public Context {
+    Goal* goal;
+    QuantifiedGoal() : Goal(goal_forall), goal(0) { };
+    QuantifiedGoal(goal_class gc) : Goal(gc), goal(0) { };
+    void print(std::ostream& s);
+  };
+  struct SimpleSequenceGoal : public Goal {
+    Goal* constraint;
+    SimpleSequenceGoal(goal_class c, Goal* g) : Goal(c), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredSequenceGoal : public Goal {
+    Goal* trigger;
+    Goal* constraint;
+    TriggeredSequenceGoal(goal_class c, Goal* t, Goal* g)
+      : Goal(c), trigger(t), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct DeadlineGoal : public Goal {
+    Goal* goal;
+    hsps::rational at;
+    DeadlineGoal(hsps::rational t, Goal* g) : Goal(goal_within), goal(g), at(t) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredDeadlineGoal : public Goal {
+    Goal* trigger;
+    Goal* goal;
+    hsps::rational delay;
+    TriggeredDeadlineGoal(Goal* t, hsps::rational d, Goal* g)
+      : Goal(goal_always_within), trigger(t), delay(d), goal(g) { };
+    void print(std::ostream& s);
+  };
+  struct Preference {
+    Symbol* name;
+    Goal* goal;
+    Preference() : name(0), goal(0) { };
+    Preference(Symbol* n) : name(n), goal(0) { };
+    Preference(Symbol* n, Goal* g) : name(n), goal(g) { };
+    bool is_state() { return goal->is_state(); };
+    bool is_propositional() { return goal->is_propositional(); };
+    hsps::rational value(metric_class metric_type, Expression* m);
+    void instantiate(SoftInstance& ins,
+       metric_class metric_type,
+       Expression* m);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Preference*> preference_vec;
+  char* domain_name;
+  char* problem_name;
+  char* domain_file;
+  char* problem_file;
+  bool ready_to_instantiate;
+  char* problem_file_basename();
+  char* enum_problem_filename(const char* s, index_type i);
+  StringTable& tab;
+  type_vec dom_types;
+  type_vec dom_base_types;
+  TypeSymbol* dom_top_type;
+  symbol_vec dom_constants;
+  PredicateSymbol* dom_eq_pred;
+  PredicateSymbol* dom_assign_pred;
+  Symbol* dom_undefined_obj;
+  static PredicateSymbol* current_eq_predicate;
+  lvector<PredicateSymbol*> dom_predicates;
+  lvector<ObjectFunctionSymbol*> dom_object_functions;
+  lvector<FunctionSymbol*> dom_functions;
+  lvector<ActionSymbol*> dom_actions;
+  lvector<SetConstraint*> dom_sc_invariants;
+  lvector<InvariantFormula*> dom_f_invariants;
+  lvector<IrrelevantItem*> dom_irrelevant;
+  atom_vec dom_init;
+  obj_init_atom_vec dom_obj_init;
+  fun_init_atom_vec dom_fun_init;
+  goal_vec dom_goals;
+  preference_vec dom_preferences;
+  ref_vec goal_tasks;
+  metric_class metric_type;
+  Expression* metric;
+  hsps::rational serial_length;
+  hsps::rational parallel_length;
+  lvector<InputPlan*> input_plans;
+  lvector<HTableEntry*> h_table;
+  lvector<ReferenceSet*> input_sets;
+  lvector<SetSymbol*> partitions;
+  static ActionSymbol* src_action_symbol(ptr_pair* p);
+  TypeSymbol* find_type(const char* name);
+  PredicateSymbol* find_predicate(const char* name);
+  FunctionSymbol* find_function(const char* name);
+  bool find_initial_fact(const char* pname, const symbol_vec& arg);
+  hsps::rational find_function_value(const char* fname, const symbol_vec& arg);
+  index_type find_element_satisfying(const symbol_vec& elements,
+         const char* pname,
+         symbol_vec& arg,
+         index_type element_arg_p);
+  void find_elements_satisfying(const symbol_vec& elements,
+    const char* pname,
+    symbol_vec& arg,
+    index_type element_arg_p,
+    index_set& sats);
+  Atom* goal_to_atom(Goal* g);
+  bool goal_to_atom_vec(Goal* g, atom_vec& av);
+  PDDL_Base(StringTable& t);
+  ~PDDL_Base();
+  void set_variable_type(variable_vec& vec, TypeSymbol* t);
+  void set_variable_type(variable_vec& vec, const TypeSet& t);
+  void set_type_type(type_vec& vec, TypeSymbol* t);
+  void set_constant_type(symbol_vec& vec, TypeSymbol* t);
+  void clear_context(variable_vec& vec);
+  void clear_context(variable_vec& vec, index_type n_min, index_type n_max);
+  bool merge_type_vectors(type_vec& v0, type_vec& v1);
+  void make_parameters(type_vec& t, const char* prefix, variable_vec& v);
+  Atom* make_atom_from_prop(ptr_pair& src, bool& neg);
+  Symbol* gensym(symbol_class c, const char* p, const TypeSet& t);
+  Symbol* gensym(symbol_class c, const char* p, TypeSymbol* t);
+  Symbol* gensym_i(symbol_class c, const char* p, index_type i, TypeSymbol* t);
+  Symbol* gensym_s(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t);
+  Symbol* gensym_n(symbol_class c, const char* p, const Name* n, TypeSymbol* t);
+  void new_variable_substitution(Atom* a,
+     symbol_pair_vec& u,
+     symbol_pair_vec& new_u);
+  Atom* new_meta_atom(PredicateSymbol* p);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& u);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+  void extend_cc(CAtom* l, catom_vec& m, catom_vec& nm,
+   lvector< swapable_pair<catom_vec> >& x,
+   index_type d);
+  void find_cc();
+  void post_process();
+  void instantiate(Instance& ins);
+  void instantiate_soft(SoftInstance& ins);
+  void instantiate_atom_set(Instance& ins, atom_vec& a, index_set& s);
+  index_type n_plans() const { return input_plans.length(); };
+  bool export_plan(index_type i, Instance& ins, const index_vec& map, Plan& p);
+  bool export_plan(index_type i, Instance& ins, Plan& p);
+  void export_heuristic(Instance& ins,
+   const index_vec& map,
+   bool opt_maximize,
+   Heuristic& h);
+  void export_sets(const name_vec& names, index_set_vec& sets);
+  void export_action_partitions(name_vec& names, index_set_vec& sets);
+  void lift_DKEL_Items(const Instance& ins);
+  PredicateSymbol* find_type_predicate(Symbol* type_sym);
+  void untype();
+  void compile_preferences();
+  void compile_constraints_1();
+  void compile_constraints_2();
+  void select_preferences(const bool_vec& sel);
+  void metric_to_goal(hsps::rational bound);
+  void compile_set_conditions_and_effects();
+  void compile_object_functions();
+  Expression* replace_violations_1(Expression* exp,
+       CPG* cpg[],
+       FunctionSymbol* f_violated[]);
+  Goal* compile_constraint_1(Goal* g, index_type i, const Symbol* n,
+        symbol_vec& aut_states, index_type n_ra);
+  AtomicGoal* make_automaton_type_a(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_e(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_o(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sb(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sa(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  void make_automaton_transition(Symbol* s_from,
+     Symbol* s_to,
+     bool is_accept,
+     CPG* f, bool neg_f,
+     CPG* g, bool neg_g,
+     PredicateSymbol* p_state,
+     PredicateSymbol* p_accept,
+     PredicateSymbol* p_synch);
+  void add_precondition_formula(ActionSymbol* a, CPG* f, bool is_neg);
+  Goal* compile_constraint_2(Goal* g, const Symbol* n);
+  Goal* compile_always_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_sometime_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_at_most_once_constraint(SimpleSequenceGoal* g,
+     const Symbol* n);
+  Goal* compile_sometime_before_constraint(TriggeredSequenceGoal* g,
+        const Symbol* n);
+  void compile_set_conditions_and_effects(ActionSymbol* act);
+  void compile_set_conditions_and_effects(ActionSymbol* act,
+       variable_vec& i_param,
+       variable_vec& d_param,
+       index_type p);
+  Atom* make_binding_atom(VariableSymbol* v);
+  void compile_object_functions(ActionSymbol* act, Symbol* undefined_value);
+  void compile_object_functions_for_validator(ActionSymbol* act);
+  Goal* compile_object_functions(Goal* g);
+  void write_declarations(std::ostream& s);
+  void write_action(std::ostream& s, ActionSymbol* act);
+  void write_set_precondition(std::ostream& s, SetOf* set);
+  void write_disjunctive_set_precondition(std::ostream& s, SetOf* set);
+  void write_set_effect(std::ostream& s, SetOf* set);
+  void write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn);
+  void write_objects(std::ostream& s, bool defined_in_problem);
+  void write_init(std::ostream& s);
+  void write_goal(std::ostream& s);
+  void write_metric(std::ostream& s);
+  void write_dkel_items(std::ostream& s, bool defined_in_problem);
+  void write_domain_begin(std::ostream& s);
+  void write_problem_begin(std::ostream& s);
+  void write_end(std::ostream& s);
+  void write_dkel_domain(std::ostream& s, bool leave_open);
+  void write_dkel_problem(std::ostream& s, bool leave_open);
+  void write_plans(std::ostream& s);
+  void write_heuristic_table(std::ostream& s);
+  void write_sets(std::ostream& s);
+  void print(std::ostream& s);
+};
+class InstanceName : public Name {
+  char* domain_name;
+  char* problem_name;
+ public:
+  InstanceName(char* d, char* p) : domain_name(d), problem_name(p) { };
+  virtual ~InstanceName() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class PDDL_Name : public Name {
+ protected:
+  bool neg;
+  PDDL_Base::Symbol* sym;
+  PDDL_Base::symbol_vec arg;
+  bool vis;
+  bool_vec avis;
+ public:
+  static char catc;
+  static bool obscure_symbol_names;
+  PDDL_Name(PDDL_Base::Symbol* s)
+    : neg(false), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, bool n)
+    : neg(n), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::symbol_vec a, bool n)
+    : neg(n), sym(s), arg(a), vis(true), avis(true, a.length()) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n);
+  void add(PDDL_Base::Symbol* s);
+  void add(PDDL_Base::Symbol* s, bool v);
+  PDDL_Base::Symbol* symbol() { return sym; };
+  PDDL_Base::symbol_vec& args() { return arg; };
+  index_type argc() { return arg.length(); };
+  bool is_neg() { return neg; };
+  virtual ~PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class Numbered_PDDL_Name : public PDDL_Name {
+  index_type copy;
+ public:
+  Numbered_PDDL_Name(PDDL_Base::Symbol* sym, index_type c)
+    : PDDL_Name(sym), copy(c) { };
+  Numbered_PDDL_Name(PDDL_Name* n, index_type c);
+  virtual ~Numbered_PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+};
+}
+namespace hsps {
+void ActionSequence::protect(index_type atom)
+{
+}
+void ActionSequence::insert(index_type act)
+{
+  append(act);
+}
+void ActionSequence::advance(hsps::rational delta)
+{
+}
+void ActionSequence::end()
+{
+}
+void ActionSequence::output(Plan& to)
+{
+  for (index_type k = 0; k < length(); k++) {
+    to.insert((*this)[k]);
+    if (k + 1 < length()) to.advance(1);
+  }
+}
+Plan* ActionSequenceSet::new_plan() {
+  inc_length();
+  (*this)[length() - 1].set_length(0);
+  return &((*this)[length() - 1]);
+}
+void ActionSequenceSet::output(PlanSet& to)
+{
+  for (index_type k = 0; k < length(); k++) {
+    Plan* p = to.new_plan();
+    if (p) {
+      (*this)[k].output(*p);
+    }
+  }
+}
+count_type CountActions::sum()
+{
+  count_type s = 0;
+  for (index_type k = 0; k < length(); k++)
+    s += (*this)[k];
+  return s;
+}
+Plan* CountActions::new_plan()
+{
+  return this;
+}
+void CountActions::protect(index_type atom)
+{
+}
+void CountActions::insert(index_type act)
+{
+  assert(act < length());
+  (*this)[act] += 1;
+}
+void CountActions::advance(hsps::rational delta)
+{
+}
+void CountActions::end()
+{
+}
+void ApxResult::solution(State& s, hsps::rational cost)
+{
+  Result::solution(s, cost);
+  bool max_state = false;
+  for (State* sp = &s; sp && !max_state; sp = sp->predecessor())
+    if (sp->is_max()) max_state = true;
+  if (!max_state) min_sol = true;
+  index_type d = s.depth();
+  if (d > sol_depth) sol_depth = d;
+}
+bool ApxResult::more()
+{
+  return false;
+}
+bool Print::print_noops = false;
+bool Print::decimal_time = true;
+Print::Print(Instance& i, std::ostream& s)
+  : instance(i),
+    to(s),
+    current_t(0),
+    peak_use(0, 0),
+    res_cons(0, 0),
+    n_actions(0),
+    n_plans(0),
+    sum_cost(0)
+{
+}
+Print::~Print()
+{
+}
+Plan* Print::new_plan()
+{
+  n_plans += 1;
+  current_t = 0;
+  peak_use.assign_value(hsps::rational(0));
+  res_cons.assign_value(hsps::rational(0));
+  n_actions = 0;
+  to << "plan:" << std::endl;
+  return this;
+}
+void Print::protect(index_type atom) {
+  if (print_noops) {
+    to << " " << current_t << ": noop"
+       << instance.atoms[atom].name
+       << " (#" << atom << ")" << std::endl;
+  }
+}
+void Print::insert(index_type act) {
+  if (decimal_time) {
+    hsps::rational end_t = current_t + instance.actions[act].dur;
+    to << " [" << current_t.decimal() << "," << end_t.decimal() << "]";
+  }
+  else {
+    to << " [" << current_t << ","
+       << current_t + instance.actions[act].dur << "]";
+  }
+  to << instance.actions[act].name << " (#" << act << ")" << std::endl;
+  for (index_type k = 0; k < instance.n_resources(); k++)
+    res_cons[k] += instance.actions[act].cons[k];
+  n_actions += 1;
+  sum_cost += instance.actions[act].cost;
+}
+void Print::advance(hsps::rational delta)
+{
+  current_t += delta;
+}
+void Print::end()
+{
+  if (decimal_time) {
+    to << "makespan: " << current_t.decimal();
+  }
+  else {
+    to << "makespan: " << current_t;
+  }
+  to << ", " << n_actions << " actions" << std::endl;
+  if (instance.n_resources() > 0) {
+    to << "resources consumed:";
+    for (index_type k = 0; k < instance.n_resources(); k++) {
+      to << " " << instance.resources[k].name << "=" << res_cons[k];
+    }
+    to << std::endl;
+  }
+}
+PrintActions::PrintActions(Instance& i, std::ostream& s)
+  : instance(i), to(s),
+    action_sep('\n'), first_action(true),
+    plan_sep('\n'), first_plan(true)
+{
+}
+PrintActions::PrintActions(Instance& i, std::ostream& s, char as)
+  : instance(i), to(s),
+    action_sep(as), first_action(true),
+    plan_sep('\n'), first_plan(true)
+{
+}
+PrintActions::PrintActions(Instance& i, std::ostream& s, char as, char ps)
+  : instance(i), to(s),
+    action_sep(as), first_action(true),
+    plan_sep(ps), first_plan(true)
+{
+}
+PrintActions::~PrintActions()
+{
+}
+Plan* PrintActions::new_plan()
+{
+  if (!first_plan) to << plan_sep;
+  first_plan = false;
+  first_action = true;
+  return this;
+}
+void PrintActions::protect(index_type atom)
+{
+}
+void PrintActions::insert(index_type act)
+{
+  if (!first_action) to << action_sep;
+  instance.actions[act].name->write(to, Name::NC_PLAN);
+  first_action = false;
+}
+void PrintActions::advance(hsps::rational delta)
+{
+}
+void PrintActions::end()
+{
+}
+void PrintActionSetNames::insert(index_type act)
+{
+  if (!first_action) to << action_sep;
+  if (instance.actions[act].src) {
+    ptr_pair* p = (ptr_pair*)instance.actions[act].src;
+    PDDL_Base::ActionSymbol* a = (PDDL_Base::ActionSymbol*)p->first;
+    if (a->part) {
+      ptr_table* ai = (ptr_table*)p->second;
+      ptr_table::key_vec* args = ai->key_sequence();
+      for (index_type k = 0; k < a->param.length(); k++)
+ a->param[k]->value = (PDDL_Base::Symbol*)((*args)[k + 1]);
+      delete args;
+      a->part->print_instance(to);
+    }
+    else {
+      instance.actions[act].name->write(to, Name::NC_PLAN);
+    }
+  }
+  else {
+    instance.actions[act].name->write(to, Name::NC_PLAN);
+  }
+  first_action = false;
+}
+PrintPDDL::PrintPDDL(Instance& i, std::ostream& s)
+  : instance(i), to(s), start_t(0)
+{
+}
+PrintPDDL::~PrintPDDL()
+{
+}
+Plan* PrintPDDL::new_plan()
+{
+  start_t = 0;
+  to << "(:plan";
+  return this;
+}
+void PrintPDDL::protect(index_type atom)
+{
+}
+void PrintPDDL::insert(index_type act)
+{
+  to << std::endl << "  " << std::resetiosflags(std::ios::scientific) << ((start_t).decimal())
+     << " : ";
+  instance.actions[act].name->write(to, Name::NC_PLAN | Name::NC_PDDL);
+}
+void PrintPDDL::advance(hsps::rational delta)
+{
+  start_t += delta;
+}
+void PrintPDDL::end()
+{
+  to << ")" << std::endl;
+}
+PrintIPC::PrintIPC(Instance& i, std::ostream& s)
+  : instance(i),
+    to(s),
+    temporal(false),
+    epsilon(0),
+    included_epsilon(false),
+    strict_separation(false),
+    start_t(0),
+    occ_current_t(false)
+{
+}
+PrintIPC::~PrintIPC()
+{
+}
+void PrintIPC::set_epsilon(hsps::rational e, bool included, bool strict)
+{
+  temporal = true;
+  epsilon = e;
+  included_epsilon = included;
+  strict_separation = strict;
+}
+Plan* PrintIPC::new_plan()
+{
+  start_t = 0;
+  occ_current_t = false;
+  return this;
+}
+void PrintIPC::protect(index_type atom)
+{
+}
+void PrintIPC::insert(index_type act)
+{
+  if (temporal && strict_separation) {
+    if (occ_current_t) {
+      start_t += epsilon;
+    }
+    else {
+      occ_current_t = true;
+    }
+  }
+  to << std::resetiosflags(std::ios::scientific) << ((start_t).decimal()) << " : ";
+  instance.actions[act].name->write(to, Name::NC_PLAN | Name::NC_IPC);
+  if (temporal) {
+    if (included_epsilon) {
+      hsps::rational d = instance.actions[act].dur;
+      d -= epsilon;
+      to << " [" << std::resetiosflags(std::ios::scientific) << ((d).decimal()) << "]";
+    }
+    else {
+      to << " [" << std::resetiosflags(std::ios::scientific) << ((instance.actions[act].dur).decimal()) << "]";
+    }
+  }
+  else {
+    to << " [1]";
+  }
+  to << std::endl;
+}
+void PrintIPC::advance(hsps::rational delta)
+{
+  start_t += delta;
+  if (!included_epsilon) start_t += epsilon;
+  occ_current_t = false;
+}
+void PrintIPC::end()
+{
+}
+PrintAssoc::PrintAssoc(Instance& i, std::ostream& s)
+  : instance(i), to(s)
+{
+}
+PrintAssoc::~PrintAssoc()
+{
+}
+void PrintAssoc::protect(index_type atom)
+{
+}
+void PrintAssoc::insert(index_type act)
+{
+  if (act > instance.n_actions()) {
+    std::cerr << "error: undefined action " << act << " in plan" << std::endl;
+    exit(255);
+  }
+  if (instance.actions[act].assoc) {
+    to << instance.actions[act].assoc;
+  }
+}
+void PrintAssoc::advance(hsps::rational delta)
+{
+}
+void PrintAssoc::end()
+{
+}
+Store::Store(Instance& i)
+  : ScheduleSet(i)
+{
+}
+Store::~Store()
+{
+  clear();
+}
+void Store::reset()
+{
+  clear();
+  Result::reset();
+}
+void Store::clear()
+{
+  for (index_type k = 0; k < solutions.length(); k++)
+    if (solutions[k]) solutions[k]->delete_path();
+  solutions.clear();
+  ScheduleSet::clear();
+  Result::reset();
+}
+void Store::solution(State& s, hsps::rational cost)
+{
+  Result::solution(s, cost);
+  solutions.append(s.copy_path());
+  Schedule* new_plan = new Schedule(instance);
+  s.insert_path(*new_plan);
+  new_plan->end();
+  append(new_plan);
+}
+void StoreFilter::no_more_solutions(hsps::rational cost)
+{
+  store.no_more_solutions(cost);
+}
+bool StoreFilter::more()
+{
+  return store.more();
+}
+void StoreMinCost::solution(State& s, hsps::rational cost)
+{
+  hsps::rational c_min = POS_INF;
+  for (index_type k = 0; k < store.n_solutions(); k++) {
+    if (store.solution(k)->acc_cost() < cost) return;
+    c_min = hsps::rational::min(c_min,store.solution(k)->acc_cost());
+  }
+  if (cost < c_min) {
+    store.clear();
+    store.solution(s, cost);
+  }
+  else if (cost == c_min) {
+    store.solution(s, cost);
+  }
+}
+count_type StoreDistinct::n_discarded = 0;
+void StoreDistinct::solution(State& s, hsps::rational cost)
+{
+  Schedule* new_plan = new Schedule(instance);
+  s.insert_path(*new_plan);
+  new_plan->end();
+  for (index_type k = 0; k < store.n_plans(); k++) {
+    if (store.plan(k)->equivalent(*new_plan)) {
+      delete new_plan;
+      n_discarded += 1;
+      std::cerr << store.n_solutions() << " solutions kept, "
+  << n_discarded << " discarded" << std::endl;
+      return;
+    }
+  }
+  delete new_plan;
+  store.solution(s, cost);
+  std::cerr << store.n_solutions() << " solutions kept, "
+     << n_discarded << " discarded" << std::endl;
+}
+State* Store::solution(index_type k)
+{
+  if (k < solutions.length()) return solutions[k];
+  else return 0;
+}
+Schedule* Store::plan(index_type k)
+{
+  if (k < length()) return (*this)[k];
+  else return 0;
+}
+void Store::output(PlanSet& to)
+{
+  ScheduleSet::output(to);
+}
+void Store::output(Result& to)
+{
+  for (index_type k = 0; k < solutions.length(); k++) {
+    to.solution(*solutions[k], solutions[k]->acc_cost());
+  }
+  to.no_more_solutions(POS_INF);
+}
+Conflicts::Conflicts(Instance& ins)
+  : instance(ins),
+    nec_del(EMPTYSET),
+    pos_del(EMPTYSET),
+    min_peak(0, 0),
+    max_peak(0, 0),
+    first(true),
+    need_to_clear(false)
+{
+}
+Conflicts::~Conflicts()
+{
+}
+void Conflicts::clear()
+{
+  nec_del.clear();
+  pos_del.clear();
+  min_peak.assign_value(0);
+  max_peak.assign_value(0);
+  first = true;
+  need_to_clear = false;
+}
+void Conflicts::solution(State& s, hsps::rational cost)
+{
+  Result::solution(s, cost);
+  if (need_to_clear) clear();
+  Schedule* plan = new Schedule(instance);
+  plan->set_trace_level(0);
+  s.insert_path(*plan);
+  plan->end();
+  const Schedule::step_vec& seq = plan->plan_steps();
+  index_set del;
+  for (index_type k = 0; k < seq.length(); k++) {
+    del.insert(instance.actions[seq[k].act].del);
+  }
+  if (first) {
+    nec_del = del;
+  }
+  else {
+    nec_del.intersect(del);
+  }
+  pos_del.insert(del);
+  ExecTrace* trace = new ExecTrace(instance);
+  plan->simulate(trace);
+  amt_vec peak(0, instance.n_resources());
+  trace->peak_resource_use(peak);
+  if (first) {
+    for (index_type k = 0; k < instance.n_resources(); k++) {
+      min_peak[k] = peak[k];
+      max_peak[k] = peak[k];
+    }
+  }
+  else {
+    for (index_type k = 0; k < instance.n_resources(); k++) {
+      min_peak[k] = hsps::rational::min(min_peak[k],peak[k]);
+      max_peak[k] = hsps::rational::max(max_peak[k],peak[k]);
+    }
+  }
+  first = false;
+}
+void Conflicts::no_more_solutions()
+{
+  need_to_clear = true;
+  first = true;
+}
+}

--- a/pr/seq-opt-hspsf/preprocess.ccx
+++ b/pr/seq-opt-hspsf/preprocess.ccx
@@ -1,0 +1,6763 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+void sort2(index_type& i, index_type& j);
+void sort3(index_type& i, index_type& j, index_type& l);
+class PairIndexFunction : index_vec {
+ public:
+  PairIndexFunction(index_type n);
+  ~PairIndexFunction();
+  index_type operator()(index_type i, index_type j) const;
+  index_type max_in() const;
+  index_type max_out() const;
+};
+class CostNode {
+ public:
+  struct Value {
+    hsps::rational val;
+    bool opt;
+    CostNode* next;
+    bool mark;
+    count_type work;
+    Value() : val(0), opt(false), next(0), mark(false), work(0) { };
+    Value(hsps::rational v, bool o) : val(v), opt(o), next(0), mark(false), work(0) { };
+    Value& operator=(const Value& v)
+    { val = v.val; opt = v.opt; return *this; };
+    Value& operator=(hsps::rational v) { val = v; return *this; };
+    bool operator==(const Value& v) { return (val == v.val); };
+    bool operator<(const Value& v) { return (val < v.val); };
+    bool operator<=(const Value& v) { return (val <= v.val); };
+    bool operator>(const Value& v) { return (val > v.val); };
+    bool operator>=(const Value& v) { return (val >= v.val); };
+    bool operator==(const hsps::rational v) { return (val == v); };
+    bool operator<(const hsps::rational v) { return (val < v); };
+    bool operator<=(const hsps::rational v) { return (val <= v); };
+    bool operator>(const hsps::rational v) { return (val > v); };
+    bool operator>=(const hsps::rational v) { return (val >= v); };
+    void clear() {
+      val = 0;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+    void clear(hsps::rational v_default) {
+      val = v_default;
+      opt = false;
+      next = 0;
+      mark = false;
+      work = 0;
+    };
+  };
+ private:
+  index_type _size;
+  index_type _depth;
+  index_type _first;
+  hsps::rational _default;
+  hsps::rational _max;
+  Value* _store;
+  CostNode* _prev;
+  CostNode(CostNode* p, index_type f);
+  hsps::rational eval(const index_set& s, index_type i);
+  hsps::rational eval(const bool_vec& s, index_type i);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, index_type i, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, index_type i, hsps::rational bound);
+  void find_all(const index_set& s, index_type i, const index_set& c,
+   index_set_vec& a);
+  void set_max(hsps::rational v);
+  void write(std::ostream& s, index_set q) const;
+  void write_pddl(std::ostream& s, Instance& ins, index_set q) const;
+ public:
+  static bool eval_set_mark;
+  CostNode(index_type size);
+  CostNode(index_type size, hsps::rational v_default);
+  ~CostNode();
+  index_type size() const { return _size; };
+  index_type depth() const { return _depth; };
+  index_type first() const { return _first; };
+  index_type last() const { return _size - 1; };
+  Value& val(index_type p);
+  const Value& val(index_type p) const;
+  hsps::rational max() const { return _max; };
+  hsps::rational max_finite() const;
+  CostNode& next(index_type p);
+  Value* val_p(index_type p);
+  CostNode* next_p(index_type p);
+  Value* find(const index_set& s);
+  Value* find(const bool_vec& s);
+  void find_all(const index_set& s, index_set_vec& a);
+  Value& insert(const index_set& s);
+  Value& insert(const bool_vec& s);
+  void store(index_type p, hsps::rational v, bool opt);
+  void store(index_type p, hsps::rational v);
+  hsps::rational eval(const index_set& s);
+  hsps::rational eval(const bool_vec& s);
+  hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  void store(const index_set& s, hsps::rational v, bool opt);
+  void store(const bool_vec& s, hsps::rational v, bool opt);
+  void store(const index_set& s, hsps::rational v);
+  void store(const bool_vec& s, hsps::rational v);
+  hsps::rational eval_min(const index_set& s);
+  void compute_max();
+  void clear_marks();
+  void clear();
+  void write(std::ostream& s) const;
+  void write_pddl(std::ostream& s, Instance& ins) const;
+};
+class CostTable : public Heuristic, public CostNode {
+ public:
+  class Entry {
+  public:
+    index_set set;
+    CostNode::Value& val;
+    Entry* prev;
+    Entry* next;
+    Entry(index_set s, CostNode::Value& v)
+      : set(s), val(v), prev(0), next(0) { };
+    Entry& operator=(const Entry& e);
+    bool operator==(const Entry& e) { return set == e.set; };
+    bool operator<(const Entry& e) { return val < e.val; };
+    bool operator<=(const Entry& e) { return val <= e.val; };
+    bool operator>(const Entry& e) { return val > e.val; };
+    bool operator>=(const Entry& e) { return val >= e.val; };
+    Entry* first();
+    Entry* last();
+    Entry* move_down();
+    Entry* move_up();
+    void unlink();
+    void place_before(Entry* p);
+    void place_after(Entry* p);
+    void delete_list();
+    count_type list_length();
+  };
+ private:
+  Statistics& stats;
+  hsps::rational* pre_cost;
+  hsps::rational* per_cost;
+  bool update(index_type i, hsps::rational v, bool_vec& f);
+  bool update(index_type i, hsps::rational v);
+  bool update(index_type i, index_type j, hsps::rational v);
+  bool update(index_type i, index_type j, index_type l, hsps::rational v);
+  Entry* entries(CostNode* n, index_set s, Entry* l,
+   const index_set* filter, bool ign_zero, bool ign_opt,
+   bool ign_inf, bool req_mark, bool sort);
+  count_type count_entries(CostNode* n, index_set s, bool ign_zero,
+      bool ign_opt, bool ign_inf);
+  void fill(index_set& s, index_type d);
+  Entry* create_new_entries(const index_set& set,
+       const index_set& conflict_set,
+       const index_set& cd_ignore,
+       CostTable::Entry* list);
+  void compute_hm_graph_min
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+  void compute_hm_graph_max
+    (const ACF& cost, const index_set& s, index_set_graph& g);
+ public:
+  static bool strong_conflict_detection;
+  static bool ultra_weak_conflict_detection;
+  static bool boost_new_entries;
+  static count_type n_entries_boosted;
+  static count_type n_entries_solved;
+  static count_type n_entries_discarded;
+  static count_type n_entries_created;
+  static count_type n_boost_searches;
+  static count_type n_boost_searches_with_cd;
+  CostTable(Instance& i, Statistics& s);
+  CostTable(Instance& i, Statistics& s, hsps::rational v_default);
+  ~CostTable();
+  virtual hsps::rational eval(index_type i);
+  virtual hsps::rational eval(index_type i, index_type j);
+  virtual hsps::rational eval(index_type i, index_type j, index_type k);
+  virtual hsps::rational eval(const index_set& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational eval(const bool_vec& s)
+    { return CostNode::eval(s); };
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new)
+    { return CostNode::incremental_eval(s, i_new); };
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound)
+    { return CostNode::eval_to_bound(s, bound); };
+  virtual void store(const index_set& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt)
+    { CostNode::store(s, v, opt); };
+  virtual void store(const index_set& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  virtual void store(const bool_vec& s, hsps::rational v)
+    { CostNode::store(s, v); };
+  void store_list(Entry* l);
+  static Entry* insert_entry(Entry* e, Entry* l);
+  static Entry* prepend_entry(Entry* e, Entry* l);
+  static Entry* remove_entry(Entry* e, Entry* l);
+  static Entry* find_entry(index_set& s, Entry* l);
+  static Entry* copy_list(Entry* l);
+  count_type write_list(std::ostream& s, Entry* l);
+  bool interesting(const index_set& s);
+  Entry* atoms();
+  Entry* pairs();
+  Entry* entries();
+  Entry* entries(bool ign_zero, bool ign_opt, bool ign_inf, bool req_mark);
+  Entry* entries(const index_set& s);
+  Entry* unsorted_entries(bool ign_zero, bool ign_opt, bool ign_inf,
+     bool req_mark);
+  Entry* boostable_entries();
+  Entry* boostable_entries(const index_set& s);
+  Entry* boost_cd_entries();
+  Entry* marked_entries(bool ign_nb);
+  count_type count_entries(bool ign_zero, bool ign_opt, bool ign_inf);
+  hsps::rational action_pre_cost(index_type i);
+  hsps::rational action_per_cost(index_type i);
+  bool compatible(index_type a, index_type b, bool opt_resources) const;
+  void compute_H1(const ACF& cost);
+  void compute_H1(const ACF& cost, const bool_vec& init);
+  void compute_H1max(const ACF& cost, const bool_vec& init);
+  void compute_H2(const ACF& cost);
+  void compute_H2(const ACF& cost, const bool_vec& init);
+  void compute_H3(const ACF& cost);
+  void compute_H2C(const ACF& cost, bool opt_resources);
+  void verify_H2C(const ACF& cost, bool opt_resources, bool opt_verbose);
+  void compute_action_cost();
+  void fill(index_type to_depth);
+  void clear();
+  void closure(const ACF& cost);
+  void closure(const ACF& cost, const index_set& nd);
+  void compute_hm_graph(const ACF& cost, const index_set& s,
+   index_set_graph& g);
+};
+class LinearScanH2Eval : public CostTable {
+  index_type n_pairs;
+  index_pair* pairs;
+  hsps::rational* values;
+  bool complete;
+ public:
+  LinearScanH2Eval(Instance& i, Statistics& s);
+  ~LinearScanH2Eval();
+  void compile_finite();
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH1 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH1(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH1();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class ForwardH2 : public Heuristic {
+  index_set goals;
+  const ACF& cost;
+  CostTable* table;
+ public:
+  ForwardH2(Instance& i, const index_set& g, const ACF& c, Statistics& s);
+  virtual ~ForwardH2();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+inline void sort2(index_type& i, index_type& j)
+{
+  if (i > j) {
+    index_type t = i;
+    i = j;
+    j = t;
+  }
+}
+inline void sort3(index_type& i, index_type& j, index_type& l)
+{
+  sort2(i, l);
+  sort2(i, j);
+  sort2(j, l);
+}
+inline CostNode::Value& CostNode::val(index_type p)
+{
+  return _store[p];
+}
+inline const CostNode::Value& CostNode::val(index_type p) const
+{
+  return _store[p];
+}
+inline CostNode::Value* CostNode::val_p(index_type p)
+{
+  return &(_store[p]);
+}
+inline CostNode& CostNode::next(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return *(_store[p].next);
+}
+inline CostNode* CostNode::next_p(index_type p)
+{
+  if (!_store[p].next) _store[p].next = new CostNode(this, p + 1);
+  return _store[p].next;
+}
+inline CostTable::Entry& CostTable::Entry::operator=(const Entry& e)
+{
+  set = e.set;
+  val = e.val;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode::Value& v)
+{
+  s << std::resetiosflags(std::ios::scientific) << ((v.val).decimal());
+  if (v.opt) s << '*';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostNode& t)
+{
+  t.write(s);
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const CostTable::Entry& e)
+{
+  if (e.set.length() > 0) {
+    s << "{" << e.set[0];
+    for (index_type k = 1; k < e.set.length(); k++) s << ',' << e.set[k];
+    s << "}:" << e.val;
+  }
+  else {
+    s << "{}:" << e.val;
+  }
+  return s;
+}
+}
+namespace hsps {
+class Preprocessor {
+ public:
+  Instance& instance;
+  index_vec atom_map;
+  index_vec action_map;
+  index_vec inv_map;
+ protected:
+  Statistics& stats;
+  CostTable* inc_relation;
+  graph* inc_graph;
+  bool make_invariant(index_type init_atom,
+        index_set& inv_set,
+        bool& exact,
+        index_set& branch_set);
+  void analyze_branch_set(const index_set& branch_set,
+     const index_set& inv_set,
+     index_set& effective);
+  void dfs_find_invariants(index_type init_atom,
+      const index_set& base_set,
+      const index_set& branch_set,
+      index_type branch_depth,
+      index_type max_branch_depth);
+  void extend_LsC1_relevance(const index_set& check,
+        const graph& lmg,
+        const bool_vec& p_act,
+        const bool_vec& p_add,
+        bool_vec& rel_atms,
+        bool_vec& rel_acts);
+ public:
+  static int default_trace_level;
+  int trace_level;
+  Preprocessor(Instance& ins, Statistics& s);
+  ~Preprocessor();
+  void compute_reachability(bool_vec& reachable_atoms,
+       bool_vec& reachable_actions,
+       bool opt_H2 = false);
+  void compute_static_atoms(const bool_vec& reachable_actions,
+       bool_vec& static_atoms);
+  void compute_relevance(const index_set& check,
+    bool_vec& r_atm,
+    bool_vec& r_act);
+  void compute_relevance(const index_set& check,
+    index_type d_check,
+    index_vec& d_atm,
+    index_vec& d_act);
+  void between(index_type p,
+        index_type q,
+        const graph& lmg,
+        bool_vec& b_atm,
+        bool_vec& b_act);
+  void compute_L1C1_relevance(const index_set& check,
+         index_type d_check,
+         const graph& lmg,
+         index_vec& d_atm,
+         index_vec& d_act);
+  void compute_L1C1_relevance(const index_set& check,
+         const graph& lmg,
+         bool_vec& rel_atms,
+         bool_vec& rel_acts);
+  void compute_LsC1_relevance(const index_set& check,
+         const graph& lmg,
+         bool_vec& rel_atms,
+         bool_vec& rel_acts);
+  void compute_relaxed_relevance(const index_set& g,
+     index_vec& path,
+     const index_set& pre,
+     bool_vec& rel_acts);
+  void strictly_relevant_actions(index_type p,
+     Heuristic& h,
+     const ACF& f,
+     bool_vec& rel);
+  void strictly_relevant_actions(index_type p,
+     hsps::rational c,
+     Heuristic& h,
+     const ACF& f,
+     bool_vec& rel);
+  void relevant_at_cost(index_type p,
+   hsps::rational c,
+   Heuristic& h,
+   const ACF& f,
+   bool_vec& r_atoms,
+   bool_vec& r_actions);
+  void relevant_at_cost(const index_set& s,
+   hsps::rational c,
+   Heuristic& h,
+   const ACF& f,
+   bool_vec& r_atoms,
+   bool_vec& r_actions);
+  CostTable* inconsistency();
+  graph* inconsistency_graph();
+  bool inconsistent(index_type p, index_type q, Heuristic& inc);
+  bool consistent(index_type p, index_type q, Heuristic& inc);
+  bool inconsistent(const index_set& s, index_type p, Heuristic& inc);
+  bool consistent(const index_set& s, index_type p, Heuristic& inc);
+  bool inconsistent(index_type p, index_type q);
+  bool consistent(index_type p, index_type q);
+  bool inconsistent(const index_set& s);
+  bool consistent(const index_set& s);
+  bool inconsistent(const index_set& s, index_type p);
+  bool consistent(const index_set& s, index_type p);
+  bool inconsistent(const index_set& s0, const index_set& s1);
+  bool consistent(const index_set& s0, const index_set& s1);
+  bool implies(index_type p, index_type q, Heuristic& inc);
+  bool implies(const index_set& s, index_type q, Heuristic& inc);
+  bool implies(index_type p, index_type q);
+  bool implies(const index_set& s, index_type q);
+  void implied_atom_set(const index_set& s, index_set& is, Heuristic& inc);
+  bool landmark_test(const index_set& init,
+       const index_set& goal,
+       index_type p,
+       bool opt_H2 = false);
+  void compute_landmarks(const index_set& init,
+    const index_set& goal,
+    index_set& landmark_atoms);
+  void compute_landmarks(bool exclude_goal,
+    bool exclude_init,
+    bool_vec& landmark_atoms);
+  void compute_landmarks(bool exclude_goal,
+    bool exclude_init,
+    index_set& landmark_atoms);
+  void quick_landmark_graph(graph& g, bool opt_H2 = false);
+  void compute_landmark_graph(graph& g, bool opt_H2 = false);
+  void compute_hierarchy(index_set_graph& g);
+  void compute_hierarchy(graph& g0, index_set_graph& g);
+  void necessary_completions_for_safeness(index_set& atoms_missing_negation);
+  void compute_irrelevant_atoms();
+  void dfs_find_invariants(index_type max_branch_depth);
+  void bfs_find_invariants();
+  void find_inconsistent_set_invariants(graph& inc);
+  void find_maximal_inconsistent_set_invariants(graph& inc);
+  void find_binary_iff_invariants(bool opt_weak_verify);
+  bool verify_invariant(Instance::Constraint& inv, Heuristic& inc);
+  bool verify_invariants(Heuristic& inc);
+  void compute_ncw_sets(Heuristic& inc);
+  void compute_ncw_sets();
+  void preprocess(bool opt_H2 = false);
+  void remove_irrelevant_atoms();
+  void remove_unverified_invariants();
+  void remove_useless_actions();
+  void remove_useless_invariants();
+  void remove_redundant_preconditions();
+  void eliminate_strictly_determined_atoms();
+  void make_safe();
+  void apply_place_replication();
+  void write_heuristic_graph(std::ostream& s,
+        Heuristic& h,
+        const ACF& cost,
+        const bool_vec& atoms,
+        const bool_vec& actions);
+  void write_heuristic_graph(std::ostream& s,
+        Heuristic& h,
+        const ACF& cost);
+  void write_relevance_graph(std::ostream& s,
+        const index_vec& d_atm,
+        const index_vec& d_act,
+        const char* label);
+  void write_relevance_graph(std::ostream& s,
+        const index_vec& d_atm,
+        const index_vec& d_act,
+        const bool_vec& mark_atm,
+        const bool_vec& mark_act,
+        const char* label);
+  bool find_inverse_actions(const Instance::Action& act, Heuristic& inc,
+       index_set& inverses);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+#include <list>
+namespace hsps {
+int Preprocessor::default_trace_level = 0;
+Preprocessor::Preprocessor(Instance& ins, Statistics& s)
+  : instance(ins),
+    atom_map(no_such_index, 0),
+    action_map(no_such_index, 0),
+    inv_map(no_such_index, 0),
+    stats(s),
+    inc_relation(0),
+    inc_graph(0),
+    trace_level(default_trace_level)
+{
+  atom_map.set_length(instance.n_atoms());
+  for (index_type k = 0; k < instance.n_atoms(); k++) atom_map[k] = k;
+  action_map.set_length(instance.n_actions());
+  for (index_type k = 0; k < instance.n_actions(); k++) action_map[k] = k;
+  inv_map.set_length(instance.n_invariants());
+  for (index_type k = 0; k < instance.n_invariants(); k++) inv_map[k] = k;
+}
+Preprocessor::~Preprocessor()
+{
+}
+CostTable* Preprocessor::inconsistency()
+{
+  if (inc_relation != 0) {
+    if (inc_relation->size() != instance.n_atoms()) {
+      if (trace_level > 0) {
+ std::cerr << "inconsistency relation invalidated by changes to instance..." << std::endl;
+      }
+      delete inc_relation;
+      inc_relation = 0;
+    }
+  }
+  if (inc_relation == 0) {
+    stats.start();
+    if (!instance.cross_referenced()) {
+      if (trace_level > 0) {
+ std::cerr << "cross referencing..." << std::endl;
+      }
+      instance.cross_reference();
+    }
+    if (trace_level > 0) {
+      std::cerr << "computing inconsistency relation..." << std::endl;
+    }
+    inc_relation = new CostTable(instance, stats);
+    inc_relation->compute_H2(ZeroACF());
+    if (trace_level > 0) {
+      std::cerr << "constructing inconsisteny graph..." << std::endl;
+    }
+    inc_graph = new graph(instance.n_atoms());
+    for (index_type i = 0; i < instance.n_atoms(); i++)
+      for (index_type j = i+1; j < instance.n_atoms(); j++)
+ if ((inc_relation->eval(i, j)).infinite())
+   inc_graph->add_undirected_edge(i, j);
+    stats.stop();
+  }
+  return inc_relation;
+}
+graph* Preprocessor::inconsistency_graph()
+{
+  if (inc_graph == 0) {
+    inconsistency();
+  }
+  return inc_graph;
+}
+void Preprocessor::compute_reachability
+(bool_vec& reachable_atoms, bool_vec& reachable_actions, bool opt_H2)
+{
+  CostTable reachable(instance, stats);
+  if (opt_H2) {
+    reachable.compute_H2(ZeroACF());
+  }
+  else {
+    reachable.compute_H1(ZeroACF());
+  }
+  reachable_atoms.set_length(instance.atoms.length());
+  for (index_type k = 0; k < instance.atoms.length(); k++) {
+    hsps::rational c = reachable.eval(k);
+    if (!(c).finite()) reachable_atoms[k] = false;
+    else reachable_atoms[k] = true;
+  }
+  reachable_actions.set_length(instance.actions.length());
+  for (index_type k = 0; k < instance.actions.length(); k++) {
+    hsps::rational c = reachable.eval(instance.actions[k].pre);
+    if (!(c).finite()) reachable_actions[k] = false;
+    else reachable_actions[k] = true;
+  }
+}
+void Preprocessor::compute_static_atoms
+(const bool_vec& reachable_actions, bool_vec& static_atoms)
+{
+  static_atoms.set_length(instance.atoms.length());
+  for (index_type k = 0; k < instance.atoms.length(); k++)
+    static_atoms[k] = instance.atoms[k].init;
+  for (index_type k = 0; k < instance.actions.length(); k++) if (reachable_actions[k]) {
+    for (index_type i = 0; i < instance.actions[k].del.length(); i++)
+      static_atoms[instance.actions[k].del[i]] = false;
+    for (index_type i = 0; i < instance.actions[k].lck.length(); i++)
+      static_atoms[instance.actions[k].lck[i]] = false;
+  }
+}
+void Preprocessor::compute_ncw_sets()
+{
+  stats.start();
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    instance.actions[k].ncw_atms.clear();
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    for (index_type i = 0; i < instance.n_atoms(); i++) {
+      bool ce = false;
+      for (index_type j = 0; (j < instance.atoms[i].add_by.length()) && !ce; j++) {
+ if (stats.break_signal_raised()) return;
+ if (instance.non_interfering(k, instance.atoms[i].add_by[j]) &&
+     instance.lock_compatible(k, instance.atoms[i].add_by[j]))
+   ce = true;
+      }
+      if (!ce) instance.actions[k].ncw_atms.insert(i);
+    }
+  stats.stop();
+}
+void Preprocessor::compute_ncw_sets(Heuristic& inc)
+{
+  stats.start();
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    instance.actions[k].ncw_atms.clear();
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    for (index_type i = 0; i < instance.n_atoms(); i++) {
+      bool ce = false;
+      for (index_type j = 0; (j < instance.atoms[i].add_by.length()) && !ce; j++) {
+ if (stats.break_signal_raised()) return;
+ if (instance.non_interfering(k, instance.atoms[i].add_by[j]) &&
+     instance.lock_compatible(k, instance.atoms[i].add_by[j])) {
+   index_set p(instance.actions[k].pre);
+   p.insert(instance.actions[instance.atoms[i].add_by[j]].pre);
+   if ((inc.eval(p)).finite()) ce = true;
+ }
+      }
+      if (!ce) instance.actions[k].ncw_atms.insert(i);
+    }
+  stats.stop();
+}
+void Preprocessor::compute_relevance
+(const index_set& check,
+ index_type d_check,
+ index_vec& d_atm,
+ index_vec& d_act)
+{
+  for (index_type k = 0; k < check.length(); k++)
+    if (d_atm[check[k]] > d_check) {
+      d_atm[check[k]] = d_check;
+      for (index_type i = 0; i < instance.atoms[check[k]].add_by.length(); i++)
+ if (d_act[instance.atoms[check[k]].add_by[i]] > d_check) {
+   d_act[instance.atoms[check[k]].add_by[i]] = d_check;
+   compute_relevance(instance.actions[instance.atoms[check[k]].add_by[i]].pre, d_check + 1, d_atm, d_act);
+ }
+    }
+}
+void Preprocessor::compute_relevance
+(const index_set& check, bool_vec& r_atm, bool_vec& r_act)
+{
+  for (index_type k = 0; k < check.length(); k++)
+    if (!r_atm[check[k]]) {
+      r_atm[check[k]] = true;
+      for (index_type i = 0; i < instance.atoms[check[k]].add_by.length(); i++)
+ if (!r_act[instance.atoms[check[k]].add_by[i]]) {
+   r_act[instance.atoms[check[k]].add_by[i]] = true;
+   compute_relevance(instance.actions[instance.atoms[check[k]].add_by[i]].pre, r_atm, r_act);
+ }
+    }
+}
+void Preprocessor::between
+(index_type p,
+ index_type q,
+ const graph& lmg,
+ bool_vec& b_atm,
+ bool_vec& b_act)
+{
+  if (!b_atm[q]) {
+    b_atm[q] = true;
+    for (index_type i = 0; i < instance.atoms[q].add_by.length(); i++)
+      if (!b_act[instance.atoms[q].add_by[i]]) {
+ b_act[instance.atoms[q].add_by[i]] = true;
+ for (index_type j = 0; j < instance.actions[instance.atoms[q].add_by[i]].pre.length(); j++)
+   if ((instance.actions[instance.atoms[q].add_by[i]].pre[j] != p) &&
+       lmg.adjacent(p, instance.actions[instance.atoms[q].add_by[i]].pre[j]))
+     between(p, instance.actions[instance.atoms[q].add_by[i]].pre[j], lmg, b_atm, b_act);
+      }
+  }
+}
+void Preprocessor::compute_L1C1_relevance
+(const index_set& check,
+ index_type d_check,
+ const graph& lmg,
+ index_vec& d_atm,
+ index_vec& d_act)
+{
+  for (index_type k = 0; k < check.length(); k++)
+    if (d_atm[check[k]] > d_check) {
+      Instance::Atom& atm = instance.atoms[check[k]];
+      d_atm[atm.index] = d_check;
+      if (trace_level > 1) {
+ std::cerr << "atom " << atm.name << " is relevant" << std::endl;
+ if (atm.goal) {
+   std::cerr << " - it is a goal" << std::endl;
+ }
+ for (index_type i = 0; i < atm.req_by.length(); i++)
+   if (d_act[atm.req_by[i]] != no_such_index) {
+     std::cerr << " - it is a precondition of relevant action "
+        << instance.actions[atm.req_by[i]].name
+        << std::endl;
+   }
+      }
+      for (index_type i = 0; i < atm.add_by.length(); i++) {
+        Instance::Action& act = instance.actions[atm.add_by[i]];
+ if (d_act[act.index] > d_check) {
+   bool ok = true;
+   for (index_type j = 0; (j < act.pre.length()) && ok; j++)
+     if (lmg.adjacent(atm.index, act.pre[j]))
+       ok = false;
+   if (ok) {
+     if (trace_level > 1) {
+       std::cerr << act.name << " is an L1(C1)-relevant establisher of "
+   << atm.name << std::endl;
+     }
+     d_act[act.index] = d_check;
+     compute_L1C1_relevance(act.pre, d_check + 1, lmg, d_atm, d_act);
+   }
+ }
+      }
+    }
+}
+void Preprocessor::compute_L1C1_relevance
+(const index_set& check,
+ const graph& lmg,
+ bool_vec& r_atm,
+ bool_vec& r_act)
+{
+  for (index_type k = 0; k < check.length(); k++)
+    if (!r_atm[check[k]]) {
+      Instance::Atom& atm = instance.atoms[check[k]];
+      r_atm[atm.index] = true;
+      for (index_type i = 0; i < atm.add_by.length(); i++)
+ if (!r_act[atm.add_by[i]]) {
+   Instance::Action& act = instance.actions[atm.add_by[i]];
+   bool ok = true;
+   for (index_type j = 0; (j < act.pre.length()) && ok; j++)
+     if (lmg.adjacent(atm.index, act.pre[j]))
+       ok = false;
+   if (ok) {
+     r_act[act.index] = true;
+     compute_L1C1_relevance(act.pre, lmg, r_atm, r_act);
+   }
+ }
+    }
+}
+void Preprocessor::extend_LsC1_relevance
+(const index_set& check,
+ const graph& lmg,
+ const bool_vec& p_act,
+ const bool_vec& p_add,
+ bool_vec& rel_atms,
+ bool_vec& rel_acts)
+{
+  for (index_type k = 0; k < check.length(); k++)
+    if (!rel_atms[check[k]]) {
+      Instance::Atom& atm = instance.atoms[check[k]];
+      rel_atms[atm.index] = true;
+      for (index_type i = 0; i < atm.add_by.length(); i++)
+ if (!rel_acts[atm.add_by[i]]) {
+   Instance::Action& act = instance.actions[atm.add_by[i]];
+   bool ok = true;
+   if (!p_act[atm.add_by[i]])
+     for (index_type j = 0; (j < act.pre.length()) && ok; j++)
+       if (lmg.adjacent(atm.index, act.pre[j])) {
+  bool_vec b_atm(false, instance.n_atoms());
+  bool_vec b_act(false, instance.n_actions());
+  between(atm.index, act.pre[j], lmg, b_atm, b_act);
+  if (p_add.first_common_element(b_atm) == no_such_index)
+    ok = false;
+       }
+   if (ok) {
+     rel_acts[act.index] = true;
+     extend_LsC1_relevance(act.pre, lmg, p_act, p_add, rel_atms, rel_acts);
+   }
+ }
+    }
+}
+void Preprocessor::compute_LsC1_relevance
+(const index_set& check,
+ const graph& lmg,
+ bool_vec& rel_atms,
+ bool_vec& rel_acts)
+{
+  compute_L1C1_relevance(check, lmg, rel_atms, rel_acts);
+  bool_vec p_add(false, instance.n_atoms());
+  index_type n = 0;
+  bool done = false;
+  while (!done) {
+    n += 1;
+    std::cerr << "iteration #" << n << ", " << rel_acts.count(true)
+       << " relevant actions" << std::endl;
+    for (index_type k = 0; k < instance.n_actions(); k++) if (rel_acts[k]) {
+      for (index_type i = 0; i < instance.actions[k].add.length(); i++)
+ p_add[instance.actions[k].add[i]] = true;
+    }
+    bool_vec new_rel_atms(false, instance.n_atoms());
+    bool_vec new_rel_acts(false, instance.n_actions());
+    extend_LsC1_relevance(check, lmg, rel_acts, p_add, new_rel_atms, new_rel_acts);
+    if (rel_acts.contains(new_rel_acts)) {
+      done = true;
+    }
+    else {
+      rel_atms.insert(new_rel_atms);
+      rel_acts.insert(new_rel_acts);
+    }
+  }
+}
+void Preprocessor::compute_relaxed_relevance
+(const index_set& g,
+ index_vec& path,
+ const index_set& pre,
+ bool_vec& rel_acts)
+{
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    if (instance.actions[k].add.count_common(pre) > 0) {
+      std::cerr << "action " << instance.actions[k].name
+  << " connects to ";
+      instance.write_atom_set(std::cerr, pre);
+      std::cerr << std::endl;
+      bool is_legal = true;
+      index_set u_pre(instance.actions[k].pre);
+      path.append(k);
+      for (index_type i = path.length(); (i > 1) && is_legal; i--) {
+ index_set cf(instance.actions[path[i - 2]].pre);
+ cf.intersect(instance.actions[path[i - 1]].add);
+ if (u_pre.contains(cf)) {
+   std::cerr << "path ";
+   for (index_type j = path.length(); j > 0; j--) {
+     if (j < path.length()) std::cerr << ",";
+     std::cerr << instance.actions[path[j - 1]].name;
+   }
+   std::cerr << " is NOT legal: atoms ";
+   instance.write_atom_set(std::cerr, cf);
+   std::cerr << " connecting " << i - 1 << "th add to "
+      << i - 2 << "th pre contained in U_pre = ";
+   instance.write_atom_set(std::cerr, u_pre);
+   std::cerr << std::endl;
+   is_legal = false;
+ }
+ u_pre.insert(instance.actions[path[i - 2]].pre);
+      }
+      if (is_legal) {
+ index_set cf(g);
+ cf.intersect(instance.actions[path[0]].add);
+ if (u_pre.contains(cf)) {
+   std::cerr << "path ";
+   for (index_type j = path.length(); j > 0; j--) {
+     if (j < path.length()) std::cerr << ",";
+     std::cerr << instance.actions[path[j - 1]].name;
+   }
+   std::cerr << " is NOT legal: atoms ";
+   instance.write_atom_set(std::cerr, cf);
+   std::cerr << " connecting last add to goal contained in U_pre = ";
+   instance.write_atom_set(std::cerr, u_pre);
+   std::cerr << std::endl;
+   is_legal = false;
+ }
+      }
+      if (is_legal) {
+ std::cerr << "path ";
+ for (index_type j = path.length(); j > 0; j--) {
+   if (j < path.length()) std::cerr << ",";
+   std::cerr << instance.actions[path[j - 1]].name;
+ }
+ std::cerr << " is legal" << std::endl;
+ rel_acts[k] = true;
+ compute_relaxed_relevance(g, path, instance.actions[k].pre, rel_acts);
+      }
+      path.dec_length();
+    }
+    else {
+      std::cerr << "action " << instance.actions[k].name
+  << " does NOT connect to ";
+      instance.write_atom_set(std::cerr, pre);
+      std::cerr << std::endl;
+    }
+}
+void Preprocessor::compute_irrelevant_atoms()
+{
+  stats.start();
+  bool_vec r_atm(false, instance.n_atoms());
+  bool_vec r_act(false, instance.n_actions());
+  compute_relevance(instance.goal_atoms, r_atm, r_act);
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (!r_atm[k]) instance.atoms[k].irrelevant = true;
+  stats.stop();
+}
+void Preprocessor::relevant_at_cost
+(index_type p, hsps::rational c, Heuristic& h, const ACF& f,
+ bool_vec& r_atoms, bool_vec& r_actions)
+{
+  r_atoms[p] = true;
+  for (index_type k = 0; k < instance.atoms[p].add_by.length(); k++) {
+    Instance::Action& act = instance.actions[instance.atoms[p].add_by[k]];
+    if (!r_actions[act.index]) {
+      hsps::rational c_pre = h.eval(act.pre);
+      hsps::rational c_post = c - f(act.index);
+      if (c_pre <= c_post) {
+ r_actions[act.index] = true;
+ for (index_type i = 0; i < act.pre.length(); i++) {
+   relevant_at_cost(act.pre[i], c_post, h, f, r_atoms, r_actions);
+ }
+      }
+    }
+  }
+}
+void Preprocessor::relevant_at_cost
+(const index_set& s, hsps::rational c, Heuristic& h, const ACF& f,
+ bool_vec& r_atoms, bool_vec& r_actions)
+{
+  for (index_type k = 0; k < s.length(); k++)
+    relevant_at_cost(s[k], c, h, f, r_atoms, r_actions);
+}
+void Preprocessor::strictly_relevant_actions
+(index_type p, hsps::rational c, Heuristic& h, const ACF& f, bool_vec& rel)
+{
+  for (index_type k = 0; k < instance.atoms[p].add_by.length(); k++) {
+    Instance::Action& act = instance.actions[instance.atoms[p].add_by[k]];
+    if (!rel[act.index]) {
+      hsps::rational c_pre = h.eval(act.pre);
+      hsps::rational c_post = c - f(act.index);
+      if (c_pre <= c_post) {
+ rel[act.index] = true;
+ for (index_type i = 0; i < act.pre.length(); i++) {
+   strictly_relevant_actions(act.pre[i], c_post, h, f, rel);
+ }
+      }
+    }
+  }
+}
+void Preprocessor::strictly_relevant_actions
+(index_type p, Heuristic& h, const ACF& f, bool_vec& rel)
+{
+  rel.assign_value(false, instance.n_actions());
+  index_set s;
+  s.assign_singleton(p);
+  strictly_relevant_actions(p, h.eval(s), h, f, rel);
+}
+void Preprocessor::remove_useless_actions()
+{
+  bool_vec u_act(false, instance.n_actions());
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    if (instance.actions[k].pre.contains(instance.actions[k].add)) {
+      if (trace_level > 1) {
+ std::cerr << "action " << instance.actions[k].name
+    << " is useless" << std::endl;
+      }
+      u_act[k] = true;
+    }
+  instance.remove_actions(u_act, action_map);
+}
+void Preprocessor::remove_useless_invariants()
+{
+  bool_vec u_inv(false, instance.n_invariants());
+  for (index_type k = 0; k < instance.n_invariants(); k++)
+    if (instance.invariants[k].set.length() <= instance.invariants[k].lim) {
+      if (trace_level > 1) {
+ std::cerr << "invariant |";
+ instance.write_atom_set(std::cerr, instance.invariants[k].set);
+ std::cerr << "| " << (instance.invariants[k].exact ? "==" : "<=")
+    << " " << instance.invariants[k].lim << " is useless"
+    << std::endl;
+      }
+      u_inv[k] = true;
+    }
+  instance.remove_invariants(u_inv, inv_map);
+}
+void Preprocessor::preprocess(bool opt_H2) {
+  stats.start();
+  instance.clear_cross_reference();
+  if (trace_level > 0)
+    std::cerr << "removing inconsistent & useless actions..." << std::endl;
+  bool_vec inc(false, instance.n_actions());
+  bool_vec useless(true, instance.n_actions());
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    for (index_type i = 0; (i < instance.actions[k].add.length()) &&
+    !inc[k]; i++)
+      if (instance.actions[k].del.contains(instance.actions[k].add[i]))
+ inc[k] = true;
+    if (inc[k] && (trace_level > 1)) {
+      std::cerr << "action " << instance.actions[k].name
+  << " is inconsistent" << std::endl;
+    }
+    for (index_type i = 0; (i < instance.actions[k].add.length()) &&
+    useless[k]; i++)
+      if (!instance.actions[k].pre.contains(instance.actions[k].add[i]))
+ useless[k] = false;
+    if (useless[k] && (trace_level > 1)) {
+      std::cerr << "action " << instance.actions[k].name
+  << " is useless" << std::endl;
+    }
+  }
+  inc.insert(useless);
+  instance.remove_actions(inc, action_map);
+  if (trace_level > 0) std::cerr << "cross referencing..." << std::endl;
+  instance.cross_reference();
+  if (trace_level > 0) std::cerr << "computing reachability..." << std::endl;
+  bool_vec reachable_atoms(false, instance.n_atoms());
+  bool_vec reachable_actions(false, instance.n_actions());
+  compute_reachability(reachable_atoms, reachable_actions, opt_H2);
+  if (trace_level > 0) std::cerr << "computing static atoms..." << std::endl;
+  bool_vec atoms_to_remove(false, instance.n_atoms());
+  compute_static_atoms(reachable_actions, atoms_to_remove);
+  reachable_actions.complement();
+  if (trace_level > 0) {
+    std::cerr << "removing unreachable actions..." << std::endl;
+    if (trace_level > 1) {
+      instance.write_action_set(std::cerr, reachable_actions);
+      std::cerr << std::endl;
+    }
+  }
+  instance.remove_actions(reachable_actions, action_map);
+  reachable_atoms.complement();
+  atoms_to_remove.insert(reachable_atoms);
+  for (index_type k = 0; k < instance.atoms.length(); k++)
+    if (instance.atoms[k].goal) atoms_to_remove[k] = false;
+  if (trace_level > 0) {
+    std::cerr << "removing unreachable and static atoms..." << std::endl;
+    if (trace_level > 1) {
+      instance.write_atom_set(std::cerr, atoms_to_remove);
+      std::cerr << std::endl;
+    }
+  }
+  if (atoms_to_remove.count(true) > 0) {
+    instance.remove_atoms(atoms_to_remove, atom_map);
+    remove_useless_actions();
+    remove_useless_invariants();
+  }
+  if (trace_level > 0) std::cerr << "re-cross referencing..." << std::endl;
+  instance.clear_cross_reference();
+  instance.cross_reference();
+  stats.stop();
+}
+void Preprocessor::remove_irrelevant_atoms()
+{
+  stats.start();
+  bool_vec atoms_to_remove(false, instance.n_atoms());
+  for (index_type k = 0; k < instance.atoms.length(); k++)
+    if (instance.atoms[k].irrelevant) atoms_to_remove[k] = true;
+  if (trace_level > 0) {
+    std::cerr << "removing irrelevant atoms..." << std::endl;
+    if (trace_level > 1) {
+      instance.write_atom_set(std::cerr, atoms_to_remove);
+      std::cerr << std::endl;
+    }
+  }
+  if (atoms_to_remove.count(true) > 0) {
+    instance.remove_atoms(atoms_to_remove, atom_map);
+    remove_useless_actions();
+    remove_useless_invariants();
+    instance.clear_cross_reference();
+  }
+  stats.stop();
+}
+void Preprocessor::remove_redundant_preconditions()
+{
+  stats.start();
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    index_set r;
+    for (index_type i = 0; i < instance.actions[k].pre.length(); i++)
+      for (index_type j = 0; j < instance.actions[k].pre.length(); j++)
+ if ((i != j) && !r.contains(instance.actions[k].pre[j])) {
+   if (implies(instance.actions[k].pre[j], instance.actions[k].pre[i]))
+     r.insert(instance.actions[k].pre[i]);
+ }
+    if (!r.empty()) {
+      if (trace_level > 1) {
+ std::cerr << "preprocessor: removing redundant preconditions ";
+ instance.write_atom_set(std::cerr, r);
+ std::cerr << " from action " << instance.actions[k].name
+    << std::endl;
+      }
+      instance.actions[k].pre.subtract(r);
+    }
+  }
+  stats.stop();
+}
+void Preprocessor::eliminate_strictly_determined_atoms()
+{
+  stats.start();
+  rule_set sd;
+  instance.compute_iff_axioms(sd);
+  if (sd.empty()) {
+    if (trace_level > 0) {
+      std::cerr << "preprocessor: axiom set is empty" << std::endl;
+    }
+    stats.stop();
+    return;
+  }
+  index_type n = sd.length();
+  if (trace_level > 0) {
+    std::cerr << "preprocessor: eliminating via axiom set ";
+    instance.write_iff_axiom_set(std::cerr, sd);
+    std::cerr << std::endl;
+  }
+  index_graph dg;
+  sd.compute_dependency_graph(instance.n_atoms(), dg);
+  sd.make_acyclic(dg);
+  if ((n > sd.length()) && (trace_level > 0)) {
+    std::cerr << "preprocessor: acyclic axiom set ";
+    instance.write_iff_axiom_set(std::cerr, sd);
+    std::cerr << std::endl;
+    n = sd.length();
+  }
+  sd.make_post_unique(dg);
+  if ((n > sd.length()) && (trace_level > 0)) {
+    std::cerr << "preprocessor: post-unique axiom set ";
+    instance.write_iff_axiom_set(std::cerr, sd);
+    std::cerr << std::endl;
+  }
+  if (trace_level > 0) {
+    instance.write_axiom_dependency_graph(std::cerr, dg, "Dependency Graph");
+  }
+  bool_vec d(true, instance.n_atoms());
+  bool_vec e(false, instance.n_atoms());
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (dg.out_degree(k) == 0) d[k] = false;
+  assert(d.count(true) == sd.length());
+  bool done = false;
+  while (!done) {
+    index_type p = no_such_index;
+    for (index_type k = 0; (k < instance.n_atoms()) && p == no_such_index; k++)
+      if (d[k] && (dg.in_degree(k) == 0))
+ p = k;
+    if (p != no_such_index) {
+      index_type r = sd.find_rule(p);
+      assert(r < sd.length());
+      instance.replace_atom_by_conjunction(p, sd[r].antecedent);
+      d[p] = false;
+      e[p] = true;
+      dg.remove_edges_with_label(r);
+      assert(dg.out_degree(p) == 0);
+    }
+    else {
+      done = true;
+    }
+  }
+  assert(e.count(true) == sd.length());
+  if (trace_level > 0) {
+    std::cerr << "preprocessor: " << e.count(true) << " atoms eliminated (";
+    instance.write_atom_set(std::cerr, e);
+    std::cerr << ")" << std::endl;
+  }
+  if (e.count(true) > 0) {
+    instance.remove_atoms(e, atom_map);
+    remove_useless_actions();
+    remove_useless_invariants();
+    instance.clear_cross_reference();
+  }
+  stats.stop();
+}
+void Preprocessor::necessary_completions_for_safeness
+(index_set& atoms_missing_negation)
+{
+  inconsistency();
+  atoms_missing_negation.clear();
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    if (consistent(instance.actions[k].pre)) {
+      for (index_type i = 0; i < instance.actions[k].add.length(); i++) {
+ if (!instance.actions[k].pre.contains(instance.actions[k].add[i])) {
+   if (consistent(instance.actions[k].pre, instance.actions[k].add[i]) &&
+       !implies(instance.actions[k].pre, instance.actions[k].add[i])) {
+     if (instance.atoms[instance.actions[k].add[i]].neg == no_such_index)
+       atoms_missing_negation.insert(instance.actions[k].add[i]);
+   }
+ }
+      }
+      for (index_type i = 0; i < instance.actions[k].del.length(); i++) {
+ if (!instance.actions[k].pre.contains(instance.actions[k].del[i])) {
+   if (consistent(instance.actions[k].pre, instance.actions[k].del[i]) &&
+       !implies(instance.actions[k].pre, instance.actions[k].del[i])) {
+     if (instance.atoms[instance.actions[k].del[i]].neg == no_such_index)
+       atoms_missing_negation.insert(instance.actions[k].del[i]);
+   }
+ }
+      }
+    }
+}
+void Preprocessor::make_safe()
+{
+  inconsistency();
+  Instance::action_vec acts(instance.actions);
+  instance.actions.clear();
+  for (index_type k = 0; k < acts.length(); k++) {
+    if (consistent(acts[k].pre)) {
+      index_set i_pre;
+      index_set r_add;
+      index_set r_del;
+      index_set v_add;
+      index_set v_del;
+      for (index_type i = 0; i < acts[k].add.length(); i++) {
+ if (!acts[k].pre.contains(acts[k].add[i])) {
+   if (inconsistent(acts[k].pre, acts[k].add[i])) {
+     if (instance.atoms[acts[k].add[i]].neg != no_such_index)
+       i_pre.insert(instance.atoms[acts[k].add[i]].neg);
+   }
+   else if (implies(acts[k].pre, acts[k].add[i])) {
+     r_add.insert(acts[k].add[i]);
+   }
+   else {
+     v_add.insert(acts[k].add[i]);
+   }
+ }
+ else {
+   r_add.insert(acts[k].add[i]);
+ }
+      }
+      for (index_type i = 0; i < acts[k].del.length(); i++) {
+ if (!acts[k].pre.contains(acts[k].del[i])) {
+   if (inconsistent(acts[k].pre, acts[k].del[i])) {
+     r_del.insert(acts[k].del[i]);
+   }
+   else if (implies(acts[k].pre, acts[k].del[i])) {
+     i_pre.insert(acts[k].del[i]);
+   }
+   else {
+     v_del.insert(acts[k].del[i]);
+   }
+ }
+      }
+      if (trace_level > 1) {
+ std::cerr << "completing action ";
+ instance.print_action(std::cerr, acts[k]);
+ std::cerr << "implied preconditions: ";
+ instance.write_atom_set(std::cerr, i_pre);
+ std::cerr << std::endl << "redundant added atoms: ";
+ instance.write_atom_set(std::cerr, r_add);
+ std::cerr << std::endl << "redundant deleted atoms: ";
+ instance.write_atom_set(std::cerr, r_del);
+ std::cerr << std::endl << "variable added atoms: ";
+ instance.write_atom_set(std::cerr, v_add);
+ std::cerr << std::endl << "variable deleted atoms: ";
+ instance.write_atom_set(std::cerr, v_del);
+ std::cerr << std::endl;
+      }
+      index_type n = 0;
+      SubsetEnumerator e_add(v_add.length());
+      bool more = e_add.first();
+      while (more) {
+ SubsetEnumerator e_del(v_del.length());
+ bool more1 = e_del.first();
+ while (more1) {
+   index_set c_pre(acts[k].pre);
+   c_pre.insert(i_pre);
+   index_set c_add(acts[k].add);
+   c_add.subtract(r_add);
+   index_set c_del(acts[k].del);
+   c_del.subtract(r_del);
+   for (index_type i = 0; i < v_add.length(); i++)
+     if (e_add.current_set()[i]) {
+       c_pre.insert(v_add[i]);
+       c_add.subtract(v_add[i]);
+     }
+     else {
+       index_type pos_pre = v_add[i];
+       index_type neg_pre = instance.atoms[pos_pre].neg;
+       assert(neg_pre != no_such_index);
+       c_pre.insert(neg_pre);
+     }
+   for (index_type i = 0; i < v_del.length(); i++)
+     if (e_del.current_set()[i]) {
+       c_pre.insert(v_del[i]);
+     }
+     else {
+       index_type pos_pre = v_del[i];
+       index_type neg_pre = instance.atoms[pos_pre].neg;
+       assert(neg_pre != no_such_index);
+       c_pre.insert(neg_pre);
+       c_del.subtract(v_del[i]);
+     }
+   if (trace_level > 1) {
+     std::cerr << "variable added atoms TRUE:";
+     for (index_type i = 0; i < v_add.length(); i++)
+       if (e_add.current_set()[i])
+  std::cerr << " " << instance.atoms[v_add[i]].name;
+     std::cerr << std::endl << "variable added atoms FALSE:";
+     for (index_type i = 0; i < v_add.length(); i++)
+       if (!e_add.current_set()[i])
+  std::cerr << " " << instance.atoms[v_add[i]].name;
+     std::cerr << std::endl << "variable deleted atoms TRUE:";
+     for (index_type i = 0; i < v_del.length(); i++)
+       if (e_del.current_set()[i])
+  std::cerr << " " << instance.atoms[v_del[i]].name;
+     std::cerr << std::endl << "variable deleted atoms FALSE:";
+     for (index_type i = 0; i < v_del.length(); i++)
+       if (!e_del.current_set()[i])
+  std::cerr << " " << instance.atoms[v_del[i]].name;
+     std::cerr << std::endl;
+   }
+   if (consistent(c_pre) && !c_add.empty()) {
+     if (trace_level > 1) {
+       std::cerr << "completed precondition ";
+       instance.write_atom_set(std::cerr, c_pre);
+       std::cerr << " is consistent and add set is non-empty:"
+   << " creating action " << n
+   << std::endl;
+     }
+     Instance::Action& c_act =
+       instance.new_action(new NameAtIndex(acts[k].name, n++));
+     c_act.sel = acts[k].sel;
+     c_act.pre = c_pre;
+     c_act.add = c_add;
+     c_act.del = c_del;
+     c_act.lck = acts[k].lck;
+     c_act.use = acts[k].use;
+     c_act.cons = acts[k].cons;
+     c_act.dur = acts[k].dur;
+     c_act.dmin = acts[k].dmin;
+     c_act.dmax = acts[k].dmax;
+     c_act.cost = acts[k].cost;
+     c_act.assoc = acts[k].assoc;
+     c_act.src = acts[k].src;
+   }
+   else if (trace_level > 1) {
+     if (!consistent(c_pre)) {
+       std::cerr << "completed precondition ";
+       instance.write_atom_set(std::cerr, c_pre);
+       std::cerr << " is NOT consistent" << std::endl;
+     }
+     if (c_add.empty()) {
+       std::cerr << "add set of completion is EMPTY" << std::endl;
+     }
+   }
+   more1 = e_del.next();
+ }
+ more = e_add.next();
+      }
+      if ((trace_level > 0) && (n == 0)) {
+ std::cerr << "warning: ZERO completions of action "
+    << acts[k].name << " created"
+    << std::endl;
+      }
+    }
+    else if (trace_level > 0) {
+      std::cerr << "warning: original action "
+  << acts[k].name
+  << " has inconsistent preconditions ";
+      instance.write_atom_set(std::cerr, acts[k].pre);
+      std::cerr << std::endl;
+    }
+  }
+  instance.clear_cross_reference();
+}
+void Preprocessor::apply_place_replication()
+{
+  index_type n_orig = instance.n_atoms();
+  for (index_type k = 0; k < n_orig; k++) {
+    index_set ca;
+    for (index_type i = 0; i < instance.atoms[k].req_by.length(); i++)
+      if (!instance.atoms[k].del_by.contains(instance.atoms[k].req_by[i]))
+ ca.insert(instance.atoms[k].req_by[i]);
+    if (!ca.empty()) {
+      graph cag(ca.length());
+      for (index_type i = 0; i < ca.length(); i++)
+ for (index_type j = i + 1; j < ca.length(); j++)
+   if (instance.non_interfering(ca[i], ca[j]) &&
+       consistent(instance.actions[ca[i]].pre,
+    instance.actions[ca[j]].pre))
+     cag.add_undirected_edge(i, j);
+      index_set_vec groups(EMPTYSET, 1);
+      index_set rem;
+      rem.fill(ca.length());
+      cag.apx_independent_set(rem, groups[0]);
+      rem.subtract(groups[0]);
+      while (!rem.empty()) {
+ index_set& g = groups.append();
+ cag.apx_independent_set(rem, g);
+ rem.subtract(g);
+      }
+      for (index_type i = 0; i < groups.length(); i++)
+ groups[i].remap(ca);
+      std::cerr << "action groups conflicting on "
+  << instance.atoms[k].name << ":";
+      for (index_type i = 0; i < groups.length(); i++) {
+ std::cerr << " ";
+ instance.write_action_set(std::cerr, groups[i]);
+      }
+      std::cerr << std::endl;
+      index_set new_pk;
+      for (index_type i = 1; i < groups.length(); i++) {
+ Instance::Atom& pki =
+   instance.new_atom(new CopyName(instance.atoms[k].name, i));
+ pki.neg = instance.atoms[k].neg;
+ pki.init = instance.atoms[k].init;
+ pki.init_t = instance.atoms[k].init_t;
+ pki.goal = instance.atoms[k].goal;
+ pki.goal_t = instance.atoms[k].goal_t;
+ pki.irrelevant = instance.atoms[k].irrelevant;
+ pki.src = instance.atoms[k].src;
+ new_pk.insert(pki.index);
+ for (index_type j = 0; j < groups[i].length(); j++) {
+   instance.actions[groups[i][j]].pre.subtract(k);
+   instance.actions[groups[i][j]].pre.insert(pki.index);
+ }
+      }
+      if (!new_pk.empty()) {
+ for (index_type i = 0; i < instance.atoms[k].add_by.length(); i++)
+   instance.actions[instance.atoms[k].add_by[i]].add.insert(new_pk);
+ for (index_type i = 0; i < instance.atoms[k].del_by.length(); i++) {
+   instance.actions[instance.atoms[k].del_by[i]].del.insert(new_pk);
+   if (instance.actions[instance.atoms[k].del_by[i]].pre.contains(k))
+     instance.actions[instance.atoms[k].del_by[i]].pre.insert(new_pk);
+ }
+      }
+    }
+  }
+  if (instance.n_atoms() > n_orig)
+    instance.clear_cross_reference();
+}
+bool Preprocessor::make_invariant
+(index_type init_atom, index_set& inv_set, bool& exact, index_set& branch_set)
+{
+  if (trace_level > 2) {
+    std::cerr << "checking ";
+    instance.write_atom_set(std::cerr, inv_set);
+    std::cerr << " with init atom " << instance.atoms[init_atom].name
+       << " for invariance..." << std::endl;
+  }
+  branch_set.clear();
+  bool converged = false;
+  while (!converged && !inv_set.empty()) {
+    converged = true;
+    bool changed = false;
+    for (index_type k = 0; k < instance.n_actions(); k++) {
+      Instance::Action& act = instance.actions[k];
+      index_set p(act.pre);
+      p.intersect(inv_set);
+      if (p.empty()) {
+ if (act.add.count_common(inv_set) > 0) {
+   if (trace_level > 2) {
+     std::cerr << "action " << act.name << " is 0-consistent and violates invariant: removing ";
+     instance.write_atom_set(std::cerr, act.add);
+     std::cerr << std::endl;
+   }
+   for (index_type i = 0; i < act.add.length(); i++)
+     if ((act.add[i] != init_atom) && inv_set.contains(act.add[i])) {
+       inv_set.subtract(act.add[i]);
+       changed = true;
+     }
+   converged = false;
+ }
+ if (exact) {
+   if (act.del.count_common(inv_set) > 0) exact = false;
+ }
+      }
+      else if ((p.length() == 1) && !act.del.contains(p[0])) {
+ if (act.add.count_common(inv_set) > 0) {
+   if (trace_level > 2) {
+     std::cerr << "action " << act.name << " is 1-consistent and violates invariant: removing ";
+     instance.write_atom_set(std::cerr, act.add);
+     std::cerr << std::endl;
+   }
+   for (index_type i = 0; i < act.add.length(); i++)
+     if ((act.add[i] != init_atom) && inv_set.contains(act.add[i])) {
+       inv_set.subtract(act.add[i]);
+       changed = true;
+     }
+   converged = false;
+ }
+ if (exact) {
+   if (act.del.count_common(inv_set) > 0) exact = false;
+ }
+      }
+    }
+    if (trace_level > 2) {
+      std::cerr << "set at end of current iteration: ";
+      instance.write_atom_set(std::cerr, inv_set);
+      std::cerr << std::endl;
+    }
+    if (!converged && !changed) {
+      if (trace_level > 2) {
+ std::cerr << "set can not converge (need to remove protected atom)"
+    << std::endl;
+      }
+      return false;
+    }
+  }
+  if (inv_set.length() <= 1) return false;
+  bool verified = true;
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    Instance::Action& act = instance.actions[k];
+    index_set p(act.pre);
+    p.intersect(inv_set);
+    if ((p.length() == 1) && act.del.contains(p[0])) {
+      if (act.add.count_common(inv_set) > 1) {
+ if (trace_level > 2) {
+   std::cerr << "action " << act.name << " is 1-consistent with delete and violates invariant: adding ";
+   instance.write_atom_set(std::cerr, act.add);
+   std::cerr << " to branch set" << std::endl;
+ }
+ branch_set.insert(act.add);
+ branch_set.intersect(inv_set);
+ verified = false;
+      }
+      if (exact) {
+ if (act.del.count_common(inv_set) > 1) exact = false;
+      }
+    }
+  }
+  branch_set.subtract(init_atom);
+  return verified;
+}
+void Preprocessor::analyze_branch_set
+(const index_set& branch_set, const index_set& inv_set, index_set& effective)
+{
+  effective.clear();
+  for (index_type k = 0; k < branch_set.length(); k++) {
+    index_type b_atom = branch_set[k];
+    if (trace_level > 2) {
+      std::cerr << "checking effects of branching on "
+  << instance.atoms[b_atom].name
+  << "..." << std::endl;
+    }
+    const index_set& a_acts = instance.atoms[branch_set[k]].req_by;
+    for (index_type i = 0; i < a_acts.length(); i++) {
+      Instance::Action& act = instance.actions[a_acts[i]];
+      index_type n_pre = act.pre.count_common(inv_set);
+      if (n_pre == 1) {
+ index_type n_add = act.add.count_common(inv_set);
+ if (n_add > 0) {
+   if (trace_level > 2) {
+     std::cerr << "effect found: action " << act.name
+        << " becomes 0-consistent and violating"
+        << std::endl;
+   }
+   effective.insert(b_atom);
+ }
+      }
+      else if (n_pre == 2) {
+ index_type n_del = act.del.count_common(inv_set);
+ if ((n_del == 0) || ((n_del == 1) && act.del.contains(b_atom))) {
+   index_type n_add = act.add.count_common(inv_set);
+   if (n_add > 0) {
+     if (trace_level > 2) {
+       std::cerr << "effect found: action " << act.name
+   << " becomes 1-consistent w/o delete and violating"
+   << std::endl;
+     }
+     effective.insert(b_atom);
+   }
+ }
+      }
+    }
+  }
+}
+void Preprocessor::dfs_find_invariants
+(index_type init_atom, const index_set& base_set, const index_set& branch_set,
+ index_type branch_depth, index_type max_branch_depth)
+{
+  index_set rem_branch_set;
+  analyze_branch_set(branch_set, base_set, rem_branch_set);
+  index_set ne_branch_set(branch_set);
+  ne_branch_set.subtract(rem_branch_set);
+  index_set inv;
+  index_set b;
+  while (!rem_branch_set.empty() && !stats.break_signal_raised()) {
+    inv.assign_copy(base_set);
+    inv.subtract(rem_branch_set[0]);
+    if (trace_level > 2) {
+      std::cerr << "(" << branch_depth << ") checking set ";
+      instance.write_atom_set(std::cerr, inv);
+      std::cerr << "..." << std::endl;
+    }
+    bool exact = false;
+    bool ok = make_invariant(init_atom, inv, exact, b);
+    if (ok) {
+      if (trace_level > 1) {
+ std::cerr << "(" << branch_depth << ") invariant found: ";
+ instance.write_atom_set(std::cerr, inv);
+ std::cerr << std::endl;
+      }
+      Instance::Constraint& c = instance.new_invariant(inv, 1, false);
+    }
+    else if (!b.empty() && (branch_depth < max_branch_depth)) {
+      if (trace_level > 2) {
+ std::cerr << "(" << branch_depth << ") found potential invariants ";
+ instance.write_atom_set(std::cerr, inv);
+ std::cerr << std::endl << "(" << branch_depth << ") branching on ";
+ instance.write_atom_set(std::cerr, b);
+ std::cerr << "..." << std::endl;
+      }
+      dfs_find_invariants(init_atom, inv, b, branch_depth + 1,
+     max_branch_depth);
+    }
+    rem_branch_set.remove(0);
+  }
+  if (!ne_branch_set.empty()) {
+    inv.assign_copy(base_set);
+    inv.subtract(ne_branch_set);
+    if (trace_level > 2) {
+      std::cerr << "(" << branch_depth << ") checking set ";
+      instance.write_atom_set(std::cerr, inv);
+      std::cerr << "..." << std::endl;
+    }
+    bool exact = false;
+    bool ok = make_invariant(init_atom, inv, exact, b);
+    if (ok) {
+      if (trace_level > 1) {
+ std::cerr << "(" << branch_depth << ") invariant found: ";
+ instance.write_atom_set(std::cerr, inv);
+ std::cerr << std::endl;
+      }
+      Instance::Constraint& c = instance.new_invariant(inv, 1, false);
+    }
+    else if (!b.empty() && (branch_depth < max_branch_depth)) {
+      if (trace_level > 2) {
+ std::cerr << "(" << branch_depth << ") found potential invariants ";
+ instance.write_atom_set(std::cerr, inv);
+ std::cerr << std::endl << "(" << branch_depth << ") branching on ";
+ instance.write_atom_set(std::cerr, b);
+ std::cerr << "..." << std::endl;
+      }
+      dfs_find_invariants(init_atom, inv, b, branch_depth + 1,
+     max_branch_depth);
+    }
+  }
+}
+void Preprocessor::dfs_find_invariants(index_type max_branch_depth)
+{
+  stats.start();
+  if (trace_level > 0) {
+    std::cerr << "searching for invariants (DFS)..." << std::endl;
+  }
+  index_set non_init_atoms;
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (!instance.atoms[k].init) non_init_atoms.insert(k);
+  for (index_type k = 0; (k < instance.init_atoms.length()) &&
+  !stats.break_signal_raised(); k++) {
+    index_set inv(non_init_atoms);
+    index_set b;
+    inv.insert(instance.init_atoms[k]);
+    if (trace_level > 2) {
+      std::cerr << "(0) checking set ";
+      instance.write_atom_set(std::cerr, inv);
+      std::cerr << "..." << std::endl;
+    }
+    bool exact = true;
+    bool ok = make_invariant(instance.init_atoms[k], inv, exact, b);
+    if (ok) {
+      if (trace_level > 1) {
+ std::cerr << "(0) invariant found: ";
+ instance.write_atom_set(std::cerr, inv);
+ if (exact) std::cerr << " (exactly-1)";
+ else std::cerr << " (at-most-1)";
+ std::cerr << std::endl;
+      }
+      Instance::Constraint& c = instance.new_invariant(inv, 1, exact);
+    }
+    else if (!b.empty() && (max_branch_depth > 0)) {
+      if (trace_level > 2) {
+ std::cerr << "(0) found potential invariants ";
+ instance.write_atom_set(std::cerr, inv);
+ std::cerr << std::endl << "(0) branching on ";
+ instance.write_atom_set(std::cerr, b);
+ std::cerr << "..." << std::endl;
+      }
+      dfs_find_invariants(instance.init_atoms[k], inv, b, 1, max_branch_depth);
+    }
+  }
+  stats.stop();
+}
+struct InvariantSearchState {
+  index_type init_atom;
+  index_set set;
+  InvariantSearchState(index_type i, const index_set& s)
+    : init_atom(i), set(s) { };
+  bool equals(const InvariantSearchState& s);
+};
+bool InvariantSearchState::equals(const InvariantSearchState& s)
+{
+  if (init_atom != s.init_atom) return false;
+  if (!(set == s.set)) return false;
+  return true;
+}
+void Preprocessor::bfs_find_invariants()
+{
+  stats.start();
+  if (trace_level > 0) {
+    std::cerr << "searching for invariants (BFS)..." << std::endl;
+  }
+  std::list<InvariantSearchState> cand;
+  index_set non_init_atoms;
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if (!instance.atoms[k].init) non_init_atoms.insert(k);
+  for (index_type k = 0; k < instance.init_atoms.length(); k++) {
+    index_set inv(non_init_atoms);
+    inv.insert(instance.init_atoms[k]);
+    InvariantSearchState s(instance.init_atoms[k], inv);
+    cand.push_back(s);
+  }
+  std::list<InvariantSearchState>::iterator next = cand.begin();
+  index_type proc = 0;
+  while ((next != cand.end()) && !stats.break_signal_raised()) {
+    index_set inv(next->set);
+    bool exact = false;
+    index_set b;
+    bool ok = make_invariant(next->init_atom, inv, exact, b);
+    if (ok) {
+      if (trace_level > 1) {
+ std::cerr << "invariant found: ";
+ instance.write_atom_set(std::cerr, inv);
+ std::cerr << std::endl;
+      }
+      Instance::Constraint& c = instance.new_invariant(inv, 1, exact);
+    }
+    else if (!b.empty()) {
+      index_set e;
+      analyze_branch_set(b, inv, e);
+      index_set ne(b);
+      ne.subtract(e);
+      if (trace_level > 2) {
+ std::cerr << "found potential invariants ";
+ instance.write_atom_set(std::cerr, inv);
+ std::cerr << " branching on ";
+ instance.write_atom_set(std::cerr, e);
+ std::cerr << " (effective) and ";
+ instance.write_atom_set(std::cerr, ne);
+ std::cerr << "..." << std::endl;
+      }
+      for (index_type k = 0; k < e.length(); k++) {
+ index_set new_inv(inv);
+ new_inv.subtract(e[k]);
+ InvariantSearchState s(next->init_atom, new_inv);
+ bool skip = false;
+ for (std::list<InvariantSearchState>::iterator p = cand.begin();
+      (p != cand.end()) && !skip; p++)
+   if (p->equals(s)) skip = true;
+ if (!skip) cand.push_back(s);
+      }
+      inv.subtract(ne);
+      InvariantSearchState s0(next->init_atom, inv);
+      bool skip = false;
+      for (std::list<InvariantSearchState>::iterator p = cand.begin();
+    (p != cand.end()) && !skip; p++)
+ if (p->equals(s0)) skip = true;
+      if (!skip) cand.push_back(s0);
+    }
+    next++;
+    proc++;
+    if (trace_level > 2) {
+      std::cerr << "|candidates| = " << cand.size() - proc
+  << " (" << cand.size() << ")" << std::endl;
+    }
+  }
+  stats.stop();
+}
+bool Preprocessor::verify_invariant
+(Instance::Constraint& inv, Heuristic& inc)
+{
+  if (trace_level > 1) {
+    std::cerr << "verifying invariant " << inv.index << ": |";
+    instance.write_atom_set(std::cerr, inv.set);
+    std::cerr << "| " << (inv.exact ? "==" : "<=") << " " << inv.lim
+       << "..." << std::endl;
+  }
+  bool v_exact = true;
+  index_type init_n = instance.init_atoms.count_common(inv.set);
+  if (init_n > inv.lim) {
+    if (trace_level > 1) {
+      std::cerr << " - violated by initial state" << std::endl;
+    }
+    return false;
+  }
+  else if (init_n < inv.lim) {
+    if (trace_level > 1) {
+      std::cerr << " - not exact in initial state";
+      if (inv.exact) std::cerr << ": weakening";
+      std::cerr << std::endl;
+    }
+    v_exact = false;
+  }
+  for (index_type k = 0; (k < instance.n_actions()) &&
+  !stats.break_signal_raised(); k++) {
+    index_type n_pre = instance.actions[k].pre.count_common(inv.set);
+    if (n_pre <= inv.lim) {
+      index_type n_true = 0;
+      for (index_type i = 0; i < inv.set.length(); i++) {
+ if ((inc.incremental_eval(instance.actions[k].pre, inv.set[i])).finite())
+   n_true += 1;
+      }
+      index_type n_safe = (n_true < inv.lim ? inv.lim - n_true : 0);
+      index_type n_add = instance.actions[k].add.count_common(inv.set);
+      index_type n_del = instance.actions[k].del.count_common(inv.set);
+      if (trace_level > 2) {
+ std::cerr << " - action " << instance.actions[k].name
+    << ": n_true = " << n_true
+    << ", n_safe = " << n_safe
+    << ", n_add = " << n_add
+    << ", n_del = " << n_del
+    << std::endl;
+      }
+      if (n_add > (n_del + n_safe)) {
+ if (trace_level > 1) {
+   std::cerr << " - violated by action "
+      << instance.actions[k].name << std::endl;
+ }
+ return false;
+      }
+      if (v_exact && (n_add < n_del)) {
+ if (trace_level > 1) {
+   std::cerr << " - not exact by action "
+      << instance.actions[k].name;
+   if (inv.exact) std::cerr << ": weakening";
+   std::cerr << std::endl;
+ }
+ v_exact = false;
+      }
+    }
+  }
+  if (v_exact) {
+    if (trace_level > 1) {
+      std::cerr << " - is exact";
+      if (!inv.exact) std::cerr << ": strengthening";
+      std::cerr << std::endl;
+    }
+    inv.exact = true;
+  }
+  else if (inv.exact && !v_exact) {
+    inv.exact = false;
+  }
+  return true;
+}
+bool Preprocessor::verify_invariants(Heuristic& inc)
+{
+  stats.start();
+  if (trace_level > 0) {
+    std::cerr << "verifying invariants (using inconsistency relation)..."
+       << std::endl;
+  }
+  for (index_type k = 0; (k < instance.n_invariants()) &&
+  !stats.break_signal_raised(); k++)
+    if (!instance.invariants[k].verified)
+      instance.invariants[k].verified =
+ verify_invariant(instance.invariants[k], inc);
+  stats.stop();
+}
+void Preprocessor::remove_unverified_invariants()
+{
+  bool_vec inv_to_remove(false, instance.n_invariants());
+  for (index_type k = 0; k < instance.n_invariants(); k++)
+    if (!instance.invariants[k].verified) inv_to_remove[k] = true;
+  instance.remove_invariants(inv_to_remove, inv_map);
+}
+bool Preprocessor::find_inverse_actions
+(const Instance::Action& act, Heuristic& inc, index_set& invs)
+{
+  index_set q(act.pre);
+  q.subtract(act.del);
+  q.insert(act.add);
+  invs.clear();
+  for (index_type k = act.index + 1; k < instance.n_actions(); k++) {
+    Instance::Action& b(instance.actions[k]);
+    bool ok = (q.contains(b.pre) && (b.add == act.del));
+    for (index_type i = 0; (i < b.del.length()) && ok; i++)
+      if ((inc.incremental_eval(act.pre, b.del[i])).finite()) ok = false;
+    if (ok) invs.insert(k);
+  }
+  return !invs.empty();
+}
+void Preprocessor::find_binary_iff_invariants(bool opt_weak_verify)
+{
+  stats.start();
+  for (index_type i = 0; i < instance.n_atoms(); i++)
+    for (index_type j = i + 1; j < instance.n_atoms(); j++)
+      if (inconsistent(i, j)) {
+ Instance::Constraint h;
+ h.set.insert(i);
+ h.set.insert(j);
+ h.lim = 1;
+ h.exact = true;
+ if (opt_weak_verify) {
+   h.verified = instance.verify_invariant(h);
+ }
+ else {
+   h.verified = verify_invariant(h, *inconsistency());
+ }
+ if (h.verified && h.exact) {
+   instance.new_invariant(h.set, h.lim, true);
+ }
+      }
+  stats.stop();
+}
+void Preprocessor::find_inconsistent_set_invariants(graph& inc)
+{
+  if (trace_level > 0) {
+    std::cerr << "searching for cliques (approximate)..." << std::endl;
+  }
+  stats.start();
+  graph iig(inc);
+  iig.complement();
+  index_type n = instance.n_invariants();
+  for (index_type k = 0; k < instance.n_atoms(); k++) {
+    index_set inv;
+    iig.apx_independent_set_including(k, inv);
+    if (trace_level > 1) {
+      instance.write_atom_set(std::cerr << "|", inv);
+      std::cerr << "| <= 1" << std::endl;
+    }
+    if (inv.length() > 1) {
+      instance.new_invariant(inv, 1, false);
+    }
+  }
+  stats.stop();
+  if (trace_level > 0) {
+    std::cerr << instance.n_invariants() - n << " invariants found in "
+       << stats.time() << " seconds" << std::endl;
+  }
+}
+void Preprocessor::find_maximal_inconsistent_set_invariants(graph& inc)
+{
+  if (trace_level > 0) {
+    std::cerr << "searching for maximal cliques..." << std::endl;
+  }
+  stats.start();
+  index_type n = instance.n_invariants();
+  for (index_type k = 0; k < instance.n_atoms(); k++) {
+    index_set_vec inv;
+    inc.all_maximal_cliques_including(k, inv);
+    for (index_type i = 0; i < inv.length(); i++) {
+      if (trace_level > 1) {
+ instance.write_atom_set(std::cerr << "|", inv[i]);
+ std::cerr << "| <= 1" << std::endl;
+      }
+      if (inv[i].length() > 1) {
+ instance.new_invariant(inv[i], 1, false);
+      }
+    }
+  }
+  stats.stop();
+  if (trace_level > 0) {
+    std::cerr << instance.n_invariants() - n << " invariants found in "
+       << stats.time() << " seconds" << std::endl;
+  }
+}
+bool Preprocessor::inconsistent(index_type p, index_type q, Heuristic& inc)
+{
+  index_set s;
+  s.insert(p);
+  s.insert(q);
+  return (inc.eval(s)).infinite();
+}
+bool Preprocessor::consistent(index_type p, index_type q, Heuristic& inc)
+{
+  index_set s;
+  s.insert(p);
+  s.insert(q);
+  return (inc.eval(s)).finite();
+}
+bool Preprocessor::inconsistent
+(const index_set& s, index_type p, Heuristic& inc)
+{
+  return (inc.incremental_eval(s, p)).infinite();
+}
+bool Preprocessor::consistent
+(const index_set& s, index_type p, Heuristic& inc)
+{
+  return (inc.incremental_eval(s, p)).finite();
+}
+bool Preprocessor::inconsistent(index_type p, index_type q)
+{
+  inconsistency();
+  return (inc_relation->eval(p, q)).infinite();
+}
+bool Preprocessor::consistent(index_type p, index_type q)
+{
+  inconsistency();
+  return (inc_relation->eval(p, q)).finite();
+}
+bool Preprocessor::inconsistent(const index_set& s, index_type p)
+{
+  inconsistency();
+  return (inc_relation->incremental_eval(s, p)).infinite();
+}
+bool Preprocessor::consistent(const index_set& s, index_type p)
+{
+  inconsistency();
+  return (inc_relation->incremental_eval(s, p)).finite();
+}
+bool Preprocessor::inconsistent(const index_set& s)
+{
+  inconsistency();
+  return (inc_relation->eval(s)).infinite();
+}
+bool Preprocessor::consistent(const index_set& s)
+{
+  inconsistency();
+  return (inc_relation->eval(s)).finite();
+}
+bool Preprocessor::inconsistent(const index_set& s0, const index_set& s1)
+{
+  index_set s(s0);
+  s.insert(s1);
+  inconsistency();
+  return (inc_relation->eval(s)).infinite();
+}
+bool Preprocessor::consistent(const index_set& s0, const index_set& s1)
+{
+  index_set s(s0);
+  s.insert(s1);
+  inconsistency();
+  return (inc_relation->eval(s)).finite();
+}
+bool Preprocessor::implies(index_type p, index_type q, Heuristic& inc)
+{
+  for (index_type k = 0; k < instance.n_invariants(); k++)
+    if ((instance.invariants[k].lim == 1) &&
+ instance.invariants[k].exact &&
+ instance.invariants[k].set.contains(q)) {
+      bool f = true;
+      for (index_type i = 0; (i < instance.invariants[k].set.length()) && f; i++)
+ if (instance.invariants[k].set[i] != q)
+   if (consistent(p, instance.invariants[k].set[i], inc))
+     f = false;
+      if (f) return true;
+    }
+  return false;
+}
+bool Preprocessor::implies(const index_set& s, index_type q, Heuristic& inc)
+{
+  if (trace_level > 2) {
+    std::cerr << "checking if ";
+    instance.write_atom_set(std::cerr, s);
+    std::cerr << " implies " << instance.atoms[q].name
+       << "..." << std::endl;
+  }
+  if (instance.atoms[q].neg != no_such_index) {
+    if ((inc.incremental_eval(s, instance.atoms[q].neg)).infinite())
+      return true;
+  }
+  for (index_type k = 0; k < instance.n_invariants(); k++)
+    if ((instance.invariants[k].lim == 1) &&
+ instance.invariants[k].exact &&
+ instance.invariants[k].set.contains(q)) {
+      if (trace_level > 2) {
+ std::cerr << "testing against invariant ";
+ instance.print_invariant(std::cerr, instance.invariants[k]);
+      }
+      bool f = true;
+      for (index_type i = 0; (i < instance.invariants[k].set.length()) && f; i++)
+ if (instance.invariants[k].set[i] != q)
+   if ((inc.incremental_eval(s, instance.invariants[k].set[i])).finite()) {
+     if (trace_level > 2) {
+       std::cerr << " - failed: set consistent with "
+   << instance.atoms[instance.invariants[k].set[i]].name
+   << std::endl;
+     }
+     f = false;
+   }
+      if (f) {
+ if (trace_level > 2) {
+   std::cerr << " - ok" << std::endl;
+ }
+ f = false;
+ return true;
+      }
+    }
+  return false;
+}
+bool Preprocessor::implies(index_type p, index_type q)
+{
+  return implies(p, q, *inconsistency());
+}
+bool Preprocessor::implies(const index_set& s, index_type q)
+{
+  return implies(s, q, *inconsistency());
+}
+void Preprocessor::implied_atom_set
+(const index_set& s, index_set& is, Heuristic& inc)
+{
+  stats.start();
+  is.clear();
+  index_set sx(s);
+  bool done = false;
+  while (!done) {
+    if (trace_level > 1) {
+      std::cerr << "begin iteration..." << std::endl;
+    }
+    done = true;
+    for (index_type k = 0; k < instance.n_atoms(); k++)
+      if (!sx.contains(k))
+ if (implies(sx, k, inc)) {
+   if (trace_level > 1) {
+     std::cerr << instance.atoms[k].name
+        << " implied by ";
+     instance.write_atom_set(std::cerr, sx);
+     std::cerr << std::endl;
+   }
+   sx.insert(k);
+   is.insert(k);
+   done = false;
+ }
+    if (trace_level > 1) {
+      std::cerr << "end iteration, done = " << done << std::endl;
+    }
+  }
+  stats.stop();
+}
+bool Preprocessor::landmark_test
+(const index_set& init, const index_set& goal, index_type p, bool opt_H2)
+{
+  if (goal.contains(p)) return true;
+  stats.start();
+  Instance* test_instance = new Instance(instance);
+  test_instance->set_initial(init);
+  test_instance->set_goal(goal);
+  test_instance->atoms[p].init = false;
+  for (index_type k = 0; k < test_instance->n_actions(); k++)
+    test_instance->actions[k].add.subtract(p);
+  test_instance->cross_reference();
+  CostTable* test_reachability = new CostTable(*test_instance, stats);
+  if (opt_H2)
+    test_reachability->compute_H2(ZeroACF());
+  else
+    test_reachability->compute_H1(ZeroACF());
+  hsps::rational val = test_reachability->eval(goal);
+  delete test_reachability;
+  delete test_instance;
+  stats.stop();
+  return (val).infinite();
+}
+void Preprocessor::compute_landmarks
+(bool exclude_goal, bool exclude_init, bool_vec& landmark_atoms)
+{
+  stats.start();
+  landmark_atoms.assign_value(false, instance.n_atoms());
+  for (index_type k = 0; k < instance.n_atoms(); k++) {
+    if (instance.atoms[k].goal) {
+      if (!exclude_goal) landmark_atoms[k] = true;
+    }
+    else if (instance.atoms[k].init) {
+      if (!exclude_init)
+ if (landmark_test(instance.init_atoms, instance.goal_atoms, k))
+   landmark_atoms[k] = true;
+    }
+    else {
+      if (landmark_test(instance.init_atoms, instance.goal_atoms, k))
+ landmark_atoms[k] = true;
+    }
+  }
+  stats.stop();
+}
+void Preprocessor::compute_landmarks
+(bool exclude_goal, bool exclude_init, index_set& landmark_atoms)
+{
+  bool_vec lm;
+  compute_landmarks(exclude_goal, exclude_init, lm);
+  lm.copy_to(landmark_atoms);
+}
+void Preprocessor::compute_landmarks
+(const index_set& init, const index_set& goal, index_set& landmark_atoms)
+{
+  stats.start();
+  landmark_atoms.clear();
+  for (index_type k = 0; k < instance.n_atoms(); k++) {
+    if (landmark_test(init, goal, k)) landmark_atoms.insert(k);
+  }
+  stats.stop();
+}
+void Preprocessor::compute_landmark_graph(graph& g, bool opt_H2)
+{
+  stats.start();
+  g.init(instance.n_atoms());
+  for (index_type i = 0; i < instance.n_atoms(); i++) {
+    index_set goal_i;
+    goal_i.assign_singleton(i);
+    for (index_type j = 0; j < instance.n_atoms(); j++) if (j != i) {
+      if (landmark_test(instance.init_atoms, goal_i, j, opt_H2))
+ g.add_edge(j, i);
+    }
+  }
+  stats.stop();
+}
+void Preprocessor::quick_landmark_graph(graph& g, bool opt_H2)
+{
+  stats.start();
+  g.init(instance.n_atoms());
+  for (index_type i = 0; i < instance.n_atoms(); i++) {
+    Instance* test_instance = new Instance(instance);
+    test_instance->atoms[i].init = false;
+    for (index_type k = 0; k < test_instance->n_actions(); k++)
+      test_instance->actions[k].add.subtract(i);
+    test_instance->cross_reference();
+    CostTable* test_reachability = new CostTable(*test_instance, stats);
+    if (opt_H2)
+      test_reachability->compute_H2(ZeroACF());
+    else
+      test_reachability->compute_H1(ZeroACF());
+    for (index_type j = 0; j < instance.n_atoms(); j++) if (i != j) {
+      hsps::rational val = test_reachability->eval(j);
+      if ((val).infinite()) g.add_edge(i, j);
+    }
+    delete test_reachability;
+    delete test_instance;
+  }
+  stats.stop();
+}
+void Preprocessor::compute_hierarchy(graph& g0, index_set_graph& g)
+{
+  g0.init(instance.n_atoms());
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    for (index_type i = 0; i < instance.actions[k].add.length(); i++) {
+      for (index_type j = i+1; j < instance.actions[k].add.length(); j++)
+        g0.add_undirected_edge(instance.actions[k].add[i],
+          instance.actions[k].add[j]);
+      for (index_type j = 0; j < instance.actions[k].del.length(); j++)
+        g0.add_undirected_edge(instance.actions[k].add[i],
+          instance.actions[k].del[j]);
+      for (index_type j = 0; j < instance.actions[k].pre.length(); j++)
+        g0.add_edge(instance.actions[k].add[i],
+      instance.actions[k].pre[j]);
+    }
+    for (index_type i = 0; i < instance.actions[k].del.length(); i++) {
+      for (index_type j = i+1; j < instance.actions[k].del.length(); j++)
+        g0.add_undirected_edge(instance.actions[k].del[i],
+          instance.actions[k].del[j]);
+      for (index_type j = 0; j < instance.actions[k].pre.length(); j++)
+        g0.add_edge(instance.actions[k].del[i],
+      instance.actions[k].pre[j]);
+    }
+  }
+  g0.remove_loops();
+  g0.strongly_connected_components();
+  g0.component_tree(g);
+  for (index_type k = 0; k < g0.n_components(); k++)
+    g0.component_node_set(k, g.node_label(k));
+}
+void Preprocessor::compute_hierarchy(index_set_graph& g)
+{
+  graph g0(instance.n_atoms());
+  compute_hierarchy(g0, g);
+}
+void Preprocessor::write_heuristic_graph
+(std::ostream& s, Heuristic& h, const ACF& cost,
+ const bool_vec& atoms, const bool_vec& actions)
+{
+  hsps::rational c_max = 0;
+  for (index_type i = 0; i < instance.n_atoms(); i++)
+    if (atoms[i])
+      if ((h.eval(i)).finite())
+ c_max = hsps::rational::max(c_max,h.eval(i));
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    if (actions[k])
+      if ((h.eval(instance.actions[k].pre)).finite())
+ c_max = hsps::rational::max(c_max,h.eval(instance.actions[k].pre));
+  s << "digraph HG  {" << std::endl;
+  s << "rankdir=LR;" << std::endl;
+  s << "node [width=0,height=0];" << std::endl;
+  hsps::rational l = 0;
+  while (l <= c_max) {
+    s << "{ rank = same; /* atom layer " << l << "*/" << std::endl;
+    s << "LP" << l << "[shape=plaintext,label=\"P" << l << "\"];"
+    << std::endl;
+    for (index_type k = 0; k < instance.n_atoms(); k++) {
+      if (atoms[k] && (h.eval(k) == l)) {
+ s << "P" << k << "[shape=ellipse,label=\""
+   << instance.atoms[k].name << "\"";
+ if (instance.atoms[k].goal) {
+   s << ",style=bold";
+ }
+ s << "];" << std::endl;
+      }
+    }
+    s << "}" << std::endl;
+    s << "{ rank = same; /* action layer " << l << "*/" << std::endl;
+    s << "LA" << l << "[shape=plaintext,label=\"A" << l << "\"];"
+      << std::endl;
+    for (index_type k = 0; k < instance.n_actions(); k++) {
+      if (actions[k] && (h.eval(instance.actions[k].pre) == l)) {
+ s << "A" << k << "[shape=box,label=\""
+   << instance.actions[k].name << "\"];" << std::endl;
+      }
+    }
+    s << "}" << std::endl;
+    l = l + 1;
+  }
+  l = 0;
+  while (l <= c_max) {
+    s << "LP" << l << " -> LA" << l << " [style=invis];" << std::endl;
+    if (l > 0) {
+      s << "LA" << l-1 << " -> LP" << l << " [style=invis];" << std::endl;
+    }
+    l = l + 1;
+  }
+  for (index_type k = 0; k < instance.n_actions(); k++) if (actions[k]) {
+    Instance::Action& act = instance.actions[k];
+    hsps::rational c_pre = h.eval(act.pre);
+    for (index_type i = 0; i < act.pre.length(); i++) if (atoms[act.pre[i]]) {
+      s << "P" << act.pre[i] << " -> A" << k;
+      if (c_pre == h.eval(act.pre[i])) {
+ s << " [style=bold]";
+      }
+      s << ";" << std::endl;
+    }
+    for (index_type i = 0; i < act.add.length(); i++) if (atoms[act.add[i]]) {
+      s << "A" << k << " -> P" << act.add[i];
+      if ((c_pre + cost(act.index)) <= h.eval(act.add[i])) {
+ s << " [style=bold]";
+      }
+      else {
+ s << " [constraint=false]";
+      }
+      s << ";" << std::endl;
+    }
+  }
+  s << "}" << std::endl;
+}
+void Preprocessor::write_heuristic_graph
+(std::ostream& s, Heuristic& h, const ACF& cost)
+{
+  bool_vec atoms(true, instance.n_atoms());
+  bool_vec actions(true, instance.n_actions());
+  write_heuristic_graph(s, h, cost, atoms, actions);
+}
+void Preprocessor::write_relevance_graph
+(std::ostream& s,
+ const index_vec& d_atm,
+ const index_vec& d_act,
+ const bool_vec& mark_atm,
+ const bool_vec& mark_act,
+ const char* label)
+{
+  index_type m = 0;
+  for (index_type k = 0; k < instance.n_atoms(); k++)
+    if ((d_atm[k] != no_such_index) && (d_atm[k] > m)) m = d_atm[k];
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    if ((d_act[k] != no_such_index) && (d_act[k] > m)) m = d_act[k];
+  s << "digraph RG  {" << std::endl;
+  if (label) {
+    s << "label=\"" << label << "\";" << std::endl;
+  }
+  s << "rankdir=TB;" << std::endl;
+  s << "node [width=0,height=0];" << std::endl;
+  for (index_type d = 0; d <= m; d++) {
+    s << "{ rank = same; /* " << d << " */" << std::endl;
+    for (index_type k = 0; k < instance.n_atoms(); k++)
+      if (d_atm[k] == d) {
+ s << " ATM" << k << " [shape=ellipse,";
+ if (mark_atm[k]) s << "style=bold,";
+ s << "label=\"" << instance.atoms[k].name << "\"];" << std::endl;
+      }
+    s << "}" << std::endl << "{ rank = same; /* " << d << " */" << std::endl;
+    for (index_type k = 0; k < instance.n_actions(); k++)
+      if (d_act[k] == d) {
+ s << " ACT" << k << " [shape=box,";
+ if (mark_act[k]) s << "style=bold,";
+ s << "label=\"" << instance.actions[k].name << "\"];" << std::endl;
+      }
+    s << "}" << std::endl;
+  }
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    if (d_act[k] != no_such_index) {
+      for (index_type i = 0; i < instance.actions[k].add.length(); i++)
+ if (d_atm[instance.actions[k].add[i]] != no_such_index) {
+   s << " ATM" << instance.actions[k].add[i] << " -> ACT" << k;
+   if (mark_atm[instance.actions[k].add[i]] && mark_act[k]) {
+     if (d_atm[instance.actions[k].add[i]] > d_act[k])
+       s << " [style=bold,constraint=false]";
+     else
+       s << " [style=bold]";
+   }
+   else if (d_atm[instance.actions[k].add[i]] > d_act[k])
+     s << " [constraint=false]";
+   s << ";" << std::endl;
+ }
+      for (index_type i = 0; i < instance.actions[k].pre.length(); i++) {
+ assert(d_atm[instance.actions[k].pre[i]] != no_such_index);
+ s << " ACT" << k << " -> ATM" << instance.actions[k].pre[i];
+ if (mark_atm[instance.actions[k].pre[i]] && mark_act[k]) {
+   if (d_atm[instance.actions[k].pre[i]] <= d_act[k])
+     s << " [style=bold,constraint=false]";
+   else
+     s << " [style=bold]";
+ }
+ else if (d_atm[instance.actions[k].pre[i]] <= d_act[k])
+   s << " [constraint=false]";
+ s << ";" << std::endl;
+      }
+    }
+  s << "}" << std::endl;
+}
+void Preprocessor::write_relevance_graph
+(std::ostream& s, const index_vec& d_atm, const index_vec& d_act,
+ const char* label)
+{
+  bool_vec mark_atm(false, instance.n_atoms());
+  bool_vec mark_act(false, instance.n_actions());
+  write_relevance_graph(s, d_atm, d_act, mark_atm, mark_act, label);
+}
+}

--- a/pr/seq-opt-hspsf/problem.ccx
+++ b/pr/seq-opt-hspsf/problem.ccx
@@ -1,0 +1,7611 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+bool Instance::write_negation = true;
+bool Instance::write_DKEL = true;
+bool Instance::write_PDDL2 = true;
+bool Instance::write_time = true;
+bool Instance::write_PDDL3 = true;
+bool Instance::write_metric = true;
+bool Instance::write_extra = true;
+bool Instance::write_resource_constraints_at_start = false;
+bool Instance::always_write_parameters = false;
+bool Instance::always_write_requirements = false;
+bool Instance::always_write_precondition = false;
+bool Instance::always_write_effect = false;
+bool Instance::always_write_conjunction = false;
+bool Instance::write_atom_set_with_symbolic_names = true;
+bool Instance::write_action_set_with_symbolic_names = true;
+int Instance::default_trace_level = 0;
+const char* Instance::goal_atom_name = "GoalReached";
+const char* Instance::goal_action_name = "GoalAction";
+hsps::rational Instance::goal_action_cost = 0;
+const char* Instance::pc_name = "constraint";
+index_type Instance::pc_count = 0;
+index_type rule_set::find_rule(index_type c) const
+{
+  for (index_type k = 0; k < length(); k++) {
+    if ((*this)[k].consequent == c) return k;
+    if ((*this)[k].consequent > c) return no_such_index;
+  }
+  return no_such_index;
+}
+void rule_set::compute_dependency_graph
+(index_type n, index_graph& g) const
+{
+  g.init(n);
+  for (index_type k = 0; k < length(); k++) {
+    g.node_label((*this)[k].consequent) = (*this)[k].consequent;
+    for (index_type i = 0; i < (*this)[k].antecedent.length(); i++) {
+      g.add_edge((*this)[k].consequent, (*this)[k].antecedent[i]);
+      g.edge_label((*this)[k].consequent, (*this)[k].antecedent[i]) = k;
+      g.node_label((*this)[k].antecedent[i]) = (*this)[k].antecedent[i];
+    }
+  }
+}
+void rule_set::remove(const bool_vec& set, index_vec& map)
+{
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  map.assign_value(no_such_index, length());
+  while (scan_p < length()) {
+    if (!set[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      map[scan_p] = put_p;
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  set_length(put_p);
+}
+void rule_set::remove(const bool_vec& set, index_graph& g)
+{
+  index_vec map;
+  remove(set, map);
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ if (map[g.edge_label(i, j)] == no_such_index) {
+   g.remove_edge(i, j);
+   g.edge_label(i, j) = no_such_index;
+ }
+ else {
+   g.edge_label(i, j) = map[g.edge_label(i, j)];
+ }
+      }
+}
+void rule_set::remove(const bool_vec& set)
+{
+  index_vec map;
+  remove(set, map);
+}
+void rule_set::make_acyclic(index_graph& dg)
+{
+  if (empty()) return;
+  bool_vec keep(true, length());
+  dg.strongly_connected_components();
+  index_type c = dg.maximal_non_unit_component();
+  while (c != no_such_index) {
+    index_set rc;
+    for (index_type k = 0; k < length(); k++) {
+      const rule& r = (*this)[k];
+      if (dg.component(r.consequent) == c) {
+ bool f = false;
+ for (index_type i = 0; (i < r.antecedent.length()) && !f; i++) {
+   if (dg.component(r.antecedent[i]) == c) {
+     f = true;
+     rc.insert(k);
+   }
+ }
+      }
+    }
+    assert(!rc.empty());
+    index_type p = no_such_index;
+    for (index_type k = 0; (k < rc.length()) && (p == no_such_index); k++) {
+      const rule& r = (*this)[rc[k]];
+      for (index_type i = 0; (i < length()) && (p == no_such_index); i++)
+ if (!rc.contains(i) && ((*this)[i].consequent == r.consequent))
+   p = rc[k];
+    }
+    for (index_type k = 0; (k < rc.length()) && (p == no_such_index); k++) {
+      const rule& r = (*this)[rc[k]];
+      for (index_type i = 0; (i < rc.length()) && (p == no_such_index); i++)
+ if ((*this)[rc[i]].consequent == r.consequent) {
+   if ((*this)[rc[i]].antecedent.length() < r.antecedent.length())
+     p = rc[i];
+   else
+     p = rc[k];
+ }
+    }
+    if (p == no_such_index) {
+      p = rc[0];
+      for (index_type k = 1; k < rc.length(); k++) {
+ const rule& r = (*this)[rc[k]];
+ if (r.antecedent.length() > (*this)[p].antecedent.length())
+   p = rc[k];
+      }
+    }
+    assert((p < length()) && keep[p]);
+    dg.remove_edges_with_label(p);
+    keep[p] = false;
+    dg.strongly_connected_components();
+    c = dg.maximal_non_unit_component();
+  }
+  if (keep.count(true) < length()) {
+    keep.complement();
+    remove(keep, dg);
+  }
+}
+void rule_set::make_post_unique(index_graph& dg)
+{
+  if (empty()) return;
+  bool_vec keep(true, length());
+  for (index_type k = 0; k < length(); k++) if (keep[k]) {
+    const rule& r = (*this)[k];
+    index_set rsc;
+    for (index_type i = k + 1; i < length(); i++)
+      if ((*this)[i].consequent == r.consequent)
+ rsc.insert(i);
+    if (!rsc.empty()) {
+      rsc.insert(k);
+      index_type p = rsc[0];
+      index_type s = dg.count_reachable((*this)[p].consequent);
+      for (index_type i = 1; i < rsc.length(); i++) {
+ index_type si = dg.count_reachable((*this)[rsc[i]].consequent);
+ if (si < s) {
+   p = rsc[i];
+   s = si;
+ }
+      }
+      assert(p < rsc.length());
+      for (index_type i = 0; i < rsc.length(); i++)
+ if (rsc[i] != p) keep[rsc[i]] = false;
+    }
+  }
+  if (keep.count(true) < length()) {
+    keep.complement();
+    remove(keep, dg);
+  }
+}
+bool Instance::Action::e_deletes(index_type p, Heuristic* inc) const
+{
+  if (del.contains(p)) return true;
+  if (inc) {
+    if ((inc->incremental_eval(pre, p)).infinite()) return true;
+  }
+  return false;
+}
+bool Instance::Action::e_deletes(const index_set& s, Heuristic* inc) const
+{
+  if (add.first_common_element(s) != no_such_index)
+    return false;
+  for (index_type k = 0; k < s.length(); k++)
+    if (!e_deletes(s[k], inc)) return false;
+  return true;
+}
+Instance::Instance()
+  : xrf(false),
+    name(0),
+    atoms(Atom(), 0),
+    actions(Action(), 0),
+    resources(Resource(), 0),
+    invariants(Constraint(), 0),
+    init_atoms(),
+    goal_atoms(),
+    max_pre(0), max_add(0), max_del(0), max_lck(0),
+    max_add_by(0), max_del_by(0), max_req_by(0),
+    min_dur(POS_INF), max_dur(NEG_INF),
+    min_cost(POS_INF), max_cost(NEG_INF),
+    atom_set_hash(0), action_set_hash(0),
+    trace_level(default_trace_level)
+{
+}
+Instance::Instance(const Name* n)
+  : xrf(false),
+    name(n),
+    atoms(Atom(), 0),
+    actions(Action(), 0),
+    resources(Resource(), 0),
+    invariants(Constraint(), 0),
+    init_atoms(),
+    goal_atoms(),
+    max_pre(0), max_add(0), max_del(0), max_lck(0),
+    max_add_by(0), max_del_by(0), max_req_by(0),
+    min_dur(POS_INF), max_dur(NEG_INF),
+    min_cost(POS_INF), max_cost(NEG_INF),
+    atom_set_hash(0), action_set_hash(0),
+    trace_level(default_trace_level)
+{
+}
+Instance::Instance(const Instance& ins)
+  : xrf(false),
+    name(ins.name),
+    atoms(ins.atoms),
+    actions(ins.actions),
+    resources(ins.resources),
+    invariants(ins.invariants),
+    init_atoms(ins.init_atoms),
+    goal_atoms(ins.goal_atoms),
+    max_pre(0), max_add(0), max_del(0), max_lck(0),
+    max_add_by(0), max_del_by(0), max_req_by(0),
+    min_dur(POS_INF), max_dur(NEG_INF),
+    min_cost(POS_INF), max_cost(NEG_INF),
+    atom_set_hash(ins.n_atoms()),
+    action_set_hash(ins.n_atoms()),
+    trace_level(ins.trace_level)
+{
+}
+Instance::Atom& Instance::new_atom(const Name* name)
+{
+  Atom& p = atoms.append();
+  p.index = atoms.length() - 1;
+  p.name = name;
+  p.neg = no_such_index;
+  p.init = false;
+  p.init_t = 0;
+  p.goal = false;
+  p.goal_t = POS_INF;
+  p.irrelevant = false;
+  p.req_by.clear();
+  p.add_by.clear();
+  p.del_by.clear();
+  if (trace_level > 2) {
+    std::cerr << "atom " << p.index << "." << p.name
+       << " created" << ::std::endl;
+  }
+  return p;
+}
+Instance::Resource& Instance::new_resource(const Name* name)
+{
+  Resource& r = resources.append();
+  r.index = resources.length() - 1;
+  r.name = name;
+  r.init = 0;
+  if (trace_level > 2) {
+    std::cerr << "resouce " << r.index << "." << r.name
+       << " created" << ::std::endl;
+  }
+  return r;
+}
+Instance::Action& Instance::new_action(const Name* name)
+{
+  Action& a = actions.append();
+  a.index = actions.length() - 1;
+  a.name = name;
+  a.pre.clear();
+  a.add.clear();
+  a.del.clear();
+  a.lck.clear();
+  a.use.assign_value(0);
+  a.cons.assign_value(0);
+  a.dur = 1;
+  a.cost = 1;
+  a.ncw_atms.clear();
+  if (trace_level > 2) {
+    ::std::cerr << "action " << a.index << "." << a.name
+       << " created" << ::std::endl;
+  }
+  return a;
+}
+Instance::Action& Instance::copy_action(index_type a1)
+{
+  Action& a = actions.append();
+  a.index = actions.length() - 1;
+  a.name = actions[a1].name;
+  a.pre = actions[a1].pre;
+  a.add = actions[a1].add;
+  a.del = actions[a1].del;
+  a.lck = actions[a1].lck;
+  a.use = actions[a1].use;
+  a.cons = actions[a1].cons;
+  a.dur = actions[a1].dur;
+  a.cost = actions[a1].cost;
+  a.ncw_atms.clear();
+  if (trace_level > 2) {
+    ::std::cerr << "action " << a.index << "." << a.name
+  << " created as copy of " << a1
+  << ::std::endl;
+  }
+  return a;
+}
+Instance::Constraint& Instance::new_invariant()
+{
+  Constraint& c = invariants.append();
+  c.index = invariants.length() - 1;
+  c.name = 0;
+  c.set.clear();
+  c.lim = 0;
+  c.exact = false;
+  c.verified = false;
+  if (trace_level > 2) {
+    std::cerr << "invariant " << invariants.length() - 1
+       << " created" << ::std::endl;
+  }
+  return c;
+}
+Instance::Constraint& Instance::new_invariant(const Name* name)
+{
+  Constraint& c = invariants.append();
+  c.index = invariants.length() - 1;
+  c.name = name;
+  c.set.clear();
+  c.lim = 0;
+  c.exact = false;
+  c.verified = false;
+  if (trace_level > 2) {
+    std::cerr << "invariant " << name << " (" << invariants.length() - 1
+       << ") created" << ::std::endl;
+  }
+  return c;
+}
+Instance::Constraint& Instance::new_invariant
+(const index_set& s, index_type l, bool e)
+{
+  for (index_type k = 0; k < invariants.length(); k++) {
+    if ((invariants[k].lim == l) && (invariants[k].exact == e)) {
+      if (invariants[k].set.contains(s)) {
+ return invariants[k];
+      }
+      else if (s.contains(invariants[k].set)) {
+ invariants[k].set = s;
+ return invariants[k];
+      }
+    }
+  }
+  Constraint& c = new_invariant();
+  c.set = s;
+  c.lim = l;
+  c.exact = e;
+  c.verified = false;
+  return c;
+}
+void Instance::atom_names(name_vec& names) const
+{
+  names.clear();
+  for (index_type k = 0; k < n_atoms(); k++)
+    names.append(atoms[k].name);
+}
+void Instance::action_names(name_vec& names) const
+{
+  names.clear();
+  for (index_type k = 0; k < n_actions(); k++)
+    names.append(actions[k].name);
+}
+void Instance::assign_unique_action_names()
+{
+  bool_vec cov(false, n_actions());
+  for (index_type k = 0; k < n_actions(); k++) if (!cov[k]) {
+    index_set s;
+    for (index_type i = k; i < n_actions(); i++)
+      if (actions[i].name->equals(actions[k].name)) {
+ s.insert(i);
+ cov[i] = true;
+      }
+    if (s.length() > 0) {
+      const Name* b = actions[k].name;
+      for (index_type i = 0; i < s.length(); i++)
+ actions[s[i]].name = new CopyName(b, i);
+    }
+  }
+}
+void Instance::coadd_graph(graph& g) const
+{
+  g.init(n_atoms());
+  for (index_type k = 0; k < n_actions(); k++) {
+    for (index_type i = 0; i < actions[k].add.length(); i++)
+      for (index_type j = i + 1; j < actions[k].add.length(); j++)
+ g.add_undirected_edge(actions[k].add[i], actions[k].add[j]);
+  }
+}
+void Instance::cochange_graph(graph& g) const
+{
+  g.init(n_atoms());
+  for (index_type k = 0; k < n_actions(); k++) {
+    for (index_type i = 0; i < actions[k].add.length(); i++)
+      for (index_type j = i + 1; j < actions[k].add.length(); j++)
+ g.add_undirected_edge(actions[k].add[i], actions[k].add[j]);
+    for (index_type i = 0; i < actions[k].del.length(); i++)
+      for (index_type j = i + 1; j < actions[k].del.length(); j++)
+ g.add_undirected_edge(actions[k].del[i], actions[k].del[j]);
+    for (index_type i = 0; i < actions[k].add.length(); i++)
+      for (index_type j = 0; j < actions[k].del.length(); j++)
+ g.add_undirected_edge(actions[k].add[i], actions[k].del[j]);
+  }
+}
+void Instance::causal_graph(graph& g) const
+{
+  cochange_graph(g);
+  for (index_type k = 0; k < n_actions(); k++) {
+    for (index_type i = 0; i < actions[k].add.length(); i++)
+      for (index_type j = 0; j < actions[k].pre.length(); j++)
+ g.add_edge(actions[k].add[i], actions[k].pre[j]);
+  }
+}
+void Instance::partitioning_graph
+(const index_set& goal, index_set_graph& g, index_set& n_goal) const
+{
+  graph ccg;
+  cochange_graph(ccg);
+  equivalence eq(n_atoms());
+  for (index_type i = 0; i < goal.length(); i++) {
+    for (index_type j = i + 1; j < goal.length(); j++)
+      if (ccg.adjacent(goal[i], goal[j]))
+ eq.merge(goal[i], goal[j]);
+    for (index_type k = 0; k < n_invariants(); k++)
+      if ((invariants[k].lim == 1) &&
+   invariants[k].set.contains(goal[i]) &&
+   (invariants[k].exact)) {
+ eq.merge(invariants[k].set);
+      }
+  }
+  index_set_graph g_tmp(ccg, eq);
+  g.copy(g_tmp);
+  index_vec m;
+  eq.make_map(m);
+  n_goal.assign_remap(goal, m);
+  bool done = false;
+  index_type d = 1;
+  while (!done) {
+    done = true;
+    eq.reset(g.size());
+    for (index_type k = 0; k < n_goal.length(); k++) {
+      for (index_type i = 0; i < g.bidirectional(n_goal[k]).length(); i++) {
+ bool in_cfl = false;
+ for (index_type j = 0; j < n_goal.length(); j++)
+   if ((j != k) &&
+       (g.bi_adjacent(g.bidirectional(n_goal[k])[i], n_goal[j]) ||
+        g.bi_adjacent(g.bidirectional(n_goal[k])[i],
+        g.bidirectional(n_goal[j]))))
+     in_cfl = true;
+ if (!in_cfl) {
+   eq.merge(n_goal[k], g.bidirectional(n_goal[k])[i]);
+   done = false;
+ }
+      }
+    }
+    g.quotient(g_tmp, eq);
+    g.copy(g_tmp);
+    eq.make_map(m);
+    n_goal.remap(m);
+  }
+}
+void Instance::make_graph_representation(index_graph& g, name_vec& nn)
+{
+  g.init(n_atoms() + n_actions());
+  nn.assign_value(0, n_atoms() + n_actions());
+  index_type o = n_atoms();
+  for (index_type k = 0; k < n_atoms(); k++) {
+    g.node_label(k) = (index_graph::NS_ELLIPSE +
+         (atoms[k].init ? index_graph::NS_FILLED : 0) +
+         (atoms[k].goal ? index_graph::NS_DOUBLE : 0));
+    nn[k] = atoms[k].name;
+  }
+  for (index_type k = 0; k < n_actions(); k++) {
+    g.node_label(o + k) = index_graph::NS_BOX;
+    nn[o + k] = actions[k].name;
+    for (index_type i = 0; i < actions[k].add.length(); i++) {
+      g.add_edge(o + k, actions[k].add[i]);
+      g.edge_label(o + k, actions[k].add[i]) =
+ index_graph::ES_NORMAL + index_graph::ED_FORWARD;
+    }
+    for (index_type i = 0; i < actions[k].pre.length(); i++) {
+      g.add_edge(actions[k].pre[i], o + k);
+      if (actions[k].del.contains(actions[k].pre[i]))
+ g.edge_label(actions[k].pre[i], o + k) =
+   index_graph::ES_NORMAL + index_graph::ED_FORWARD;
+      else
+ g.edge_label(actions[k].pre[i], o + k) =
+   index_graph::ES_DASHED + index_graph::ED_FORWARD;
+    }
+    for (index_type i = 0; i < actions[k].del.length(); i++)
+      if (!actions[k].pre.contains(actions[k].del[i])) {
+ g.add_edge(o + k, actions[k].del[i]);
+ g.edge_label(o + k, actions[k].del[i]) =
+   index_graph::ES_BOLD + index_graph::ED_NONE;
+      }
+  }
+}
+void Instance::copy(const Instance& ins)
+{
+  name = ins.name;
+  atoms = ins.atoms;
+  resources = ins.resources;
+  actions = ins.actions;
+  invariants = ins.invariants;
+  xrf = false;
+}
+Instance* Instance::copy() const
+{
+  Instance* new_ins = new Instance();
+  new_ins->copy(*this);
+  return new_ins;
+}
+void Instance::clear()
+{
+  atoms.clear();
+  actions.clear();
+  resources.clear();
+  invariants.clear();
+  clear_cross_reference();
+}
+void Instance::restricted_copy
+(const Instance& ins, const index_set& atms, const index_set& rc,
+ index_set& acts, index_vec& map)
+{
+  clear();
+  map.assign_value(no_such_index, ins.n_atoms());
+  for (index_type k = 0; k < atms.length(); k++) {
+    assert(atms[k] < ins.n_atoms());
+    Atom& a = new_atom(ins.atoms[atms[k]].name);
+    a.init = ins.atoms[atms[k]].init;
+    a.goal = ins.atoms[atms[k]].goal;
+    map[atms[k]] = a.index;
+  }
+  for (index_type k = 0; k < rc.length(); k++) {
+    assert(rc[k] < ins.n_resources());
+    Resource& r = new_resource(ins.resources[rc[k]].name);
+    r.init = ins.resources[rc[k]].init;
+  }
+  acts.clear();
+  for (index_type k = 0; k < ins.actions.length(); k++)
+    if (ins.actions[k].add.count_common(atms) > 0) {
+      Action& a = new_action(ins.actions[k].name);
+      for (index_type i = 0; i < ins.actions[k].pre.length(); i++)
+ if (map[ins.actions[k].pre[i]] != no_such_index)
+   a.pre.insert(map[ins.actions[k].pre[i]]);
+      for (index_type i = 0; i < ins.actions[k].add.length(); i++)
+ if (map[ins.actions[k].add[i]] != no_such_index)
+   a.add.insert(map[ins.actions[k].add[i]]);
+      for (index_type i = 0; i < ins.actions[k].del.length(); i++)
+ if (map[ins.actions[k].del[i]] != no_such_index)
+   a.del.insert(map[ins.actions[k].del[i]]);
+      for (index_type i = 0; i < ins.actions[k].lck.length(); i++)
+ if (map[ins.actions[k].lck[i]] != no_such_index)
+   a.lck.insert(map[ins.actions[k].lck[i]]);
+      for (index_type i = 0; i < n_resources(); i++)
+ a.use[i] = ins.actions[k].use[rc[i]];
+      for (index_type i = 0; i < n_resources(); i++)
+ a.cons[i] = ins.actions[k].cons[rc[i]];
+      a.dur = ins.actions[k].dur;
+      a.cost = ins.actions[k].cost;
+      acts.insert(k);
+    }
+  for (index_type k = 0; k < ins.invariants.length(); k++)
+    if (ins.invariants[k].set.count_common(atms) > ins.invariants[k].lim) {
+      Constraint& c = new_invariant(ins.invariants[k].name);
+      for (index_type i = 0; i < ins.invariants[k].set.length(); i++)
+ if (map[ins.invariants[k].set[i]] != no_such_index)
+   c.set.insert(map[ins.invariants[k].set[i]]);
+      c.lim = ins.invariants[k].lim;
+      c.exact = false;
+      c.verified = false;
+    }
+}
+void Instance::restricted_copy
+(const Instance& ins, const index_set& acts, index_vec& map)
+{
+  clear();
+  index_set atms;
+  for (index_type k = 0; k < acts.length(); k++) {
+    atms.insert(ins.actions[acts[k]].pre);
+    atms.insert(ins.actions[acts[k]].add);
+    atms.insert(ins.actions[acts[k]].del);
+    atms.insert(ins.actions[acts[k]].lck);
+  }
+  map.assign_value(no_such_index, ins.n_atoms());
+  for (index_type k = 0; k < atms.length(); k++) {
+    Atom& a = new_atom(ins.atoms[atms[k]].name);
+    a.init = ins.atoms[atms[k]].init;
+    a.goal = ins.atoms[atms[k]].goal;
+    map[atms[k]] = a.index;
+  }
+  for (index_type k = 0; k < acts.length(); k++) {
+    Action& a = new_action(ins.actions[acts[k]].name);
+    for (index_type i = 0; i < ins.actions[acts[k]].pre.length(); i++)
+      a.pre.insert(map[ins.actions[acts[k]].pre[i]]);
+    for (index_type i = 0; i < ins.actions[acts[k]].add.length(); i++)
+      a.add.insert(map[ins.actions[acts[k]].add[i]]);
+    for (index_type i = 0; i < ins.actions[acts[k]].del.length(); i++)
+      a.del.insert(map[ins.actions[acts[k]].del[i]]);
+    for (index_type i = 0; i < ins.actions[acts[k]].lck.length(); i++)
+      a.lck.insert(map[ins.actions[acts[k]].lck[i]]);
+    a.dur = ins.actions[acts[k]].dur;
+    a.cost = ins.actions[acts[k]].cost;
+  }
+  for (index_type k = 0; k < ins.invariants.length(); k++)
+    if (ins.invariants[k].set.count_common(atms) > ins.invariants[k].lim) {
+      Constraint& c = new_invariant(ins.invariants[k].name);
+      for (index_type i = 0; i < ins.invariants[k].set.length(); i++)
+ if (map[ins.invariants[k].set[i]] != no_such_index)
+   c.set.insert(map[ins.invariants[k].set[i]]);
+      c.lim = ins.invariants[k].lim;
+      c.exact = false;
+      c.verified = false;
+    }
+}
+void Instance::abstracted_copy
+(const Instance& ins, const index_set& atms, index_vec& atm_map,
+ index_vec& act_map)
+{
+  clear();
+  atm_map.assign_value(no_such_index, ins.n_atoms());
+  for (index_type k = 0; k < atms.length(); k++) {
+    assert(atms[k] < ins.n_atoms());
+    Atom& a = new_atom(ins.atoms[atms[k]].name);
+    a.init = ins.atoms[atms[k]].init;
+    a.goal = ins.atoms[atms[k]].goal;
+    atm_map[atms[k]] = a.index;
+  }
+  act_map.assign_value(no_such_index, ins.n_actions());
+  for (index_type k = 0; k < ins.actions.length(); k++) {
+    if (ins.actions[k].add.count_common(atms) > 0) {
+      index_set pre;
+      index_set add;
+      index_set del;
+      index_set lck;
+      for (index_type i = 0; i < ins.actions[k].pre.length(); i++)
+ if (atm_map[ins.actions[k].pre[i]] != no_such_index)
+   pre.insert(atm_map[ins.actions[k].pre[i]]);
+      for (index_type i = 0; i < ins.actions[k].add.length(); i++)
+ if (atm_map[ins.actions[k].add[i]] != no_such_index)
+   add.insert(atm_map[ins.actions[k].add[i]]);
+      for (index_type i = 0; i < ins.actions[k].del.length(); i++)
+ if (atm_map[ins.actions[k].del[i]] != no_such_index)
+   del.insert(atm_map[ins.actions[k].del[i]]);
+      for (index_type i = 0; i < ins.actions[k].lck.length(); i++)
+ if (atm_map[ins.actions[k].lck[i]] != no_such_index)
+   lck.insert(atm_map[ins.actions[k].lck[i]]);
+      bool found = false;
+      for (index_type i = 0; (i < n_actions()) && !found; i++) {
+ if ((actions[i].pre == pre) && (actions[i].add == add) &&
+     (actions[i].del == del) && (actions[i].lck == lck)) {
+   actions[i].dur = hsps::rational::min(actions[i].dur,ins.actions[k].dur);
+   actions[i].cost = hsps::rational::min(actions[i].cost,ins.actions[k].cost);
+   act_map[k] = i;
+   found = true;
+ }
+      }
+      if (!found) {
+ Action& a = new_action(ins.actions[k].name);
+ a.pre = pre;
+ a.add = add;
+ a.del = del;
+ a.lck = lck;
+ a.dur = ins.actions[k].dur;
+ a.cost = ins.actions[k].cost;
+ act_map[k] = a.index;
+      }
+    }
+    else {
+      act_map[k] = no_such_index;
+    }
+  }
+  for (index_type k = 0; k < ins.invariants.length(); k++) {
+    index_set s;
+    for (index_type i = 0; i < ins.invariants[k].set.length(); i++)
+      if (atm_map[ins.invariants[k].set[i]] != no_such_index)
+ s.insert(atm_map[ins.invariants[k].set[i]]);
+    if (s.length() > ins.invariants[k].lim) {
+      Constraint& c = new_invariant(s, ins.invariants[k].lim, false);
+      if (!c.name && ins.invariants[k].name)
+ c.name = ins.invariants[k].name;
+      c.verified = false;
+    }
+  }
+}
+void Instance::reverse_copy(const Instance& ins)
+{
+  clear();
+  for (index_type k = 0; k < ins.n_atoms(); k++) {
+    assert(ins.atoms[k].neg != no_such_index);
+    Atom& a = new_atom(ins.atoms[k].name);
+    if (ins.atoms[ins.atoms[k].neg].goal)
+      a.init = false;
+    else
+      a.init = true;
+    a.goal = ins.atoms[k].init;
+  }
+  for (index_type k = 0; k < ins.n_actions(); k++) {
+    index_set per_pre(ins.actions[k].pre);
+    per_pre.subtract(ins.actions[k].del);
+    index_set del_pre(ins.actions[k].pre);
+    del_pre.intersect(ins.actions[k].del);
+    Action& a = new_action(ins.actions[k].name);
+    a.pre = ins.actions[k].add;
+    a.pre.insert(per_pre);
+    ins.negation_atom_set(ins.actions[k].del, a.pre);
+    a.add = del_pre;
+    ins.negation_atom_set(ins.actions[k].pre, a.del);
+    for (index_type i = 0; i < ins.actions[k].add.length(); i++)
+      if (!ins.actions[k].pre.contains(ins.actions[k].add[i]) &&
+   !ins.actions[k].pre.contains(ins.atoms[ins.actions[k].add[i]].neg)) {
+ a.add.insert(ins.actions[k].add[i]);
+ a.add.insert(ins.atoms[ins.actions[k].add[i]].neg);
+      }
+    for (index_type i = 0; i < ins.actions[k].del.length(); i++)
+      if (!ins.actions[k].pre.contains(ins.actions[k].del[i]) &&
+   !ins.actions[k].pre.contains(ins.atoms[ins.actions[k].del[i]].neg)) {
+ a.add.insert(ins.actions[k].del[i]);
+ a.add.insert(ins.atoms[ins.actions[k].del[i]].neg);
+      }
+    a.lck = ins.actions[k].lck;
+    a.cost = ins.actions[k].cost;
+    a.dmin = ins.actions[k].dmin;
+    a.dmax = ins.actions[k].dmax;
+    a.dur = ins.actions[k].dur;
+    a.assoc = ins.actions[k].assoc;
+    a.src = ins.actions[k].src;
+  }
+}
+void Instance::delete_relax(const index_set& x_atms)
+{
+  for (index_type k = 0; k < n_actions(); k++)
+    actions[k].del.intersect(x_atms);
+}
+void Instance::delete_relax_less(const index_set& x_atms)
+{
+  for (index_type k = 0; k < n_actions(); k++)
+    if (actions[k].del.first_common_element(x_atms) == no_such_index)
+      actions[k].del.clear();
+}
+bool Instance::non_interfering(index_type a0, index_type a1) const
+{
+  for (index_type k = 0; k < actions[a0].del.length(); k++) {
+    if (actions[a1].pre.contains(actions[a0].del[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << actions[a0].name << " deletes "
+    << atoms[actions[a0].del[k]].name
+    << " precondition of "
+    << actions[a1].name << ::std::endl;
+      }
+      return false;
+    }
+    if (actions[a1].add.contains(actions[a0].del[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << actions[a0].name << " deletes "
+    << atoms[actions[a0].del[k]].name
+    << " added by "
+    << actions[a1].name << ::std::endl;
+      }
+      return false;
+    }
+  }
+  for (index_type k = 0; k < actions[a1].del.length(); k++) {
+    if (actions[a0].pre.contains(actions[a1].del[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << actions[a1].name << " deletes "
+    << atoms[actions[a1].del[k]].name
+    << " precondition of "
+    << actions[a0].name << ::std::endl;
+      }
+      return false;
+    }
+    if (actions[a0].add.contains(actions[a1].del[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << actions[a1].name << " deletes "
+    << atoms[actions[a1].del[k]].name
+    << " added by "
+    << actions[a0].name << ::std::endl;
+      }
+      return false;
+    }
+  }
+  return true;
+}
+bool Instance::lock_compatible(index_type a0, index_type a1) const
+{
+  for (index_type k = 0; k < actions[a0].lck.length(); k++) {
+    if (actions[a1].lck.contains(actions[a0].lck[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << actions[a0].name << " and "
+    << actions[a1].name << " both require "
+    << atoms[actions[a0].lck[k]].name << ::std::endl;
+      }
+      return false;
+    }
+    else if (actions[a1].del.contains(actions[a0].lck[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << actions[a1].name << " deletes "
+    << atoms[actions[a0].lck[k]].name << " locked by "
+    << actions[a0].name << ::std::endl;
+      }
+      return false;
+    }
+    else if (actions[a1].pre.contains(actions[a0].lck[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << actions[a0].name << " locks "
+    << atoms[actions[a0].lck[k]].name
+    << " persistent precondition of "
+    << actions[a1].name << ::std::endl;
+      }
+      return false;
+    }
+  }
+  for (index_type k = 0; k < actions[a1].lck.length(); k++) {
+    if (actions[a0].del.contains(actions[a1].lck[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << actions[a0].name << " deletes "
+    << atoms[actions[a1].lck[k]].name << " locked by "
+    << actions[a1].name << ::std::endl;
+      }
+      return false;
+    }
+    else if (actions[a0].pre.contains(actions[a1].lck[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << actions[a1].name << " locks "
+    << atoms[actions[a1].lck[k]].name
+    << " persistent precondition of "
+    << actions[a0].name << ::std::endl;
+      }
+      return false;
+    }
+  }
+  return true;
+}
+bool Instance::resource_compatible(index_type a0, index_type a1) const
+{
+  for (index_type k = 0; k < n_resources(); k++) {
+    hsps::rational sum = actions[a0].use[k] + actions[a1].use[k];
+    if (sum > resources[k].init) return false;
+  }
+  return true;
+}
+bool Instance::commutative
+(const Instance::Action& a0, const Instance::Action& a1) const
+{
+  for (index_type k = 0; k < a0.del.length(); k++) {
+    if (a1.pre.contains(a0.del[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << a0.name << " deletes "
+    << atoms[a0.del[k]].name
+    << " precondition of "
+    << a1.name << ::std::endl;
+      }
+      return false;
+    }
+    if (a1.add.contains(a0.del[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << a0.name << " deletes "
+    << atoms[a0.del[k]].name
+    << " added by "
+    << a1.name << ::std::endl;
+      }
+      return false;
+    }
+  }
+  for (index_type k = 0; k < a0.add.length(); k++) {
+    if (a1.pre.contains(a0.add[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << a0.name << " adds "
+    << atoms[a0.add[k]].name
+    << " precondition of "
+    << a1.name << ::std::endl;
+      }
+      return false;
+    }
+  }
+  for (index_type k = 0; k < a1.del.length(); k++) {
+    if (a0.pre.contains(a1.del[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << a1.name << " deletes "
+    << atoms[a1.del[k]].name
+    << " precondition of "
+    << a0.name << ::std::endl;
+      }
+      return false;
+    }
+    if (a0.add.contains(a1.del[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << a1.name << " deletes "
+    << atoms[a1.del[k]].name
+    << " added by "
+    << a0.name << ::std::endl;
+      }
+      return false;
+    }
+  }
+  for (index_type k = 0; k < a1.add.length(); k++) {
+    if (a0.pre.contains(a1.add[k])) {
+      if (trace_level > 3) {
+ ::std::cerr << a1.name << " adds "
+    << atoms[a1.add[k]].name
+    << " precondition of "
+    << a0.name << ::std::endl;
+      }
+      return false;
+    }
+  }
+  return true;
+}
+bool Instance::commutative(index_type a0, index_type a1) const
+{
+  return commutative(actions[a0], actions[a1]);
+}
+bool Instance::additive(index_type p0, index_type p1) const
+{
+  for (index_type k = 0; k < n_actions(); k++) {
+    if (actions[k].add.contains(p0) &&
+ actions[k].add.contains(p1))
+      return false;
+  }
+  return true;
+}
+bool Instance::cochanged(index_type p0, index_type p1) const
+{
+  for (index_type k = 0; k < n_actions(); k++) {
+    if (actions[k].add.contains(p0)) {
+      if (actions[k].add.contains(p1))
+ return true;
+      if (actions[k].del.contains(p1))
+ return true;
+    }
+    else if (actions[k].del.contains(p0)) {
+      if (actions[k].add.contains(p1))
+ return true;
+      if (actions[k].del.contains(p1))
+ return true;
+    }
+  }
+  return false;
+}
+bool Instance::eval_invariant_in_partial_state
+(const index_set& s, const Instance::Constraint& inv)
+{
+  index_type n = 0;
+  for (index_type i = 0; (i < inv.set.length()) && (n <= inv.lim); i++)
+    if (s.contains(inv.set[i])) n += 1;
+  if (n > inv.lim) {
+    if (trace_level > 2) {
+      ::std::cerr << "state ";
+      write_atom_set(::std::cerr, s);
+      ::std::cerr << " violates invariant " << '|';
+      write_atom_set(::std::cerr, inv.set);
+      ::std::cerr << "| <= " << inv.lim << ::std::endl;
+    }
+    return false;
+  }
+  else {
+    return true;
+  }
+}
+bool Instance::eval_invariant_in_partial_state
+(const bool_vec& s, const Instance::Constraint& inv)
+{
+  index_type n = 0;
+  for (index_type i = 0; (i < inv.set.length()) && (n <= inv.lim); i++)
+    if (s[inv.set[i]]) n += 1;
+  if (n > inv.lim) {
+    if (trace_level > 2) {
+      ::std::cerr << "state ";
+      write_atom_set(::std::cerr, s);
+      ::std::cerr << " violates invariant " << '|';
+      write_atom_set(::std::cerr, inv.set);
+      ::std::cerr << "| <= " << inv.lim << ::std::endl;
+    }
+    return false;
+  }
+  else {
+    return true;
+  }
+}
+bool Instance::eval_invariant_in_complete_state
+(const index_set& s, const Instance::Constraint& inv)
+{
+  index_type n = 0;
+  for (index_type i = 0; (i < inv.set.length()) && (n <= inv.lim); i++)
+    if (s.contains(inv.set[i])) n += 1;
+  if (n > inv.lim) {
+    if (trace_level > 2) {
+      ::std::cerr << "state ";
+      write_atom_set(::std::cerr, s);
+      ::std::cerr << " violates invariant " << '|';
+      write_atom_set(::std::cerr, inv.set);
+      ::std::cerr << "| <= " << inv.lim << ::std::endl;
+    }
+    return false;
+  }
+  else if ((n < inv.lim) && inv.exact) {
+    if (trace_level > 2) {
+      ::std::cerr << "state ";
+      write_atom_set(::std::cerr, s);
+      ::std::cerr << " violates invariant " << '|';
+      write_atom_set(::std::cerr, inv.set);
+      ::std::cerr << "| == " << inv.lim << ::std::endl;
+    }
+    return false;
+  }
+  else {
+    return true;
+  }
+}
+bool Instance::eval_invariant_in_complete_state
+(const bool_vec& s, const Instance::Constraint& inv)
+{
+  index_type n = 0;
+  for (index_type i = 0; (i < inv.set.length()) && (n <= inv.lim); i++)
+    if (s[inv.set[i]]) n += 1;
+  if (n > inv.lim) {
+    if (trace_level > 2) {
+      ::std::cerr << "state ";
+      write_atom_set(::std::cerr, s);
+      ::std::cerr << " violates invariant " << '|';
+      write_atom_set(::std::cerr, inv.set);
+      ::std::cerr << "| <= " << inv.lim << ::std::endl;
+    }
+    return false;
+  }
+  else if ((n < inv.lim) && inv.exact) {
+    if (trace_level > 2) {
+      ::std::cerr << "state ";
+      write_atom_set(::std::cerr, s);
+      ::std::cerr << " violates invariant " << '|';
+      write_atom_set(::std::cerr, inv.set);
+      ::std::cerr << "| == " << inv.lim << ::std::endl;
+    }
+    return false;
+  }
+  else {
+    return true;
+  }
+}
+void Instance::negation_atom_set(const index_set& pset, index_set& nset) const
+{
+  for (index_type k = 0; k < pset.length(); k++)
+    if (atoms[pset[k]].neg != no_such_index)
+      nset.insert(atoms[pset[k]].neg);
+}
+bool Instance::verify_invariant(Instance::Constraint& inv)
+{
+  if (!cross_referenced()) cross_reference();
+  if (trace_level > 1) {
+    ::std::cerr << "verifying invariant |";
+    write_atom_set(::std::cerr, inv.set);
+    ::std::cerr << "| " << (inv.exact ? "==" : "<=") << " " << inv.lim
+       << "..." << ::std::endl;
+  }
+  index_type init_n = init_atoms.count_common(inv.set);
+  if (init_n > inv.lim) {
+    if (trace_level > 2) {
+      ::std::cerr << " - violated by initial state" << ::std::endl;
+    }
+    return false;
+  }
+  else if (init_n < inv.lim) {
+    if (trace_level > 2) {
+      ::std::cerr << " - not exact in initial state" << ::std::endl;
+    }
+    return false;
+  }
+  for (index_type k = 0; k < n_actions(); k++) {
+    index_type n_pre = actions[k].pre.count_common(inv.set);
+    if (n_pre <= inv.lim) {
+      index_type n_add = actions[k].add.count_common(inv.set);
+      index_type n_del = actions[k].del.count_common(inv.set);
+      if (n_add > n_del) {
+ if (trace_level > 2) {
+   ::std::cerr << " - violated by action "
+      << actions[k].name << ::std::endl;
+ }
+ return false;
+      }
+      if (n_add < n_del) {
+ if (trace_level > 2) {
+   ::std::cerr << " - not exact by action "
+      << actions[k].name << ::std::endl;
+ }
+ return false;
+      }
+    }
+  }
+  if (!inv.exact) {
+    if (trace_level > 2) {
+      ::std::cerr << " - is in fact exact: strengthening" << ::std::endl;
+    }
+    inv.exact = true;
+  }
+  else if (trace_level > 2) {
+    ::std::cerr << " - ok" << ::std::endl;
+  }
+  return true;
+}
+void Instance::verify_invariants()
+{
+  if (trace_level > 0) {
+    ::std::cerr << "verifying invariants (instance only)..." << ::std::endl;
+  }
+  for (index_type k = 0; k < n_invariants(); k++)
+    invariants[k].verified = verify_invariant(invariants[k]);
+}
+index_type Instance::n_verified_invariants() const
+{
+  index_type n = 0;
+  for (index_type k = 0; k < n_invariants(); k++)
+    if (invariants[k].verified) n += 1;
+  return n;
+}
+void Instance::cross_reference()
+{
+  if (xrf) return;
+  for (index_type k = 0; k < actions.length(); k++) {
+    Action& act = actions[k];
+    for (index_type i = 0; i < act.pre.length(); i++)
+      atoms[act.pre[i]].req_by.append(k);
+    for (index_type i = 0; i < act.add.length(); i++)
+      atoms[act.add[i]].add_by.append(k);
+    for (index_type i = 0; i < act.del.length(); i++)
+      atoms[act.del[i]].del_by.append(k);
+    for (index_type i = 0; i < n_resources(); i++) {
+      if (act.use[i] > 0) resources[i].used = true;
+      if (act.cons[i] > 0) resources[i].consumed = true;
+    }
+    if (act.pre.length() > max_pre) max_pre = act.pre.length();
+    if (act.add.length() > max_add) max_add = act.add.length();
+    if (act.del.length() > max_del) max_del = act.del.length();
+    if (act.lck.length() > max_lck) max_lck = act.lck.length();
+    if (act.dur < min_dur) min_dur = act.dur;
+    if (act.dur > max_dur) max_dur = act.dur;
+    if (act.cost < min_cost) min_cost = act.cost;
+    if (act.cost > max_cost) max_cost = act.cost;
+  }
+  init_atoms.clear();
+  goal_atoms.clear();
+  for (index_type k = 0; k < atoms.length(); k++) {
+    Atom& prop = atoms[k];
+    if (prop.req_by.length() > max_req_by)
+      max_req_by = prop.req_by.length();
+    if (prop.add_by.length() > max_add_by)
+      max_add_by = prop.add_by.length();
+    if (prop.del_by.length() > max_del_by)
+      max_del_by = prop.del_by.length();
+    if (prop.init) init_atoms.insert(k);
+    if (prop.goal) goal_atoms.insert(k);
+  }
+  xrf = true;
+  atom_set_hash.init(n_atoms());
+  action_set_hash.init(n_actions());
+}
+void Instance::remap_set(index_set& set, const index_vec& map)
+{
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < set.length()) {
+    if (map[set[scan_p]] != no_such_index) {
+      set[put_p] = map[set[scan_p]];
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  set.set_length(put_p);
+}
+void Instance::remap_sets(index_set_vec& sets, const index_vec& map)
+{
+  for (index_type k = 0; k < sets.length(); k++)
+    remap_set(sets[k], map);
+}
+void Instance::remove_actions(const bool_vec& set, index_vec& map)
+{
+  assert(set.length() >= actions.length());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, actions.length());
+  while (scan_p < actions.length()) {
+    if (!set[scan_p]) {
+      if (put_p < scan_p) {
+ actions[put_p] = actions[scan_p];
+ actions[put_p].index = put_p;
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  actions.set_length(put_p);
+  for (index_type k = 0; k < map.length(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.length());
+      map[k] = rm_map[map[k]];
+    }
+}
+void Instance::remove_atoms(const bool_vec& set, index_vec& map)
+{
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, atoms.length());
+  while (scan_p < atoms.length()) {
+    if (!set[scan_p]) {
+      if (put_p < scan_p) {
+ atoms[put_p] = atoms[scan_p];
+ atoms[put_p].index = put_p;
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  atoms.set_length(put_p);
+  for (index_type k = 0; k < atoms.length(); k++) {
+    if (atoms[k].neg != no_such_index)
+      atoms[k].neg = rm_map[atoms[k].neg];
+  }
+  for (index_type k = 0; k < actions.length(); k++) {
+    remap_set(actions[k].pre, rm_map);
+    remap_set(actions[k].add, rm_map);
+    remap_set(actions[k].del, rm_map);
+    remap_set(actions[k].lck, rm_map);
+  }
+  for (index_type k = 0; k < invariants.length(); k++) {
+    remap_set(invariants[k].set, rm_map);
+  }
+  for (index_type k = 0; k < map.length(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.length());
+      map[k] = rm_map[map[k]];
+    }
+}
+void Instance::remove_invariants(const bool_vec& set, index_vec& map)
+{
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, invariants.length());
+  while (scan_p < invariants.length()) {
+    if (!set[scan_p]) {
+      if (put_p < scan_p) {
+ invariants[put_p] = invariants[scan_p];
+ invariants[put_p].index = put_p;
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  invariants.set_length(put_p);
+  for (index_type k = 0; k < map.length(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.length());
+      map[k] = rm_map[map[k]];
+    }
+}
+void Instance::set_initial(const index_set& init)
+{
+  for (index_type k = 0; k < n_atoms(); k++) atoms[k].init = false;
+  for (index_type k = 0; k < init.length(); k++) atoms[init[k]].init = true;
+  init_atoms = init;
+}
+void Instance::set_goal(const index_set& goal)
+{
+  for (index_type k = 0; k < n_atoms(); k++) {
+    atoms[k].goal = false;
+    atoms[k].irrelevant = false;
+  }
+  for (index_type k = 0; k < goal.length(); k++) atoms[goal[k]].goal = true;
+  goal_atoms = goal;
+}
+void Instance::set_DNF_goal(const index_set_vec& goal)
+{
+  for (index_type k = 0; k < n_atoms(); k++) {
+    atoms[k].goal = false;
+    atoms[k].irrelevant = false;
+  }
+  Atom& g_atom = new_atom(new StringName(goal_atom_name));
+  g_atom.goal = true;
+  for (index_type k = 0; k < goal.length(); k++) {
+    Action& g_act = new_action(new EnumName(goal_action_name, k));
+    g_act.pre = goal[k];
+    g_act.add.assign_singleton(g_atom.index);
+    g_act.cost = goal_action_cost;
+    g_act.dmin = goal_action_cost;
+    g_act.dmax = goal_action_cost;
+    g_act.dur = goal_action_cost;
+  }
+  clear_cross_reference();
+}
+void Instance::replace_atom_by_conjunction(index_type p, const index_set& c)
+{
+  assert(p < n_atoms());
+  for (index_type k = 0; k < n_actions(); k++) {
+    if (actions[k].pre.contains(p))
+      actions[k].pre.insert(c);
+  }
+  if (atoms[p].goal) {
+    for (index_type k = 0; k < c.length(); k++)
+      atoms[c[k]].goal = true;
+  }
+}
+void Instance::set_cost_bound(hsps::rational b)
+{
+  Resource& r = new_resource(new StringName("_bcost"));
+  for (index_type k = 0; k < n_actions(); k++)
+    actions[k].cons[r.index] = actions[k].cost;
+  r.init = b;
+}
+void Instance::create_composite_resource(const index_set& set)
+{
+  ConcatenatedName* cn = new ConcatenatedName();
+  for (index_type r = 0; r < set.length(); r++) {
+    assert(set[r] < n_resources());
+    cn->append(resources[set[r]].name);
+  }
+  Resource& cr = new_resource(cn);
+  for (index_type r = 0; r < set.length(); r++) {
+    cr.init += resources[set[r]].init;
+  }
+  for (index_type k = 0; k < n_actions(); k++) {
+    hsps::rational cu = 0;
+    hsps::rational cc = 0;
+    for (index_type r = 0; r < set.length(); r++) {
+      cu += actions[k].use[set[r]];
+      cc += actions[k].cons[set[r]];
+    }
+    actions[k].use[cr.index] = cu;
+    actions[k].cons[cr.index] = cc;
+    if (cu > 0) resources[cr.index].used = true;
+    if (cc > 0) resources[cr.index].consumed = true;
+  }
+}
+void Instance::create_total_resource()
+{
+  index_set s;
+  s.fill(n_resources());
+  create_composite_resource(s);
+}
+void Instance::add_all_negation_invariants()
+{
+  index_type n_new = 0;
+  for (index_type k = 0; k < n_atoms(); k++) {
+    if (atoms[k].neg != no_such_index) {
+      Constraint& c = new_invariant();
+      c.set.insert(k);
+      c.set.insert(atoms[k].neg);
+      c.lim = 1;
+      c.exact = true;
+      n_new += 1;
+    }
+  }
+  if (trace_level > 0) {
+    ::std::cerr << n_new << " negation invariants added" << ::std::endl;
+  }
+}
+void Instance::add_missing_negation_invariants()
+{
+  bool_vec a(false, n_atoms());
+  for (index_type k = 0; k < n_invariants(); k++)
+    for (index_type i = 0; i < invariants[k].set.length(); i++)
+      a[invariants[k].set[i]] = true;
+  if (trace_level > 0) {
+    ::std::cerr << a.count(true) << " of " << n_atoms()
+       << " atoms part of some invariant..." << ::std::endl;
+  }
+  index_type n_new = 0;
+  for (index_type k = 0; k < n_atoms(); k++) if (!a[k]) {
+    if (atoms[k].neg != no_such_index) {
+      Constraint& c = new_invariant();
+      c.set.insert(k);
+      c.set.insert(atoms[k].neg);
+      c.lim = 1;
+      c.exact = true;
+      a[k] = true;
+      a[atoms[k].neg] = true;
+      n_new += 1;
+    }
+  }
+  if (trace_level > 0) {
+    ::std::cerr << n_new << " negation invariants added" << ::std::endl;
+  }
+}
+void Instance::create_atom_negation(index_type a)
+{
+  Atom& not_a = new_atom(new ModName(atoms[a].name, "neg-of"));
+  not_a.init = !atoms[a].init;
+  not_a.neg = atoms[a].index;
+  atoms[a].neg = not_a.index;
+  for (index_type k = 0; k < n_actions(); k++) {
+    if (actions[k].add.contains(a)) actions[k].del.insert(not_a.index);
+    if (actions[k].del.contains(a)) actions[k].add.insert(not_a.index);
+  }
+}
+index_type Instance::complete_atom_negation(index_type a)
+{
+  assert(a < atoms.length());
+  if (atoms[a].neg == no_such_index) {
+    create_atom_negation(a);
+    clear_cross_reference();
+  }
+  assert(atoms[a].neg != no_such_index);
+  return atoms[a].neg;
+}
+void Instance::complete_atom_negations(const index_set& s)
+{
+  index_type n = n_atoms();
+  for (index_type k = 0; k < s.length(); k++)
+    if (atoms[s[k]].neg == no_such_index)
+      create_atom_negation(s[k]);
+  if (n_atoms() > n)
+    clear_cross_reference();
+}
+void Instance::complete_atom_negations()
+{
+  index_type n = n_atoms();
+  for (index_type k = 0; k < n; k++)
+    if (atoms[k].neg == no_such_index)
+      create_atom_negation(k);
+  if (n_atoms() > n)
+    clear_cross_reference();
+}
+void Instance::extract_atom_negations_from_invariants()
+{
+  for (index_type k = 0; k < n_invariants(); k++)
+    if ((invariants[k].set.length() == 2) &&
+ (invariants[k].lim == 1) &&
+ invariants[k].exact) {
+      index_type p = invariants[k].set[0];
+      index_type q = invariants[k].set[1];
+      assert(p < n_atoms());
+      assert(q < n_atoms());
+      if ((atoms[p].neg == no_such_index) &&
+   (atoms[q].neg == no_such_index)) {
+ atoms[p].neg = q;
+ atoms[q].neg = p;
+      }
+    }
+}
+void Instance::compute_iff_axioms(rule_set& ax)
+{
+  extract_atom_negations_from_invariants();
+  for (index_type k = 0; k < n_invariants(); k++)
+    if ((invariants[k].lim == 1) && invariants[k].exact) {
+      index_set n_set;
+      index_type p0 = no_such_index;
+      bool ok = true;
+      for (index_type i = 0; (i < invariants[k].set.length()) && ok; i++) {
+ index_type p = invariants[k].set[i];
+ if ((atoms[p].neg != no_such_index) &&
+     !invariants[k].set.contains(atoms[p].neg)) {
+   n_set.insert(atoms[p].neg);
+ }
+ else if (p0 == no_such_index) {
+   p0 = p;
+ }
+ else {
+   ok = false;
+ }
+      }
+      if (ok && (n_set.length() == invariants[k].set.length())) {
+ for (index_type i = 0; i < invariants[k].set.length(); i++) {
+   rule r(n_set, invariants[k].set[i]);
+   assert(r.antecedent.contains(atoms[r.consequent].neg));
+   r.antecedent.subtract(atoms[r.consequent].neg);
+   ax.insert(r);
+ }
+      }
+      if (ok && (n_set.length() == (invariants[k].set.length() - 1))) {
+ assert(p0 < n_atoms());
+ rule r(n_set, p0);
+ ax.insert(r);
+      }
+    }
+}
+index_type Instance::create_history_atom(index_type a)
+{
+  Atom& ha = new_atom(new ModName(atoms[a].name, "reached"));
+  ha.init = atoms[a].init;
+  for (index_type k = 0; k < n_actions(); k++)
+    if (actions[k].add.contains(a)) actions[k].add.insert(ha.index);
+  return ha.index;
+}
+index_type Instance::compile_pc_always(const index_set& f, const Name* n)
+{
+  if (!n) n = new EnumName(pc_name, pc_count++);
+  if (trace_level > 2) {
+    ::std::cerr << "compiling " << n << ": always ";
+    write_atom_set(std::cerr, f);
+    std::cerr << "..." << ::std::endl;
+  }
+  Atom& a_ok = new_atom(new ModName(n, "ok"));
+  a_ok.init = true;
+  a_ok.goal = true;
+  for (index_type k = 0; (k < f.length()) && a_ok.init; k++)
+    if (!atoms[f[k]].init) a_ok.init = false;
+  if (a_ok.init) {
+    for (index_type k = 0; k < n_actions(); k++)
+      if (actions[k].del.first_common_element(f) != no_such_index)
+ actions[k].del.insert(a_ok.index);
+  }
+  clear_cross_reference();
+  return a_ok.index;
+}
+index_type Instance::compile_pc_sometime(const index_set& f, const Name* n)
+{
+  if (!n) n = new EnumName(pc_name, pc_count++);
+  if (trace_level > 2) {
+    ::std::cerr << "compiling " << n << ": sometime ";
+    write_atom_set(std::cerr, f);
+    std::cerr << "..." << ::std::endl;
+  }
+  Atom& a_ok = new_atom(new ModName(n, "ok"));
+  a_ok.init = true;
+  a_ok.goal = true;
+  for (index_type k = 0; (k < f.length()) && a_ok.init; k++)
+    if (!atoms[f[k]].init) a_ok.init = false;
+  if (!a_ok.init) {
+    index_type n_act = n_actions();
+    for (index_type k = 0; k < n_act; k++)
+      if ((actions[k].add.first_common_element(f) != no_such_index) &&
+   (actions[k].del.first_common_element(f) == no_such_index)) {
+ index_set c(f);
+ c.subtract(actions[k].add);
+ if (c.empty()) {
+   actions[k].add.insert(a_ok.index);
+ }
+ else {
+   Action& a2 = copy_action(k);
+   a2.pre.insert(c);
+   a2.add.insert(a_ok.index);
+ }
+      }
+  }
+  clear_cross_reference();
+  return a_ok.index;
+}
+index_type Instance::compile_pc_at_most_once(const index_set& f, const Name* n)
+{
+  if (!n) n = new EnumName(pc_name, pc_count++);
+  if (trace_level > 2) {
+    ::std::cerr << "compiling " << n << ": at-most-once ";
+    write_atom_set(std::cerr, f);
+    std::cerr << "..." << ::std::endl;
+  }
+  Atom& a_ok = new_atom(new ModName(n, "ok"));
+  a_ok.init = true;
+  a_ok.goal = true;
+  Atom& a_once = new_atom(new ModName(n, "once"));
+  a_once.init = false;
+  a_once.goal = false;
+  index_set m;
+  for (index_type k = 0; k < n_actions(); k++) {
+    if (actions[k].del.first_common_element(f) != no_such_index) {
+      index_set c(f);
+      c.subtract(actions[k].pre);
+      m.insert(c);
+    }
+    if ((actions[k].add.first_common_element(f) != no_such_index) &&
+ (actions[k].del.first_common_element(f) == no_such_index)) {
+      index_set c(f);
+      c.subtract(actions[k].add);
+      m.insert(c);
+    }
+  }
+  complete_atom_negations(m);
+  index_type n_act = n_actions();
+  for (index_type k = 0; k < n_act; k++)
+    if (actions[k].del.first_common_element(f) != no_such_index) {
+      index_set c(f);
+      c.subtract(actions[k].pre);
+      if (c.empty()) {
+ actions[k].add.insert(a_once.index);
+      }
+      else {
+ for (index_type i = 0; i < c.length(); i++) {
+   assert(atoms[c[i]].neg != no_such_index);
+   Action& a2 = copy_action(k);
+   a2.pre.insert(atoms[c[i]].neg);
+ }
+ actions[k].pre.insert(c);
+ actions[k].add.insert(a_once.index);
+      }
+    }
+  index_type a_not_once = complete_atom_negation(a_once.index);
+  n_act = n_actions();
+  for (index_type k = 0; k < n_act; k++)
+    if ((actions[k].add.first_common_element(f) != no_such_index) &&
+ (actions[k].del.first_common_element(f) == no_such_index)) {
+      index_set c(f);
+      c.subtract(actions[k].add);
+      if (c.empty()) {
+ Action& a2 = copy_action(k);
+ actions[k].pre.insert(a_not_once);
+ a2.pre.insert(a_once.index);
+ a2.del.insert(a_ok.index);
+      }
+      else {
+ for (index_type i = 0; i < c.length(); i++) {
+   assert(atoms[c[i]].neg != no_such_index);
+   Action& a2 = copy_action(k);
+   a2.pre.insert(atoms[c[i]].neg);
+ }
+ Action& a3 = copy_action(k);
+ a3.pre.insert(c);
+ a3.pre.insert(a_once.index);
+ a3.del.insert(a_ok.index);
+ actions[k].pre.insert(c);
+ actions[k].pre.insert(a_not_once);
+      }
+    }
+  clear_cross_reference();
+  return a_ok.index;
+}
+index_type Instance::compile_pc_sometime_before
+(const index_set& f_t, const index_set& f_c, const Name* n)
+{
+  if (!n) n = new EnumName(pc_name, pc_count++);
+  if (trace_level > 2) {
+    ::std::cerr << "compiling " << n << ": sometime-before ";
+    write_atom_set(std::cerr, f_t);
+    ::std::cerr << " ";
+    write_atom_set(std::cerr, f_c);
+    std::cerr << "..." << ::std::endl;
+  }
+  Atom& a_safe = new_atom(new ModName(n, "safe"));
+  a_safe.init = true;
+  for (index_type k = 0; k < f_c.length(); k++)
+    if (!atoms[f_c[k]].init) a_safe.init = false;
+  a_safe.goal = false;
+  Atom& a_ok = new_atom(new ModName(n, "ok"));
+  a_ok.init = false;
+  for (index_type k = 0; k < f_t.length(); k++)
+    if (!atoms[f_t[k]].init) a_ok.init = true;
+  a_ok.goal = true;
+  if (a_ok.init && !a_safe.init) {
+    index_set m;
+    for (index_type k = 0; k < n_actions(); k++) {
+      if ((actions[k].add.first_common_element(f_t) != no_such_index) &&
+   (actions[k].del.first_common_element(f_t) == no_such_index)) {
+ index_set c(f_t);
+ c.subtract(actions[k].add);
+ m.insert(c);
+      }
+    }
+    if (trace_level > 2) {
+      ::std::cerr << "completing negations of ";
+      write_atom_set(std::cerr, m);
+      std::cerr << "..." << ::std::endl;
+    }
+    complete_atom_negations(m);
+    index_type n_act = n_actions();
+    for (index_type k = 0; k < n_act; k++)
+      if ((actions[k].add.first_common_element(f_c) != no_such_index) &&
+   (actions[k].del.first_common_element(f_c) == no_such_index)) {
+ index_set c(f_c);
+ c.subtract(actions[k].add);
+ if (c.empty()) {
+   actions[k].add.insert(a_safe.index);
+   if (trace_level > 2) {
+     std::cerr << "case 1: atom " << a_safe.index << "." << a_safe.name
+        << " add by " << k << "." << actions[k].name
+        << std::endl;
+   }
+ }
+ else {
+   Action& a2 = copy_action(k);
+   a2.pre.insert(c);
+   a2.add.insert(a_safe.index);
+   if (trace_level > 2) {
+     std::cerr << "case 2: atoms " << c << " pre of "
+        << a2.index << "." << a2.name
+        << std::endl;
+     std::cerr << "case 2: atom " << a_safe.index << "." << a_safe.name
+        << " add by " << a2.index << "." << a2.name
+        << std::endl;
+   }
+ }
+      }
+    n_act = n_actions();
+    for (index_type k = 0; k < n_act; k++)
+      if ((actions[k].add.first_common_element(f_t) != no_such_index) &&
+   (actions[k].del.first_common_element(f_t) == no_such_index)) {
+ index_set c(f_t);
+ c.subtract(actions[k].add);
+ if (c.empty()) {
+   Action& a2 = copy_action(k);
+   a2.del.insert(a_ok.index);
+   if (trace_level > 2) {
+     std::cerr << "case 3: atom " << a_ok.index << "." << a_ok.name
+        << " del by " << a2.index << "." << a2.name
+        << std::endl;
+   }
+   actions[k].pre.insert(a_safe.index);
+   if (trace_level > 2) {
+     std::cerr << "case 4: atom " << a_safe.index << "." << a_safe.name
+        << " pre of " << k << "." << actions[k].name
+        << std::endl;
+   }
+ }
+ else {
+   for (index_type i = 0; i < c.length(); i++) {
+     assert(atoms[c[i]].neg != no_such_index);
+     Action& a2 = copy_action(k);
+     a2.pre.insert(atoms[c[i]].neg);
+     if (trace_level > 2) {
+       std::cerr << "case 5: atom " << atoms[c[i]].neg
+   << " pre of " << a2.index << "." << a2.name
+   << std::endl;
+     }
+   }
+   Action& a3 = copy_action(k);
+   a3.del.insert(a_ok.index);
+   if (trace_level > 2) {
+     std::cerr << "case 6: atom " << a_ok.index << "." << a_ok.name
+        << " del by " << a3.index << "." << a3.name
+        << std::endl;
+   }
+   actions[k].pre.insert(a_safe.index);
+   if (trace_level > 2) {
+     std::cerr << "case 7: atom " << a_safe.index << "." << a_safe.name
+        << " pre of " << k << "." << actions[k].name
+        << std::endl;
+   }
+ }
+      }
+  }
+  clear_cross_reference();
+  return a_ok.index;
+}
+void Instance::enforce_pc_always(const index_set& f, const Name* n)
+{
+  if (trace_level > 2) {
+    ::std::cerr << "enforcing ";
+    if (n) std::cerr << n << ": ";
+    std::cerr << "always ";
+    write_atom_set(std::cerr, f);
+    std::cerr << "..." << ::std::endl;
+  }
+  bool_vec d(false, n_actions());
+  for (index_type k = 0; k < n_actions(); k++)
+    if (actions[k].del.first_common_element(f) != no_such_index)
+      d[k] = true;
+  actions.remove(d);
+  clear_cross_reference();
+}
+void Instance::enforce_pc_sometime(const index_set& f, const Name* n)
+{
+  if (trace_level > 2) {
+    ::std::cerr << "enforcing ";
+    if (n) std::cerr << n << ": ";
+    std::cerr << "sometime ";
+    write_atom_set(std::cerr, f);
+    std::cerr << "..." << ::std::endl;
+  }
+  index_type g = compile_pc_sometime(f, n);
+  atoms[g].goal = true;
+  clear_cross_reference();
+}
+void Instance::enforce_pc_at_most_once(const index_set& f, const Name* n)
+{
+  if (!n) n = new EnumName(pc_name, pc_count++);
+  if (trace_level > 2) {
+    ::std::cerr << "enforcing " << n << ": at-most-once ";
+    write_atom_set(std::cerr, f);
+    std::cerr << "..." << ::std::endl;
+  }
+  index_type a_first = new_atom(new ModName(n, "first")).index;
+  atoms[a_first].init = true;
+  atoms[a_first].goal = false;
+  index_set m;
+  for (index_type k = 0; k < n_actions(); k++) {
+    if (actions[k].del.first_common_element(f) != no_such_index) {
+      index_set c(f);
+      c.subtract(actions[k].pre);
+      m.insert(c);
+    }
+    if ((actions[k].add.first_common_element(f) != no_such_index) &&
+ (actions[k].del.first_common_element(f) == no_such_index)) {
+      index_set c(f);
+      c.subtract(actions[k].add);
+      m.insert(c);
+    }
+  }
+  complete_atom_negations(m);
+  index_type n_act = n_actions();
+  for (index_type k = 0; k < n_act; k++)
+    if (actions[k].del.first_common_element(f) != no_such_index) {
+      index_set c(f);
+      c.subtract(actions[k].pre);
+      if (c.empty()) {
+ actions[k].del.insert(a_first);
+      }
+      else {
+ for (index_type i = 0; i < c.length(); i++) {
+   assert(atoms[c[i]].neg != no_such_index);
+   Action& a2 = copy_action(k);
+   a2.pre.insert(atoms[c[i]].neg);
+ }
+ actions[k].pre.insert(c);
+ actions[k].del.insert(a_first);
+      }
+    }
+  n_act = n_actions();
+  for (index_type k = 0; k < n_act; k++)
+    if ((actions[k].add.first_common_element(f) != no_such_index) &&
+ (actions[k].del.first_common_element(f) == no_such_index)) {
+      index_set c(f);
+      c.subtract(actions[k].add);
+      if (c.empty()) {
+ actions[k].pre.insert(a_first);
+      }
+      else {
+ for (index_type i = 0; i < c.length(); i++) {
+   assert(atoms[c[i]].neg != no_such_index);
+   Action& a2 = copy_action(k);
+   a2.pre.insert(atoms[c[i]].neg);
+ }
+ actions[k].pre.insert(c);
+ actions[k].pre.insert(a_first);
+      }
+    }
+  clear_cross_reference();
+}
+void Instance::enforce_pc_sometime_before
+(const index_set& f_t, const index_set& f_c, const Name* n)
+{
+  if (!n) n = new EnumName(pc_name, pc_count++);
+  if (trace_level > 2) {
+    ::std::cerr << "compiling " << n << ": sometime-before ";
+    write_atom_set(std::cerr, f_t);
+    ::std::cerr << " ";
+    write_atom_set(std::cerr, f_c);
+    std::cerr << "..." << ::std::endl;
+  }
+  bool is_safe = true;
+  for (index_type k = 0; k < f_c.length(); k++)
+    if (!atoms[f_c[k]].init) is_safe = false;
+  if (!is_safe) {
+    index_type a_safe = new_atom(new ModName(n, "safe")).index;
+    atoms[a_safe].init = false;
+    atoms[a_safe].goal = false;
+    index_set m;
+    for (index_type k = 0; k < n_actions(); k++) {
+      if ((actions[k].add.first_common_element(f_t) != no_such_index) &&
+   (actions[k].del.first_common_element(f_t) == no_such_index)) {
+ index_set c(f_t);
+ c.subtract(actions[k].add);
+ m.insert(c);
+      }
+    }
+    if (trace_level > 2) {
+      ::std::cerr << "completing negations of ";
+      write_atom_set(std::cerr, m);
+      std::cerr << "..." << ::std::endl;
+    }
+    complete_atom_negations(m);
+    index_type n_act = n_actions();
+    for (index_type k = 0; k < n_act; k++)
+      if ((actions[k].add.first_common_element(f_c) != no_such_index) &&
+   (actions[k].del.first_common_element(f_c) == no_such_index)) {
+ index_set c(f_c);
+ c.subtract(actions[k].add);
+ c.subtract(actions[k].pre);
+ if (c.empty()) {
+   actions[k].add.insert(a_safe);
+ }
+ else {
+   Action& a2 = copy_action(k);
+   a2.pre.insert(c);
+   a2.add.insert(a_safe);
+ }
+      }
+    n_act = n_actions();
+    for (index_type k = 0; k < n_act; k++)
+      if ((actions[k].add.first_common_element(f_t) != no_such_index) &&
+   (actions[k].del.first_common_element(f_t) == no_such_index)) {
+ index_set c(f_t);
+ c.subtract(actions[k].add);
+ if (c.empty()) {
+   actions[k].pre.insert(a_safe);
+ }
+ else {
+   for (index_type i = 0; i < c.length(); i++) {
+     assert(atoms[c[i]].neg != no_such_index);
+     Action& a2 = copy_action(k);
+     a2.pre.insert(atoms[c[i]].neg);
+   }
+   actions[k].pre.insert(a_safe);
+ }
+      }
+  }
+  clear_cross_reference();
+}
+void Instance::clear_cross_reference()
+{
+  max_pre = 0;
+  max_add = 0;
+  max_del = 0;
+  max_lck = 0;
+  max_req_by = 0;
+  max_add_by = 0;
+  max_del_by = 0;
+  min_dur = POS_INF;
+  max_dur = NEG_INF;
+  min_cost = POS_INF;
+  max_cost = NEG_INF;
+  for (index_type k = 0; k < atoms.length(); k++) {
+    atoms[k].req_by.clear();
+    atoms[k].add_by.clear();
+    atoms[k].del_by.clear();
+  }
+  init_atoms.clear();
+  goal_atoms.clear();
+  for (index_type k = 0; k < actions.length(); k++)
+    actions[k].ncw_atms.clear();
+  for (index_type k = 0; k < resources.length(); k++) {
+    resources[k].used = false;
+    resources[k].consumed = false;
+  }
+  xrf = false;
+}
+bool Instance::cross_referenced() const
+{
+  return xrf;
+}
+void Instance::save_durations(cost_vec& out) const
+{
+  out.assign_value(0, n_actions());
+  for (index_type k = 0; k < n_actions(); k++)
+    out[k] = actions[k].dur;
+}
+void Instance::set_durations(const cost_vec& in)
+{
+  for (index_type k = 0; k < n_actions(); k++)
+    actions[k].dur = in[k];
+}
+void Instance::set_durations(const cost_vec& in, cost_vec& out)
+{
+  out.assign_value(0, n_actions());
+  for (index_type k = 0; k < n_actions(); k++) {
+    out[k] = actions[k].dur;
+    actions[k].dur = in[k];
+  }
+}
+void Instance::assign_unit_durations(hsps::rational unit)
+{
+  for (index_type k = 0; k < n_actions(); k++)
+    actions[k].dur = unit;
+  min_dur = unit;
+  max_dur = unit;
+}
+void Instance::discretize_durations(hsps::rational interval_width)
+{
+  min_dur = POS_INF;
+  max_dur = NEG_INF;
+  for (index_type k = 0; k < n_actions(); k++) {
+    hsps::rational d = (actions[k].dur / interval_width);
+    if (!(d).integral()) d = (d).floor() + 1;
+    actions[k].dur = d*interval_width;
+    min_dur = hsps::rational::min(min_dur,actions[k].dur);
+    max_dur = hsps::rational::max(max_dur,actions[k].dur);
+  }
+}
+void Instance::quantize_durations(index_type n_intervals)
+{
+  max_dur = NEG_INF;
+  for (index_type k = 0; k < n_actions(); k++)
+    max_dur = hsps::rational::max(max_dur,actions[k].dur);
+  hsps::rational w = max_dur / n_intervals;
+  min_dur = POS_INF;
+  max_dur = NEG_INF;
+  for (index_type k = 0; k < n_actions(); k++) {
+    hsps::rational d = (actions[k].dur / w);
+    if (!(d).integral()) d = (d).floor() + 1;
+    actions[k].dur = d*w;
+    min_dur = hsps::rational::min(min_dur,actions[k].dur);
+    max_dur = hsps::rational::max(max_dur,actions[k].dur);
+  }
+}
+void Instance::round_durations_up()
+{
+  min_dur = POS_INF;
+  max_dur = NEG_INF;
+  for (index_type k = 0; k < n_actions(); k++) {
+    if (!(actions[k].dur).integral()) {
+      actions[k].dur = (actions[k].dur).floor() + 1;
+    }
+    min_dur = hsps::rational::min(min_dur,actions[k].dur);
+    max_dur = hsps::rational::max(max_dur,actions[k].dur);
+  }
+}
+void Instance::round_durations_down()
+{
+  min_dur = POS_INF;
+  max_dur = NEG_INF;
+  for (index_type k = 0; k < n_actions(); k++) {
+    actions[k].dur = (actions[k].dur).floor();
+    min_dur = hsps::rational::min(min_dur,actions[k].dur);
+    max_dur = hsps::rational::max(max_dur,actions[k].dur);
+  }
+}
+void Instance::round_durations()
+{
+  min_dur = POS_INF;
+  max_dur = NEG_INF;
+  for (index_type k = 0; k < n_actions(); k++) {
+    if ((actions[k].dur).frac() > (hsps::rational(1,2).reduce())) {
+      actions[k].dur = (actions[k].dur).floor() + 1;
+    }
+    else {
+      actions[k].dur = (actions[k].dur).floor();
+    }
+    min_dur = hsps::rational::min(min_dur,actions[k].dur);
+    max_dur = hsps::rational::max(max_dur,actions[k].dur);
+  }
+}
+void Instance::assign_unit_costs(cost_vec& save)
+{
+  save.assign_value(0, n_actions());
+  for (index_type k = 0; k < n_actions(); k++) {
+    save[k] = actions[k].cost;
+    actions[k].cost = 1;
+  }
+  min_cost = 1;
+  max_cost = 1;
+}
+void Instance::restore_costs(const cost_vec& saved)
+{
+  for (index_type k = 0; k < n_actions(); k++) {
+    actions[k].dur = saved[k];
+  }
+}
+void Instance::assign_unlimited_resources(cost_vec& save)
+{
+  save.assign_value(0, n_resources());
+  for (index_type k = 0; k < n_resources(); k++) {
+    save[k] = resources[k].init;
+    resources[k].init = POS_INF;
+  }
+}
+void Instance::restore_resources(const cost_vec& saved)
+{
+  for (index_type k = 0; k < n_resources(); k++)
+    resources[k].init = saved[k];
+}
+index_type Instance::n_reusable_resources() const
+{
+  index_type n = 0;
+  for (index_type k = 0; k < n_resources(); k++)
+    if (resources[k].used && !resources[k].consumed) n += 1;
+  return n;
+}
+index_type Instance::n_consumable_resources() const
+{
+  index_type n = 0;
+  for (index_type k = 0; k < n_resources(); k++)
+    if (resources[k].consumed) n += 1;
+  return n;
+}
+void Instance::write_atom_set
+(::std::ostream& s, const index_vec& set, unsigned int c) const
+{
+  s << '{';
+  for (index_type k = 0; k < set.length(); k++) {
+    if (k > 0) s << ',';
+    if (write_atom_set_with_symbolic_names)
+      atoms[set[k]].name->write(s, c);
+    else
+      s << set[k];
+  }
+  s << '}';
+}
+void Instance::write_atom_set
+(::std::ostream& s, const bool_vec& set, unsigned int c) const
+{
+  s << '{';
+  bool need_comma = false;
+  for (index_type k = 0; k < n_atoms(); k++) if (set[k]) {
+    if (need_comma) s << ',';
+    if (write_atom_set_with_symbolic_names)
+      atoms[k].name->write(s, c);
+    else
+      s << k;
+    need_comma = true;
+  }
+  s << '}';
+}
+void Instance::write_atom_sets
+(::std::ostream& s, const index_set_vec& sets, unsigned int c) const
+{
+  s << '{';
+  for (index_type k = 0; k < sets.length(); k++) {
+    if (k > 0) s << ',';
+    write_atom_set(s, sets[k], c);
+  }
+  s << '}';
+}
+void Instance::write_action_set
+(::std::ostream& s, const index_vec& set, unsigned int c) const
+{
+  s << '{';
+  for (index_type k = 0; k < set.length(); k++) {
+    if (k > 0) s << ',';
+    if (write_action_set_with_symbolic_names)
+      actions[set[k]].name->write(s, c);
+    else
+      s << set[k];
+  }
+  s << '}';
+}
+void Instance::write_action_set
+(::std::ostream& s, const bool_vec& set, unsigned int c) const
+{
+  s << '{';
+  bool need_comma = false;
+  for (index_type k = 0; k < n_actions(); k++) if (set[k]) {
+    if (need_comma) s << ',';
+    if (write_action_set_with_symbolic_names)
+      actions[k].name->write(s, c);
+    else
+      s << k;
+    need_comma = true;
+  }
+  s << '}';
+}
+void Instance::write_iff_axiom
+(::std::ostream& s, const rule& r) const
+{
+  s << atoms[r.consequent].name << " <-> (";
+  for (index_type k = 0; k < r.antecedent.length(); k++) {
+    if (k > 0) s << " & ";
+    s << atoms[r.antecedent[k]].name;
+  }
+  s << ")";
+}
+void Instance::write_iff_axiom_set
+(::std::ostream& s, const rule_set& rset) const
+{
+  s << '{';
+  for (index_type k = 0; k < rset.length(); k++) {
+    if (k > 0) s << ", ";
+    s << k << ": ";
+    write_iff_axiom(s, rset[k]);
+  }
+  s << '}';
+}
+void Instance::write_atom_digraph
+(::std::ostream& s,
+ const graph& g,
+ const index_set& atomset,
+ const bool_vec& mark_shaded,
+ const bool_vec& mark_dashed,
+ const char* label) const
+{
+  s << "digraph ADG {" << ::std::endl;
+  s << "label=\"" << label << "\";" << ::std::endl;
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < atomset.length(); k++) {
+    s << "A" << k << " [";
+    if (mark_shaded[atomset[k]]) {
+      s << "style=filled,";
+    }
+    if (mark_dashed[atomset[k]]) {
+      s << "style=dashed,";
+    }
+    s << "label=\"" << atoms[atomset[k]].name << "\"];"
+      << ::std::endl;
+  }
+  for (index_type i = 0; i < atomset.length(); i++)
+    for (index_type j = 0; j < atomset.length(); j++)
+      if (g.adjacent(i, j)) {
+ s << "A" << i << " -> A" << j << ";" << ::std::endl;
+      }
+  s << "}" << ::std::endl;
+}
+void Instance::write_atom_digraph
+(::std::ostream& s, const graph& g, const char* label) const
+{
+  index_set all_atoms;
+  all_atoms.fill(n_atoms());
+  bool_vec no_atoms(false, n_atoms());
+  write_atom_digraph(s, g, all_atoms, no_atoms, no_atoms, label);
+}
+void Instance::write_atom_action_digraph
+(::std::ostream& s,
+ const graph& g,
+ const index_set& atomset,
+ const index_set& actionset,
+ const bool_vec& mark_shaded,
+ const bool_vec& mark_bold,
+ const bool_vec& mark_dashed,
+ const char* label) const
+{
+  s << "digraph AADG {" << ::std::endl;
+  s << "label=\"" << label << "\";" << ::std::endl;
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < atomset.length(); k++) {
+    s << "ATM" << k << " [shape=ellipse,";
+    if (mark_shaded[atomset[k]]) {
+      s << "style=filled,";
+    }
+    if (mark_bold[atomset[k]]) {
+      s << "style=bold,";
+    }
+    if (mark_dashed[atomset[k]]) {
+      s << "style=dashed,";
+    }
+    s << "label=\"" << atoms[atomset[k]].name << "\"];"
+      << ::std::endl;
+  }
+  for (index_type k = 0; k < actionset.length(); k++) {
+    s << "ACT" << k << " [shape=box,";
+    if (mark_shaded[atomset.length() + actionset[k]]) {
+      s << "style=filled,";
+    }
+    if (mark_bold[atomset.length() + actionset[k]]) {
+      s << "style=bold,";
+    }
+    if (mark_dashed[atomset.length() + actionset[k]]) {
+      s << "style=dashed,";
+    }
+    s << "label=\"" << actions[actionset[k]].name << "\"];"
+      << ::std::endl;
+  }
+  for (index_type i = 0; i < atomset.length(); i++) {
+    for (index_type j = 0; j < atomset.length(); j++)
+      if (g.adjacent(i, j))
+ s << "ATM" << i << " -> ATM" << j << ";" << ::std::endl;
+    for (index_type j = 0; j < actionset.length(); j++)
+      if (g.adjacent(i, atomset.length() + j))
+ s << "ATM" << i << " -> ACT" << j << ";" << ::std::endl;
+  }
+  for (index_type i = 0; i < actionset.length(); i++) {
+    for (index_type j = 0; j < atomset.length(); j++)
+      if (g.adjacent(atomset.length() + i, j))
+ s << "ACT" << i << " -> ATM" << j << ";" << ::std::endl;
+    for (index_type j = 0; j < actionset.length(); j++)
+      if (g.adjacent(atomset.length() + i, atomset.length() + j))
+ s << "ACT" << i << " -> ACT" << j << ";" << ::std::endl;
+  }
+  s << "}" << ::std::endl;
+}
+void Instance::write_atom_set_digraph
+(::std::ostream& s, const index_set_graph& g, const char* label) const
+{
+  s << "digraph SDG {" << ::std::endl;
+  s << "label=\"" << label << "\";" << ::std::endl;
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "S" << k << " [label=\"";
+    write_atom_set(s, g.node_label(k));
+    s << "\"];" << ::std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "S" << i << " -> S" << j << ";" << ::std::endl;
+      }
+  s << "}" << ::std::endl;
+}
+void Instance::write_atom_set_graph
+(::std::ostream& s, const index_set_graph& g, const char* label) const
+{
+  s << "graph SG {" << ::std::endl;
+  s << "label=\"" << label << "\";" << ::std::endl;
+  s << "node [width=0,height=0];" << ::std::endl;
+  s << "edge [len=1.0];" << ::std::endl;
+  s << "overlap=false;" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "S" << k << " [label=\"";
+    if (g.node_has_label(k))
+      write_atom_set(s, g.node_label(k));
+    else
+      s << "{}";
+    s << "\"];" << ::std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = i + 1; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.adjacent(i, j)) {
+ s << "S" << i << " -- S" << j;
+ if (g.edge_has_label(i, j)) {
+   if (g.edge_has_label(j, i)) {
+     if (g.edge_label(i, j) == g.edge_label(j, i)) {
+       s << "[label=\"";
+       write_atom_set(s, g.edge_label(i, j));
+       s << "\"]";
+     }
+     else {
+       s << "[label=\"";
+       write_atom_set(s, g.edge_label(i, j));
+       s << " / ";
+       write_atom_set(s, g.edge_label(j, i));
+       s << "\"]";
+     }
+   }
+   else {
+     s << "[label=\"";
+     write_atom_set(s, g.edge_label(i, j));
+     s << " / {}\"]";
+   }
+ }
+ else if (g.edge_has_label(j, i)) {
+   s << "[label=\"{} / ";
+   write_atom_set(s, g.edge_label(j, i));
+   s << "\"]";
+ }
+ s << ";" << ::std::endl;
+      }
+  s << "}" << ::std::endl;
+}
+void Instance::write_axiom_dependency_graph
+(::std::ostream& s, const index_graph& g, const char* label) const
+{
+  s << "digraph DG {" << ::std::endl;
+  s << "label=\"" << label << "\";" << ::std::endl;
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++)
+    if ((g.out_degree(k) > 0) || (g.in_degree(k) > 0)) {
+      s << "N" << k << " [shape=ellipse,";
+      if (g.out_degree(k) > 0) {
+ s << "style=filled,";
+      }
+      if (g.node_label(k) != no_such_index) {
+ assert(g.node_label(k) < n_atoms());
+ s << "label=\""
+   << atoms[g.node_label(k)].name
+   << "\"];";
+      }
+      else {
+ s << "label=\"?\"];";
+      }
+      s << ::std::endl;
+    }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "N" << i << " -> N" << j << " [label=\""
+   << g.edge_label(i, j)
+   << "\"];" << ::std::endl;
+      }
+  s << "}" << ::std::endl;
+}
+void Instance::write_PDDL_action(::std::ostream& s, const Action& act) const
+{
+  index_type n_use = 0;
+  for (index_type i = 0; i < n_resources(); i++)
+    if (act.use[i] > 0) n_use += 1;
+  index_type n_cons = 0;
+  for (index_type i = 0; i < n_resources(); i++)
+    if (act.cons[i] > 0) n_cons += 1;
+  s << " (:action ";
+  act.name->write(s, Name::NC_INSTANCE);
+  if (always_write_parameters) {
+    s << ::std::endl << "  :parameters ()";
+  }
+  if (act.assoc && write_extra) {
+    s << ::std::endl << "  :assoc \"" << act.assoc << "\"";
+  }
+  if (write_PDDL2) {
+    if ((act.pre.length() + act.lck.length() + n_use + n_cons) > 0) {
+      s << ::std::endl << "  :precondition";
+      if (((act.pre.length() + act.lck.length() + n_use + n_cons) > 1) ||
+   always_write_conjunction)
+ s << " (and";
+      for (index_type i = 0; i < act.pre.length(); i++)
+ if (!act.lck.contains(act.pre[i])) {
+   if (write_negation &&
+       (atoms[act.pre[i]].neg != no_such_index) &&
+       (atoms[act.pre[i]].neg < act.pre[i])) {
+     s << " (not (";
+     atoms[atoms[act.pre[i]].neg].name->write(s, Name::NC_INSTANCE);
+     s << "))";
+   }
+   else {
+     s << " (";
+     atoms[act.pre[i]].name->write(s, Name::NC_INSTANCE);
+     s << ")";
+   }
+ }
+      if (write_time) {
+ for (index_type i = 0; i < act.lck.length(); i++) {
+   if (write_negation &&
+       (atoms[act.lck[i]].neg != no_such_index) &&
+       (atoms[act.lck[i]].neg < act.lck[i])) {
+     s << " (at start (not (";
+     atoms[atoms[act.lck[i]].neg].name->write(s, Name::NC_INSTANCE);
+     s << ")))";
+   }
+   else {
+     s << " (at start (";
+     atoms[act.lck[i]].name->write(s, Name::NC_INSTANCE);
+     s << "))";
+   }
+ }
+      }
+      for (index_type i = 0; i < n_resources(); i++) {
+ if (write_time) {
+   if (write_resource_constraints_at_start) {
+     if ((act.use[i] + act.cons[i]) > 0) {
+       s << " (at start (>= (";
+       resources[i].name->write(s, Name::NC_INSTANCE);
+       s << ") " << std::resetiosflags(std::ios::scientific) << ((act.use[i] + act.cons[i]).decimal()) << "))";
+     }
+   }
+   else {
+     if ((act.use[i] + act.cons[i]) > 0) {
+       s << " (over all (>= (";
+       resources[i].name->write(s, Name::NC_INSTANCE);
+       s << ") 0))";
+     }
+   }
+ }
+ else {
+   if ((act.use[i] + act.cons[i]) > 0) {
+     s << " (>= (";
+     resources[i].name->write(s, Name::NC_INSTANCE);
+     s << ") " << std::resetiosflags(std::ios::scientific) << ((act.use[i] + act.cons[i]).decimal()) << ")";
+   }
+ }
+      }
+      if (((act.pre.length() + act.lck.length() + n_use + n_cons) > 1) ||
+   always_write_conjunction)
+ s << ")";
+    }
+    else if (always_write_precondition) {
+      if (always_write_conjunction)
+ s << ::std::endl << "  :precondition (and)";
+      else
+ s << ::std::endl << "  :precondition ()";
+    }
+  }
+  else {
+    if (act.pre.length() > 0) {
+      s << ::std::endl << "  :precondition";
+      if ((act.pre.length() > 1) || always_write_conjunction)
+ s << " (and";
+      for (index_type i = 0; i < act.pre.length(); i++) {
+ if (write_negation &&
+     (atoms[act.pre[i]].neg != no_such_index) &&
+     (atoms[act.pre[i]].neg < act.pre[i])) {
+   s << " (not (";
+   atoms[atoms[act.pre[i]].neg].name->write(s, Name::NC_INSTANCE);
+   s << "))";
+ }
+ else {
+   s << " (";
+   atoms[act.pre[i]].name->write(s, Name::NC_INSTANCE);
+   s << ")";
+ }
+      }
+      if ((act.pre.length() > 1) || always_write_conjunction)
+ s << ")";
+    }
+    else if (always_write_precondition) {
+      if (always_write_conjunction)
+ s << ::std::endl << "  :precondition (and)";
+      else
+ s << ::std::endl << "  :precondition ()";
+    }
+  }
+  if (write_PDDL2) {
+    if (((act.add.length() + act.del.length() +
+   act.lck.length() + n_use + n_cons) > 0) ||
+ write_metric) {
+      s << ::std::endl << "  :effect";
+      if ((act.add.length() + act.del.length() +
+    act.lck.length() + n_use + n_cons +
+    (write_metric ? 1 : 0)) > 1)
+ s << " (and";
+      for (index_type i = 0; i < act.add.length(); i++) {
+ if (write_negation &&
+     (atoms[act.add[i]].neg != no_such_index) &&
+     (atoms[act.add[i]].neg < act.add[i])) {
+   s << " (not (";
+   atoms[atoms[act.add[i]].neg].name->write(s, Name::NC_INSTANCE);
+   s << "))";
+ }
+ else {
+   s << " (";
+   atoms[act.add[i]].name->write(s, Name::NC_INSTANCE);
+   s << ")";
+ }
+      }
+      for (index_type i = 0; i < act.del.length(); i++) {
+ if (write_negation &&
+     (atoms[act.del[i]].neg != no_such_index) &&
+     (atoms[act.del[i]].neg < act.del[i])) {
+   s << " (";
+   atoms[atoms[act.del[i]].neg].name->write(s, Name::NC_INSTANCE);
+   s << ")";
+ }
+ else {
+   s << " (not (";
+   atoms[act.del[i]].name->write(s, Name::NC_INSTANCE);
+   s << "))";
+ }
+      }
+      if (write_time) {
+ for (index_type i = 0; i < act.lck.length(); i++) {
+   if (write_negation &&
+       (atoms[act.lck[i]].neg != no_such_index) &&
+       (atoms[act.lck[i]].neg < act.lck[i])) {
+     s << " (at start (";
+     atoms[atoms[act.lck[i]].neg].name->write(s, Name::NC_INSTANCE);
+     s << ")) (at end (not (";
+     atoms[atoms[act.lck[i]].neg].name->write(s, Name::NC_INSTANCE);
+     s << ")))";
+   }
+   else {
+     s << " (at start (not (";
+     atoms[act.lck[i]].name->write(s, Name::NC_INSTANCE);
+     s << "))) (at end (";
+     atoms[act.lck[i]].name->write(s, Name::NC_INSTANCE);
+     s << "))";
+   }
+ }
+      }
+      for (index_type i = 0; i < n_resources(); i++) {
+ if (write_time) {
+   if ((act.use[i] + act.cons[i]) > 0) {
+     s << " (at start (decrease (";
+     resources[i].name->write(s, Name::NC_INSTANCE);
+     s << ") " << std::resetiosflags(std::ios::scientific) << ((act.use[i] + act.cons[i]).decimal()) << "))";
+   }
+   if (act.use[i] > 0) {
+     s << " (at end (increase (";
+     resources[i].name->write(s, Name::NC_INSTANCE);
+     s << ") " << std::resetiosflags(std::ios::scientific) << ((act.use[i]).decimal()) << "))";
+   }
+ }
+ else {
+   if (act.cons[i] > 0) {
+     s << " (decrease (";
+     resources[i].name->write(s, Name::NC_INSTANCE);
+     s << ") " << std::resetiosflags(std::ios::scientific) << ((act.cons[i]).decimal()) << ")";
+   }
+ }
+      }
+      if (write_metric) {
+ s << " (increase (_cost) " << act.cost << ")";
+      }
+      if ((act.add.length() + act.del.length() +
+    act.lck.length() + n_use + n_cons +
+    (write_metric ? 1 : 0)) > 1)
+ s << ")";
+    }
+  }
+  else {
+    if ((act.add.length() + act.del.length()) > 0) {
+      s << ::std::endl << "  :effect";
+      if ((act.add.length() + act.del.length()) > 1)
+ s << " (and";
+      for (index_type i = 0; i < act.add.length(); i++) {
+ if (write_negation &&
+     (atoms[act.add[i]].neg != no_such_index) &&
+     (atoms[act.add[i]].neg < act.add[i])) {
+   s << " (not (";
+   atoms[atoms[act.add[i]].neg].name->write(s, Name::NC_INSTANCE);
+   s << "))";
+ }
+ else {
+   s << " (";
+   atoms[act.add[i]].name->write(s, Name::NC_INSTANCE);
+   s << ")";
+ }
+      }
+      for (index_type i = 0; i < act.del.length(); i++) {
+ if (write_negation &&
+     (atoms[act.del[i]].neg != no_such_index) &&
+     (atoms[act.del[i]].neg < act.del[i])) {
+   s << " (";
+   atoms[atoms[act.del[i]].neg].name->write(s, Name::NC_INSTANCE);
+   s << ")";
+ }
+ else {
+   s << " (not (";
+   atoms[act.del[i]].name->write(s, Name::NC_INSTANCE);
+   s << "))";
+ }
+      }
+      if ((act.add.length() + act.del.length()) > 1)
+ s << ")";
+    }
+  }
+  if (write_PDDL2 && write_time) {
+    if (act.dmin == act.dmax) {
+      s << ::std::endl
+ << "  :duration (= ?duration "
+ << std::resetiosflags(std::ios::scientific) << ((act.dur).decimal())
+ << ")";
+    }
+    else {
+      s << ::std::endl
+ << "  :duration (and (>= ?duration "
+ << std::resetiosflags(std::ios::scientific) << ((act.dmin).decimal())
+ << ") (<= ?duration "
+ << std::resetiosflags(std::ios::scientific) << ((act.dmax).decimal())
+ << "))";
+    }
+  }
+  s << ")" << ::std::endl;
+}
+void Instance::write_DKEL_invariant_item
+(::std::ostream& s, const Constraint& inv, string_set& tags) const
+{
+  s << " (:invariant";
+  if (inv.name) {
+    s << " :name ";
+    inv.name->write(s, Name::NC_INSTANCE);
+  }
+  for (index_type k = 0; k < tags.length(); k++)
+    s << " :tag " << tags[k];
+  s << " :set-constraint";
+  if (inv.exact)
+    s << " (exactly-n " << inv.lim;
+  else
+    s << " (at-most-n " << inv.lim;
+  for (index_type i = 0; i < inv.set.length(); i++) {
+    if (write_negation &&
+ (atoms[inv.set[i]].neg != no_such_index) &&
+ (atoms[inv.set[i]].neg < inv.set[i])) {
+      s << " (not (";
+      atoms[atoms[inv.set[i]].neg].name->write(s, Name::NC_INSTANCE);
+      s << "))";
+    }
+    else {
+      s << " (";
+      atoms[inv.set[i]].name->write(s, Name::NC_INSTANCE);
+      s << ")";
+    }
+  }
+  s << "))" << ::std::endl;
+}
+void Instance::write_DKEL_irrelevant_atom_item
+(::std::ostream& s, const Atom& atm, string_set& tags) const
+{
+  if (write_negation &&
+      (atm.neg != no_such_index) &&
+      (atm.neg < atm.index))
+    return;
+  s << " (:irrelevant";
+  for (index_type k = 0; k < tags.length(); k++)
+    s << " :tag " << tags[k];
+  s << " :fact (";
+  atm.name->write(s, Name::NC_INSTANCE);
+  s << "))" << ::std::endl;
+}
+void Instance::write_DKEL_irrelevant_action_item
+(::std::ostream& s, const Action& act, string_set& tags) const
+{
+  s << " (:irrelevant";
+  for (index_type k = 0; k < tags.length(); k++)
+    s << " :tag " << tags[k];
+  s << " :action (";
+  act.name->write(s, Name::NC_INSTANCE);
+  s << "))" << ::std::endl;
+}
+void Instance::write_domain_atom_set
+(::std::ostream& s, const index_set& set) const
+{
+  s << "(:set";
+  for (index_type i = 0; i < set.length(); i++) {
+    s << " (";
+    atoms[set[i]].name->write(s, Name::NC_INSTANCE);
+    s << ")";
+  }
+  s << ")" << ::std::endl;
+}
+void Instance::write_domain_action_set
+(::std::ostream& s, const index_set& set) const
+{
+  s << "(:set";
+  for (index_type i = 0; i < set.length(); i++) {
+    s << " (";
+    actions[set[i]].name->write(s, Name::NC_INSTANCE);
+    s << ")";
+  }
+  s << ")" << ::std::endl;
+}
+void Instance::write_domain_action_set
+(::std::ostream& s, const index_set& set, const Name* name) const
+{
+  s << "(:set";
+  if (name) {
+    s << " :name ";
+    name->write(s, Name::NC_INSTANCE);
+  }
+  for (index_type i = 0; i < set.length(); i++) {
+    s << " (";
+    actions[set[i]].name->write(s, Name::NC_INSTANCE);
+    s << ")";
+  }
+  s << ")" << ::std::endl;
+}
+void Instance::write_domain_init(::std::ostream& s) const
+{
+  if (name) {
+    s << "(define (domain ";
+    name->write(s, Name::NC_INSTANCE | Name::NC_DOMAIN);
+    s << ")" << ::std::endl;
+  }
+  else {
+    s << "(define (domain NONAME)" << ::std::endl;
+  }
+  if (always_write_requirements) {
+    if (write_PDDL2) {
+      s << " (:requirements :strips :durative-actions)" << ::std::endl;
+    }
+    else {
+      s << " (:requirements :strips)" << ::std::endl;
+    }
+  }
+}
+void Instance::write_domain_declarations(::std::ostream& s) const
+{
+  if (n_atoms() > 0) {
+    s << " (:predicates";
+    for (index_type k = 0; k < n_atoms(); k++) {
+      if (!write_negation ||
+   (atoms[k].neg == no_such_index) ||
+   (k < atoms[k].neg)) {
+ s << " (";
+ atoms[k].name->write(s, Name::NC_INSTANCE);
+ s << ")";
+      }
+    }
+    s << ")" << ::std::endl;
+  }
+  if (write_PDDL2 && ((n_resources() > 0) || write_metric)) {
+    s << " (:functions";
+    for (index_type k = 0; k < n_resources(); k++) {
+      s << " (";
+      resources[k].name->write(s, Name::NC_INSTANCE);
+      s << ")";
+    }
+    if (write_metric) {
+      s << " (_cost)";
+    }
+    s << ")" << ::std::endl;
+  }
+}
+void Instance::write_domain_actions(::std::ostream& s) const
+{
+  for (index_type k = 0; k < n_actions(); k++) if (actions[k].sel) {
+    write_PDDL_action(s, actions[k]);
+  }
+}
+void Instance::write_domain_DKEL_items(::std::ostream& s) const
+{
+  if (!write_DKEL) return;
+  string_set no_tags;
+  for (index_type k = 0; k < n_invariants(); k++) {
+    write_DKEL_invariant_item(s, invariants[k], no_tags);
+  }
+  for (index_type k = 0; k < n_atoms(); k++) if (atoms[k].irrelevant) {
+    write_DKEL_irrelevant_atom_item(s, atoms[k], no_tags);
+  }
+}
+void Instance::write_domain(::std::ostream& s) const
+{
+  write_domain_init(s);
+  write_domain_declarations(s);
+  write_domain_actions(s);
+  write_domain_DKEL_items(s);
+  s << ")" << ::std::endl;
+}
+void Instance::write_problem_init(::std::ostream& s) const
+{
+  bool write_init = write_metric;
+  if (write_PDDL2) {
+    write_init = (n_resources() > 0);
+  }
+  for (index_type k = 0; (k < n_atoms()) && !write_init; k++)
+    if (atoms[k].init) write_init = true;
+  if (write_init) {
+    s << " (:init";
+    for (index_type k = 0; k < n_atoms(); k++) if (atoms[k].init) {
+      if (!write_negation ||
+   (atoms[k].neg == no_such_index) ||
+   (k < atoms[k].neg)) {
+ s << " (";
+ atoms[k].name->write(s, Name::NC_INSTANCE);
+ s << ")";
+      }
+    }
+    if (write_PDDL2) {
+      for (index_type k = 0; k < n_resources(); k++) {
+ s << " (= (";
+ resources[k].name->write(s, Name::NC_INSTANCE);
+ s << ") " << std::resetiosflags(std::ios::scientific) << ((resources[k].init).decimal()) << ")";
+      }
+      if (write_metric) {
+ s << " (= (_cost) 0)";
+      }
+    }
+    s << ")" << ::std::endl;
+  }
+}
+void Instance::write_problem_goal(::std::ostream& s) const
+{
+  index_type write_goal = 0;
+  for (index_type k = 0; (k < n_atoms()) && (write_goal < 2); k++)
+    if (atoms[k].goal) write_goal += 1;
+  if (write_goal > 0) {
+    s << " (:goal";
+    if (write_goal > 1) s << " (and";
+    for (index_type k = 0; k < n_atoms(); k++) if (atoms[k].goal) {
+      if (write_negation &&
+   (atoms[k].neg != no_such_index) &&
+   (atoms[k].neg < k)) {
+ s << " (not (";
+ atoms[atoms[k].neg].name->write(s, Name::NC_INSTANCE);
+ s << "))";
+      }
+      else {
+ s << " (";
+ atoms[k].name->write(s, Name::NC_INSTANCE);
+ s << ")";
+      }
+    }
+    if (write_goal > 1) s << ")";
+    s << ")" << ::std::endl;
+  }
+}
+void Instance::write_problem_metric(::std::ostream& s) const
+{
+  if (write_PDDL2 && write_metric) {
+    s << " (:metric minimize (_cost))" << ::std::endl;
+  }
+}
+void Instance::write_problem(::std::ostream& s) const
+{
+  if (name) {
+    s << "(define (problem ";
+    name->write(s, Name::NC_INSTANCE | Name::NC_PROBLEM);
+    s << ")" << ::std::endl;
+    s << " (:domain ";
+    name->write(s, Name::NC_INSTANCE | Name::NC_DOMAIN);
+    s << ")" << ::std::endl;
+  }
+  else {
+    s << "(define (problem NONAME)" << ::std::endl;
+    s << " (:domain NONAME)" << ::std::endl;
+  }
+  write_problem_init(s);
+  write_problem_goal(s);
+  write_problem_metric(s);
+  s << ")" << ::std::endl;
+}
+void Instance::print(::std::ostream& s) const
+{
+  s << "atoms:" << ::std::endl;
+  for (index_type k = 0; k < n_atoms(); k++)
+    print_atom(s, atoms[k]);
+  s << "resources:" << ::std::endl;
+  for (index_type k = 0; k < n_resources(); k++)
+    print_resource(s, resources[k]);
+  s << "actions:" << ::std::endl;
+  for (index_type k = 0; k < n_actions(); k++)
+    print_action(s, actions[k]);
+  s << "invariants:" << ::std::endl;
+  for (index_type k = 0; k < n_invariants(); k++)
+    print_invariant(s, invariants[k]);
+}
+void Instance::print_atom(::std::ostream& s, const Atom& atm) const
+{
+  s << atm.index << ". " << atm.name;
+  if (atm.neg != no_such_index) {
+    s << " (neg: " << atoms[atm.neg].index
+      << "." << atoms[atm.neg].name
+      << ")";
+  }
+  else {
+    s << " (no neg.)";
+  }
+  s << ::std::endl;
+  s << "  init: " << (atm.init ? 'T' : 'F');
+  if (atm.init) {
+    s << " (init_t = " << atm.init_t << ")";
+  }
+  s << ", goal: " << (atm.goal ? 'T' : 'F');
+  if (atm.goal) {
+    s << " (goal_t = " << atm.goal_t << ")";
+  }
+  s << ", irrel: " << (atm.irrelevant ? 'T' : 'F')
+    << ::std::endl;
+  if (xrf) {
+    s << "  req. by:";
+    for (index_type i = 0; i < atm.req_by.length(); i++)
+      s << ' ' << atm.req_by[i] << '.'
+ << actions[atm.req_by[i]].name;
+    s << ::std::endl;
+    s << "  add by:";
+    for (index_type i = 0; i < atm.add_by.length(); i++)
+      s << ' ' << atm.add_by[i] << '.'
+ << actions[atm.add_by[i]].name;
+    s << ::std::endl;
+    s << "  del by:";
+    for (index_type i = 0; i < atm.del_by.length(); i++)
+      s << ' ' << atm.del_by[i] << '.'
+ << actions[atm.del_by[i]].name;
+    s << ::std::endl;
+  }
+}
+void Instance::print_resource(::std::ostream& s, const Resource& res) const
+{
+  s << res.index << ". " << res.name << " (";
+  if (res.consumed) s << "consumed, ";
+  if (res.used) s << "used, ";
+  s << res.init << ")" << ::std::endl;
+  s << " used by:";
+  for (index_type i = 0; i < n_actions(); i++)
+    if (actions[i].use[res.index] > 0)
+      s << " " << i << "." << actions[i].name
+ << "=" << actions[i].use[res.index];
+  s << ::std::endl << " consumed by:";
+  for (index_type i = 0; i < n_actions(); i++)
+    if (actions[i].cons[res.index] > 0)
+      s << " " << i << "." << actions[i].name
+ << "=" << actions[i].cons[res.index];
+  s << ::std::endl;
+}
+void Instance::print_action(::std::ostream& s, const Action& act) const
+{
+  s << act.index << ". " << act.name
+    << (act.sel ? " (selectable)" : " (non-selectable)")
+    << ":" << ::std::endl;
+  s << "  pre:";
+  for (index_type i = 0; i < act.pre.length(); i++) {
+    s << ' ' << act.pre[i] << '.';
+    if (act.pre[i] < n_atoms())
+      s << atoms[act.pre[i]].name;
+    else
+      s << "?";
+    if (act.del.contains(act.pre[i])) s << " (del)";
+    if (act.lck.contains(act.pre[i])) s << " (lck)";
+  }
+  s << ::std::endl << "  add:";
+  for (index_type i = 0; i < act.add.length(); i++) {
+    s << ' ' << act.add[i] << '.';
+    if (act.add[i] < n_atoms())
+      s << atoms[act.add[i]].name;
+    else
+      s << "?";
+  }
+  s << ::std::endl << "  del:";
+  for (index_type i = 0; i < act.del.length(); i++) {
+    s << ' ' << act.del[i] << '.';
+    if (act.del[i] < n_atoms())
+      s << atoms[act.del[i]].name;
+    else
+      s << "?";
+  }
+  s << ::std::endl << "  lock:";
+  for (index_type i = 0; i < act.lck.length(); i++)
+    s << ' ' << act.lck[i] << '.' << atoms[act.lck[i]].name;
+  s << ::std::endl << "  use:";
+  for (index_type i = 0; i < n_resources(); i++)
+    s << ' ' << i << '.' << resources[i].name << '=' << act.use[i];
+  s << ::std::endl << "  cons:";
+  for (index_type i = 0; i < n_resources(); i++)
+    s << ' ' << i << '.' << resources[i].name << '=' << act.cons[i];
+  s << ::std::endl << "  dur: " << act.dur
+    << ::std::endl << "  cost: " << act.cost
+    << ::std::endl;
+  if (act.ncw_atms.length() > 0) {
+    s << "  n.c.w. atoms:";
+    for (index_type i = 0; i < act.ncw_atms.length(); i++)
+      s << ' ' << act.ncw_atms[i] << '.'
+ << atoms[act.ncw_atms[i]].name;
+    s << ::std::endl;
+  }
+}
+void Instance::print_invariant(::std::ostream& s, const Constraint& inv) const
+{
+  s << inv.index << ". ";
+  if (inv.name) {
+    s << inv.name << " ";
+  }
+  s << "|{";
+  for (index_type k = 0; k < inv.set.length(); k++) {
+    if (k > 0) s << ", ";
+    s << k << "=" << inv.set[k] << "." << atoms[inv.set[k]].name;
+  }
+  s << "}|";
+  if (inv.exact) {
+    s << " = ";
+  }
+  else {
+    s << " <= ";
+  }
+  s << inv.lim;
+  s << " (size: " << inv.set.length();
+  if (inv.verified) {
+    s << ", verified";
+  }
+  s << ")" << ::std::endl;
+}
+PreconditionEvaluator::PreconditionEvaluator(Instance& ins)
+  : instance(ins),
+    node_type(undecided_leaf),
+    i_test(no_such_index),
+    next(0, 0),
+    prev(0),
+    n_positive(0)
+{
+}
+PreconditionEvaluator::~PreconditionEvaluator()
+{
+  for (index_type k = 0; k < next.length(); k++) {
+    assert(next[k]);
+    delete next[k];
+  }
+}
+void PreconditionEvaluator::construct
+(Instance& ins,
+ PreconditionEvaluator* p,
+ bool_vec& s,
+ bool_vec& ua,
+ index_type n_ua,
+ index_type n_pos,
+ bool_vec& rem_invs,
+ bool_vec& rem_atoms,
+ hsps::rational T)
+{
+  assert(n_ua > 0);
+  index_type best_option = no_such_index;
+  hsps::rational best_option_val = POS_INF;
+  index_type b = ins.n_invariants();
+  if (n_ua > 2) {
+    for (index_type k = 0; k < ins.n_invariants(); k++) if (rem_invs[k]) {
+      Instance::Constraint& c = ins.invariants[k];
+      index_type n1 = 0;
+      for (index_type i = 0; i < c.set.length(); i++)
+ n1 += ua.count_common(ins.atoms[c.set[i]].req_by);
+      index_type n = 0;
+      for (index_type i = 0; i < c.set.length(); i++) {
+ n += ((n_ua - n1) + ua.count_common(ins.atoms[c.set[i]].req_by));
+      }
+      if (!c.exact) {
+ n += (n_ua - n1);
+      }
+      index_type m = (c.exact ? c.set.length() : c.set.length() + 1);
+      hsps::rational val = (hsps::rational(n,m).reduce());
+      if (val < best_option_val) {
+ best_option = k;
+ best_option_val = val;
+      }
+    }
+    for (index_type k = 0; k < ins.n_atoms(); k++) if (rem_atoms[k]) {
+      index_type n = 0;
+      s[k] = true;
+      for (index_type i = 0; i < ins.n_actions(); i++) if (ua[i]) {
+ if (s.contains(ins.actions[i].pre)) n += 1;
+      }
+      s[k] = false;
+      hsps::rational val = (hsps::rational((n_ua - ua.count_common(ins.atoms[k].req_by)) + (n_ua - n),2).reduce());
+      if (val < best_option_val) {
+ best_option = k + b;
+ best_option_val = val;
+      }
+    }
+  }
+  if (best_option_val > (T * n_ua)) {
+    if (p->n_positive > 0) {
+      PreconditionEvaluator* pp = new PreconditionEvaluator(ins);
+      pp->prev = p;
+      pp->node_type = undecided_leaf;
+      for (index_type k = 0; k < ins.n_actions(); k++)
+ if (ua[k]) pp->acts.append(k);
+      pp->n_positive = p->n_positive;
+      p->node_type = no_test;
+      p->next.set_length(1);
+      p->next[0] = pp;
+    }
+    else {
+      p->node_type = undecided_leaf;
+      for (index_type k = 0; k < ins.n_actions(); k++)
+ if (ua[k]) p->acts.append(k);
+    }
+  }
+  else if (best_option < b) {
+    assert(best_option < ins.n_invariants());
+    assert(rem_invs[best_option]);
+    assert(p->next.empty());
+    Instance::Constraint& c = ins.invariants[best_option];
+    bool_vec rem_invs_copy(rem_invs);
+    bool_vec rem_atoms_copy(rem_atoms);
+    for (index_type k = 0; k < c.set.length(); k++)
+      rem_atoms_copy[c.set[k]] = false;
+    bool_vec ua_copy(ua);
+    for (index_type k = 0; k < c.set.length(); k++) {
+      if (k > 0) ua_copy.assign_copy(ua);
+      PreconditionEvaluator* pp = new PreconditionEvaluator(ins);
+      pp->prev = p;
+      for (index_type i = 0; i < c.set.length(); i++) if (i != k) {
+ for (index_type j = 0; j < ins.atoms[c.set[i]].req_by.length(); j++)
+   ua_copy[ins.atoms[c.set[i]].req_by[j]] = false;
+      }
+      s[c.set[k]] = true;
+      for (index_type i = 0; i < ins.n_actions(); i++) if (ua_copy[i]) {
+ if (s.contains(ins.actions[i].pre)) {
+   pp->acts.append(i);
+   pp->n_positive += 1;
+   ua_copy[i] = false;
+ }
+      }
+      index_type r_ua = ua_copy.count(true);
+      if (r_ua == 0) {
+ pp->node_type = positive_leaf;
+      }
+      else {
+ if (k > 0) rem_invs_copy.assign_copy(rem_invs);
+ rem_invs_copy[best_option] = false;
+ for (index_type j = 0; j < ins.n_invariants(); j++)
+   if (ins.invariants[j].set.contains(c.set[k]))
+     rem_invs_copy[j] = false;
+ construct(ins, pp, s, ua_copy, r_ua, n_pos + p->n_positive,
+    rem_invs_copy, rem_atoms_copy, T);
+      }
+      s[c.set[k]] = false;
+      p->next.append(pp);
+    }
+    if (!c.exact) {
+      PreconditionEvaluator* pp = new PreconditionEvaluator(ins);
+      pp->prev = p;
+      ua_copy.assign_copy(ua);
+      for (index_type i = 0; i < c.set.length(); i++)
+ for (index_type j = 0; j < ins.atoms[c.set[i]].req_by.length(); j++)
+   ua_copy[ins.atoms[c.set[i]].req_by[j]] = false;
+      index_type r_ua = ua_copy.count(true);
+      if (r_ua == 0) {
+ pp->node_type = positive_leaf;
+      }
+      else {
+ rem_invs_copy.assign_copy(rem_invs);
+ rem_invs_copy[best_option] = false;
+ construct(ins, pp, s, ua_copy, r_ua, n_pos + p->n_positive,
+    rem_invs_copy, rem_atoms_copy, T);
+      }
+      p->next.append(pp);
+    }
+    p->node_type = test_invariant;
+    p->i_test = best_option;
+  }
+  else {
+    assert((best_option >= b) && ((best_option - b) < ins.n_atoms()));
+    best_option -= b;
+    assert(rem_atoms[best_option]);
+    assert(p->next.empty());
+    rem_atoms[best_option] = false;
+    bool_vec ua_copy(ua);
+    PreconditionEvaluator* p_true = new PreconditionEvaluator(ins);
+    p_true->prev = p;
+    s[best_option] = true;
+    for (index_type i = 0; i < ins.n_actions(); i++) if (ua_copy[i]) {
+      if (s.contains(ins.actions[i].pre)) {
+ p_true->acts.append(i);
+ p_true->n_positive += 1;
+ ua_copy[i] = false;
+      }
+    }
+    index_type r_ua = ua_copy.count(true);
+    if (r_ua == 0) {
+      p_true->node_type = positive_leaf;
+    }
+    else {
+      bool_vec rem_invs_copy(rem_invs);
+      for (index_type j = 0; j < ins.n_invariants(); j++)
+ if (ins.invariants[j].set.contains(best_option))
+   rem_invs_copy[j] = false;
+      construct(ins, p_true, s, ua_copy, r_ua, n_pos + p->n_positive,
+  rem_invs_copy, rem_atoms, T);
+    }
+    s[best_option] = false;
+    p->next.append(p_true);
+    ua_copy.assign_copy(ua);
+    PreconditionEvaluator* p_false = new PreconditionEvaluator(ins);
+    p_false->prev = p;
+    for (index_type j = 0; j < ins.atoms[best_option].req_by.length(); j++)
+      ua_copy[ins.atoms[best_option].req_by[j]] = false;
+    r_ua = ua_copy.count(true);
+    if (r_ua == 0) {
+      p_false->node_type = positive_leaf;
+    }
+    else {
+      construct(ins, p_false, s, ua_copy, r_ua, n_pos + p->n_positive,
+  rem_invs, rem_atoms, T);
+    }
+    p->next.append(p_false);
+    p->node_type = test_atom;
+    p->i_test = best_option;
+    rem_atoms[best_option] = true;
+  }
+  p->n_positive += n_pos;
+}
+PreconditionEvaluator* PreconditionEvaluator::construct
+(Instance& ins, hsps::rational T)
+{
+  PreconditionEvaluator* root = new PreconditionEvaluator(ins);
+  bool_vec ua(true, ins.n_actions());
+  for (index_type k = 0; k < ins.n_actions(); k++)
+    if (ins.actions[k].pre.empty()) {
+      root->acts.append(k);
+      root->n_positive += 1;
+      ua[k] = false;
+    }
+  if (ua.count(true) == 0) {
+    root->node_type = positive_leaf;
+    return root;
+  }
+  bool_vec s(false, ins.n_atoms());
+  bool_vec rem_invs(false, ins.n_invariants());
+  for (index_type k = 0; k < ins.n_invariants(); k++)
+    if ((ins.invariants[k].lim == 1) && (ins.invariants[k].set.length() > 1))
+      rem_invs[k] = true;
+  bool_vec rem_atoms(true, ins.n_atoms());
+  construct(ins, root, s, ua, ua.count(true), 0, rem_invs, rem_atoms, T);
+  return root;
+}
+PreconditionEvaluator* PreconditionEvaluator::node(const bool_vec& s)
+{
+  PreconditionEvaluator* p = this;
+  while ((p->node_type != positive_leaf) && (p->node_type != undecided_leaf)) {
+    if (p->node_type == no_test) {
+      assert(p->next[0]);
+      p = p->next[0];
+    }
+    else if (p->node_type == test_invariant) {
+      assert(p->i_test < instance.n_invariants());
+      Instance::Constraint& inv = instance.invariants[p->i_test];
+      assert(inv.lim == 1);
+      index_type k = 0;
+      bool hit = false;
+      while ((k < inv.set.length()) && !hit) {
+ if (s[inv.set[k]]) {
+   assert(p->next[k]);
+   p = p->next[k];
+   hit = true;
+ }
+ k += 1;
+      }
+      if (!hit) {
+ assert(!inv.exact);
+ assert(p->next[inv.set.length()]);
+ p = p->next[inv.set.length()];
+      }
+    }
+    else if (p->node_type == test_atom) {
+      assert(p->i_test < instance.n_atoms());
+      if (s[p->i_test]) {
+ assert(p->next[0]);
+ p = p->next[0];
+      }
+      else {
+ assert(p->next[1]);
+ p = p->next[1];
+      }
+    }
+    else {
+      assert(0);
+    }
+  }
+  return p;
+}
+index_type PreconditionEvaluator::eval
+(const bool_vec& s, const bool_vec& a, index_type* app, index_type c)
+{
+  PreconditionEvaluator* p = node(s);
+  if (p->node_type == undecided_leaf) {
+    for (index_type k = 0; k < p->acts.length(); k++) if (a[p->acts[k]]) {
+      bool f = true;
+      for (index_type i = 0;
+    (i < instance.actions[p->acts[k]].pre.length()) && f; i++)
+ if (!s[instance.actions[p->acts[k]].pre[i]]) f = false;
+      if (f) {
+ app[c++] = p->acts[k];
+      }
+    }
+  }
+  else {
+    assert(p->node_type == positive_leaf);
+    for (index_type k = 0; k < p->acts.length(); k++)
+      if (a[p->acts[k]]) app[c++] = p->acts[k];
+  }
+  p = p->prev;
+  while (p) {
+    if (p->n_positive == 0) return c;
+    for (index_type k = 0; k < p->acts.length(); k++)
+      if (a[p->acts[k]]) app[c++] = p->acts[k];
+    p = p->prev;
+  }
+  return c;
+}
+void PreconditionEvaluator::write_graph(std::ostream& s, bool root)
+{
+  if (root) {
+    s << "digraph PreconditionEvaluator {" << std::endl;
+  }
+  s << "N" << this << " [shape=box,label=\"";
+  if (node_type == test_invariant) {
+    s << "inv #" << i_test;
+  }
+  else if (node_type == test_atom) {
+    s << "atom #" << i_test;
+  }
+  else {
+    s << "no test";
+  }
+  s << " :" << n_positive
+    << " / " << acts.length()
+    << "\\n" << acts
+    << "\"";
+  if (node_type == positive_leaf) {
+    s << ",style=bold";
+  }
+  else if (node_type == undecided_leaf) {
+    s << ",style=dashed";
+  }
+  s << "];" << std::endl;
+  for (index_type k = 0; k < next.length(); k++) {
+    assert(next[k]);
+    next[k]->write_graph(s, false);
+  }
+  for (index_type k = 0; k < next.length(); k++) {
+    s << "N" << this << " -> N" << next[k];
+    if (node_type == test_invariant) {
+      s << " [label=\"" << k
+ << "=" << instance.invariants[i_test].set[k] << "\"];"
+ << std::endl;
+    }
+    else if (node_type == test_atom) {
+      if (k == 0) s << " [label=\"T\"];" << std::endl;
+      else s << " [label=\"F\"];" << std::endl;
+    }
+    else {
+      s << ";" << std::endl;
+    }
+  }
+  if (root) {
+    s << "}" << std::endl;
+  }
+}
+}

--- a/pr/seq-opt-hspsf/ptr_table.ccx
+++ b/pr/seq-opt-hspsf/ptr_table.ccx
@@ -1,0 +1,1668 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+namespace hsps {
+ptr_table::~ptr_table() {
+  if (_next) delete _next;
+  if (_left) delete _left;
+  if (_right) delete _right;
+}
+void ptr_table::key_sequence(key_vec& k)
+{
+  if (_prev) {
+    _prev->key_sequence(k);
+  }
+  else {
+    k.set_length(0);
+  }
+  k.append(_key);
+}
+ptr_table::key_vec* ptr_table::key_sequence()
+{
+  key_vec* k = new key_vec((void*)0, 0);
+  key_sequence(*k);
+  return k;
+}
+ptr_table* ptr_table::root()
+{
+  ptr_table* p = this;
+  while (p->_prev) {
+    p = p->_prev;
+  }
+  while (p->_up) {
+    p = p->_up;
+  }
+  return p;
+}
+ptr_table* ptr_table::enum_key_first()
+{
+  ptr_table* p = this;
+  bool leaf = false;
+  while (!leaf) {
+    if (p->_left) p = p->_left;
+    else if (p->_right) p = p->_right;
+    else leaf = true;
+  }
+  return p;
+}
+ptr_table* ptr_table::enum_key_next()
+{
+  if (_up) {
+    if (_up->_right == this) {
+      return _up;
+    }
+    else if (_up->_right) {
+      return _up->_right->enum_key_first();
+    }
+  }
+  return 0;
+}
+ptr_table* ptr_table::insert(void* k) {
+  if (_key == 0) {
+    _key = k;
+    _count += 1;
+    return this;
+  }
+  if (_key == k) return this;
+  else if (k < _key) {
+    if (!_left) {
+      _left = new ptr_table(k, this, _prev);
+      _count += 1;
+      return _left;
+    }
+    ptr_table* r = _left->insert(k);
+    _count = _left->_count + (_right ? _right->_count : 0) + 1;
+    return r;
+  }
+  else {
+    if (!_right) {
+      _right = new ptr_table(k, this, _prev);
+      _count += 1;
+      return _right;
+    }
+    ptr_table* r = _right->insert(k);
+    _count = (_left ? _left->_count : 0) + _right->_count + 1;
+    return r;
+  }
+}
+ptr_table* ptr_table::insert_next(void* k) {
+  if (!_next) {
+    _next = _next = new ptr_table(k, 0, this);
+    return _next;
+  }
+  return _next->insert(k);
+}
+ptr_table* ptr_table::insert(void** k, index_type l) {
+  ptr_table* r = this;
+  for (index_type i = 0; i < l; i++) {
+    r = r->insert_next(k[i]);
+  }
+  return r;
+}
+ptr_table* ptr_table::insert(key_vec& k) {
+  ptr_table* r = this;
+  for (index_type i = 0; i < k.length(); i++) {
+    r = r->insert_next(k[i]);
+  }
+  return r;
+}
+ptr_table* ptr_table::find(void* k) {
+  if (_key == 0) return 0;
+  if (_key == k) return this;
+  if (k < _key) {
+    if (!_left) return 0;
+    return _left->find(k);
+  }
+  else {
+    if (!_right) return 0;
+    return _right->find(k);
+  }
+}
+ptr_table* ptr_table::find_next(void* k) {
+  if (!_next) return 0;
+  return _next->find(k);
+}
+ptr_table* ptr_table::find(void** k, index_type l) {
+  ptr_table* r = this;
+  for (index_type i = 0; (i < l) && r; i++) {
+    r = r->find_next(k[i]);
+  }
+  return r;
+}
+ptr_table* ptr_table::find(key_vec& k) {
+  ptr_table* r = this;
+  for (index_type i = 1; (i < k.length()) && r; i++) {
+    r = r->find_next(k[i]);
+  }
+  return r;
+}
+index_type ptr_table::count_values() {
+  return ((_left ? _left->count_values() : 0) +
+   (_right ? _right->count_values() : 0) +
+   (_next ? _next->count_values() : 0) +
+   (val != 0 ? 1 : 0));
+}
+index_type ptr_table::count_keys() {
+  return ((_left ? _left->count_keys() : 0) +
+   (_right ? _right->count_keys() : 0) +
+   (_key != 0 ? 1 : 0));
+}
+void ptr_table::dump_values(value_vec& vec) {
+  if (val != 0) vec.append(val);
+  if (_left) _left->dump_values(vec);
+  if (_right) _right->dump_values(vec);
+  if (_next) _next->dump_values(vec);
+}
+void ptr_table::dump(cell_vec& vec) {
+  vec.append(this);
+  if (_left) _left->dump(vec);
+  if (_right) _right->dump(vec);
+  if (_next) _next->dump(vec);
+}
+void ptr_table::dump_keys(key_vec& vec) {
+  if (_key != 0) vec.append(_key);
+  if (_left) _left->dump_keys(vec);
+  if (_right) _right->dump_keys(vec);
+}
+ptr_table::value_vec* ptr_table::values() {
+  value_vec* vec = new value_vec((void*)0,0);
+  dump_values(*vec);
+  return vec;
+}
+ptr_table::key_vec* ptr_table::keys() {
+  key_vec* vec = new key_vec((void*)0,0);
+  dump_keys(*vec);
+  return vec;
+}
+}

--- a/pr/seq-opt-hspsf/rational.ccx
+++ b/pr/seq-opt-hspsf/rational.ccx
@@ -1,0 +1,753 @@
+
+
+
+#include <ctype.h>
+#include <math.h>
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+
+  rational operator=(const rational r);
+  rational operator=(long n);
+
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+
+  double decimal() const;
+};
+
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+
+
+
+
+
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+
+inline rational::rational()
+  : nm(0), dv(1) { }
+
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+
+
+
+
+
+
+
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+
+inline long rational::numerator() const { return nm; }
+
+inline long rational::divisor() const { return dv; }
+
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+
+inline rational rational::round(const rational r, long d_max)
+{
+
+
+
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+
+
+
+    s.reduce();
+
+
+
+  }
+  return s;
+}
+
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+
+inline rational rational::operator=(const rational r)
+{
+
+
+
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+
+inline rational rational::operator=(long n)
+{
+
+
+
+  nm = n;
+  dv = 1;
+  return *this;
+}
+
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+
+inline double rational::decimal() const { return nm/(double)dv; };
+
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+
+inline rational operator+(const rational r0, const rational r1)
+{
+
+
+
+
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+const long CONVERSION_MAX_DIVISOR = 100000;
+inline double floor_d(double d) {
+  return floor(d);
+}
+long euclid(long n, long k, long& a, long& b) {
+  long q = n / k;
+  long r = n % k;
+  if (r == 0) {
+    a = 1;
+    b = 1-q;
+    return k;
+  }
+  else {
+    long a1, b1;
+    long c = euclid(k, r, a1, b1);
+    a = b1;
+    b = a1 - (b1*q);
+    return c;
+  }
+}
+long gcd(long n, long k) {
+  long q = n / k;
+  long r = n % k;
+  if (r == 0) return k;
+  else return gcd(k, r);
+}
+long lcm(long n, long k) {
+  long d = gcd(n, k);
+  return ((n / d) * (k / d) * d);
+}
+unsigned long ilog(unsigned long n)
+{
+  unsigned long k = 0;
+  while (n > 0) {
+    k += 1;
+    n = (n / 2);
+  }
+  return k;
+}
+long imag(long n)
+{
+  return (n < 0 ? n * -1 : n);
+}
+rational rational::dtor(double v) {
+  long d = 1;
+  while (((v - floor_d(v)) > 0.0) && (d < CONVERSION_MAX_DIVISOR)) {
+    v *= 10.0;
+    d *= 10;
+  }
+  return reduce(rational((long)floor_d(v), d));
+}
+rational rational::ator(const char* s) {
+  long n = 0;
+  long d = 1;
+  if (*s == '-') {
+    d = -1;
+    s += 1;
+  }
+  while (isdigit(*s)) {
+    n = (n*10) + (*s - 48);
+    s += 1;
+  }
+  if (*s == '.') {
+    s += 1;
+    while (isdigit(*s)) {
+      n = (n*10) + (*s - 48);
+      d *= 10;
+      s += 1;
+    }
+  }
+  return reduce(rational(n, d));
+}
+}

--- a/pr/seq-opt-hspsf/resource.ccx
+++ b/pr/seq-opt-hspsf/resource.ccx
@@ -1,0 +1,4583 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+BasicResourceState::BasicResourceState
+(Instance& i, estimator_vec& est)
+  : instance(i),
+    estimators(est),
+    amt_consumed(0, instance.n_resources())
+{
+}
+BasicResourceState::BasicResourceState
+(Instance& i, estimator_vec& est, const amt_vec& ac)
+  : instance(i),
+    estimators(est),
+    amt_consumed(ac)
+{
+}
+BasicResourceState::BasicResourceState
+(const BasicResourceState& s)
+  : instance(s.instance),
+    estimators(s.estimators),
+    amt_consumed(s.amt_consumed)
+{
+}
+BasicResourceState::~BasicResourceState()
+{
+}
+hsps::rational BasicResourceState::available_for_consumption(index_type r) const
+{
+  return available(r);
+}
+hsps::rational BasicResourceState::available(index_type r) const
+{
+  return instance.resources[r].init - amt_consumed[r];
+}
+bool BasicResourceState::applicable(Instance::Action& a)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++)
+    if (available(r) < a.req(r)) return false;
+  return true;
+}
+bool BasicResourceState::sufficient_consumable(const index_set& s)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++) if (estimators[r]) {
+    if (estimators[r]->eval(s) > available_for_consumption(r)) return false;
+  }
+  return true;
+}
+bool BasicResourceState::sufficient_consumable(const bool_vec& s)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++) if (estimators[r]) {
+    if (estimators[r]->eval(s) > available_for_consumption(r)) return false;
+  }
+  return true;
+}
+void BasicResourceState::apply(Instance::Action& a)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++)
+    amt_consumed[r] += a.cons[r];
+}
+bool BasicResourceState::is_root()
+{
+  for (index_type r = 0; r < instance.n_resources(); r++)
+    if (amt_consumed[r] > 0) return false;
+  return true;
+}
+int BasicResourceState::compare(const BasicResourceState& s)
+{
+  return amt_consumed.compare(s.amt_consumed, instance.n_resources());
+}
+index_type BasicResourceState::hash()
+{
+  return amt_consumed.hash(instance.n_resources());
+}
+BasicResourceState* BasicResourceState::new_state()
+{
+  return new BasicResourceState(instance, estimators);
+}
+BasicResourceState* BasicResourceState::copy()
+{
+  return new BasicResourceState(*this);
+}
+void BasicResourceState::write(std::ostream& s)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++) {
+    if (r > 0) s << ", ";
+    s << instance.resources[r].name << "=" << available(r);
+  }
+}
+RegressionResourceState::RegressionResourceState
+(Instance& i, estimator_vec& est)
+  : BasicResourceState(i, est),
+    max_required(0, instance.n_resources())
+{
+}
+RegressionResourceState::RegressionResourceState
+(Instance& i, estimator_vec& est, const amt_vec& ac)
+  : BasicResourceState(i, est, ac),
+    max_required(0, instance.n_resources())
+{
+}
+RegressionResourceState::RegressionResourceState
+(const RegressionResourceState& s)
+  : BasicResourceState(s),
+    max_required(s.max_required)
+{
+}
+RegressionResourceState::~RegressionResourceState()
+{
+}
+hsps::rational RegressionResourceState::available(index_type r) const
+{
+  return instance.resources[r].init;
+}
+hsps::rational RegressionResourceState::available_for_consumption(index_type r) const
+{
+  return hsps::rational::min(instance.resources[r].init - amt_consumed[r],instance.resources[r].init - max_required[r]);
+}
+bool RegressionResourceState::applicable(Instance::Action& a)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++) {
+    if (available(r) < a.req(r)) return false;
+    if (available_for_consumption(r) < a.cons[r]) return false;
+  }
+  return true;
+}
+bool RegressionResourceState::applicable
+(Instance::Action& a, const index_vec& c)
+{
+  amt_vec cr(0, instance.n_resources());
+  amt_vec cc(0, instance.n_resources());
+  for (index_type r = 0; r < instance.n_resources(); r++) {
+    hsps::rational cr = 0;
+    hsps::rational cc = 0;
+    for (index_type k = 0; k < c.length(); k++) {
+      cr += instance.actions[c[k]].req(r);
+      cc += instance.actions[c[k]].cons[r];
+    }
+    if (available(r) < (cr + a.req(r))) return false;
+    if (available_for_consumption(r) < (cc + a.cons[r])) return false;
+  }
+  return true;
+}
+bool RegressionResourceState::applicable
+(Instance::Action& a, const index_cost_vec& c)
+{
+  amt_vec cr(0, instance.n_resources());
+  amt_vec cc(0, instance.n_resources());
+  for (index_type r = 0; r < instance.n_resources(); r++) {
+    hsps::rational cr = 0;
+    hsps::rational cc = 0;
+    for (index_type k = 0; k < c.length(); k++) {
+      cr += instance.actions[c[k].first].req(r);
+      cc += instance.actions[c[k].first].cons[r];
+    }
+    if (available(r) < (cr + a.req(r))) return false;
+    if (available_for_consumption(r) < (cc + a.cons[r])) return false;
+  }
+  return true;
+}
+bool RegressionResourceState::applicable
+(Instance::Action& a, const index_cost_vec& c1, const index_vec& c2)
+{
+  amt_vec cr(0, instance.n_resources());
+  amt_vec cc(0, instance.n_resources());
+  for (index_type r = 0; r < instance.n_resources(); r++) {
+    hsps::rational cr = 0;
+    hsps::rational cc = 0;
+    for (index_type k = 0; k < c1.length(); k++) {
+      cr += instance.actions[c1[k].first].req(r);
+      cc += instance.actions[c1[k].first].cons[r];
+    }
+    for (index_type k = 0; k < c2.length(); k++) {
+      cr += instance.actions[c2[k]].req(r);
+      cc += instance.actions[c2[k]].cons[r];
+    }
+    if (available(r) < (cr + a.req(r))) return false;
+    if (available_for_consumption(r) < (cc + a.cons[r])) return false;
+  }
+  return true;
+}
+bool RegressionResourceState::sufficient_consumable(const index_set& s)
+{
+  return BasicResourceState::sufficient_consumable(s);
+}
+bool RegressionResourceState::sufficient_consumable(const bool_vec& s)
+{
+  return BasicResourceState::sufficient_consumable(s);
+}
+bool RegressionResourceState::sufficient_consumable
+(const index_set& s, const Instance::Action& cact)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++) if (estimators[r]) {
+    hsps::rational afc = hsps::rational::min(instance.resources[r].init - amt_consumed[r],instance.resources[r].init - hsps::rational::max(cact.req(r),max_required[r]));
+    if (estimators[r]->eval(s) > afc) return false;
+  }
+  return true;
+}
+bool RegressionResourceState::sufficient_consumable
+(const bool_vec& s, const Instance::Action& cact)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++) if (estimators[r]) {
+    hsps::rational afc = hsps::rational::min(instance.resources[r].init - amt_consumed[r],instance.resources[r].init - hsps::rational::max(cact.req(r),max_required[r]));
+    if (estimators[r]->eval(s) > afc) return false;
+  }
+  return true;
+}
+bool RegressionResourceState::sufficient_consumable
+(const index_set& s, const index_cost_vec& cacts)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++)
+    if (estimators[r]) {
+      hsps::rational creq = 0;
+      for (index_type k = 0; k < cacts.length(); k++)
+ creq += instance.actions[cacts[k].first].req(r);
+      hsps::rational afc = hsps::rational::min(instance.resources[r].init - amt_consumed[r],instance.resources[r].init - hsps::rational::max(creq,max_required[r]));
+      if (estimators[r]->eval(s) > afc) {
+ return false;
+      }
+    }
+  return true;
+}
+bool RegressionResourceState::sufficient_consumable
+(const bool_vec& s, const index_cost_vec& cacts)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++)
+    if (estimators[r]) {
+      hsps::rational creq = 0;
+      for (index_type k = 0; k < cacts.length(); k++)
+ creq += instance.actions[cacts[k].first].req(r);
+      hsps::rational afc = hsps::rational::min(instance.resources[r].init - amt_consumed[r],instance.resources[r].init - hsps::rational::max(creq,max_required[r]));
+      if (estimators[r]->eval(s) > afc) {
+ return false;
+      }
+    }
+  return true;
+}
+void RegressionResourceState::apply(Instance::Action& a)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++) {
+    amt_consumed[r] += a.cons[r];
+    max_required[r] = hsps::rational::max(max_required[r],a.req(r));
+  }
+}
+void RegressionResourceState::reserve_as_required(const amt_vec& req)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++)
+    max_required[r] = hsps::rational::max(max_required[r],req[r]);
+}
+bool RegressionResourceState::is_root()
+{
+  for (index_type r = 0; r < instance.n_resources(); r++)
+    if ((amt_consumed[r] > 0) || (max_required[r] > 0)) return false;
+  return true;
+}
+int RegressionResourceState::compare(const RegressionResourceState& s)
+{
+  int i = amt_consumed.compare(s.amt_consumed, instance.n_resources());
+  if (i != 0) return i;
+  return max_required.compare(s.max_required, instance.n_resources());
+}
+index_type RegressionResourceState::hash()
+{
+  return (amt_consumed.hash(instance.n_resources()) +
+   max_required.hash(instance.n_resources()));
+}
+RegressionResourceState* RegressionResourceState::new_state()
+{
+  return new RegressionResourceState(instance, estimators);
+}
+RegressionResourceState* RegressionResourceState::copy()
+{
+  return new RegressionResourceState(*this);
+}
+void RegressionResourceState::write(std::ostream& s)
+{
+  for (index_type r = 0; r < instance.n_resources(); r++) {
+    if (r > 0) s << ", ";
+    s << instance.resources[r].name << "=" << available_for_consumption(r);
+  }
+}
+}

--- a/pr/seq-opt-hspsf/rng.ccx
+++ b/pr/seq-opt-hspsf/rng.ccx
@@ -1,0 +1,1573 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <cmath>
+#include <iostream>
+#include <unistd.h>
+#include <time.h>
+namespace hsps {
+const double PI = 2 * std::acos(0.0);
+void RNG::seed_with_pid()
+{
+  seed(getpid());
+}
+void RNG::seed_with_time()
+{
+  seed(time(0));
+}
+unsigned long RNG::random_in_range
+(unsigned long range)
+{
+  unsigned long v = random();
+  return (v % range);
+}
+unsigned long RNG::random_in_range
+(unsigned long range, unsigned long except)
+{
+  if (except >= range) {
+    return random_in_range(range);
+  }
+  if (range <= 1) {
+    ::std::cerr << "error: empty range in random_in_range("
+       << range << ", " << except << ")" << ::std::endl;
+    exit(255);
+  }
+  unsigned long r = (random() % (range - 1));
+  if (r < except)
+    return r;
+  else
+    return (r + 1);
+}
+double RNG::random_double(unsigned long div)
+{
+  return ((random() % div)/(double)div);
+}
+double RNG::normal_sample(double mean, double var)
+{
+  double x2pi = random_double(max()) * 2.0 * PI;
+  double g2rad = std::sqrt(-2.0 * std::log(1.0 - random_double(max())));
+  return (std::cos(x2pi) * g2rad * sqrt(var)) + mean;
+}
+unsigned long RNG::binomial_sample(unsigned long n, double p)
+{
+  double s = round(normal_sample(n * p, n * p * (1 - p)));
+  if (s < 0) return 0;
+  else if (s > n) return n;
+  else return (unsigned long)s;
+}
+index_type RNG::select_one_of(const bool_vec& selectable)
+{
+  index_type n = selectable.count(true);
+  if (n == 0) return no_such_index;
+  index_type m = random_in_range(n);
+  for (index_type k = 0; k < selectable.length(); k++) if (selectable[k]) {
+    if (m == 0) return k;
+    m -= 1;
+  }
+  assert(0);
+}
+index_type RNG::select_one_of(const index_vec& selectable)
+{
+  if (selectable.empty()) return no_such_index;
+  index_type m = random_in_range(selectable.length());
+  return selectable[m];
+}
+void RNG::select_fixed_set
+(index_set& s, index_type m, index_type n)
+{
+  assert(n >= m);
+  s.clear();
+  while (m > 0) {
+    index_type i = random_in_range(n - s.length());
+    index_type k = 0;
+    while ((i > 0) || s.contains(k)) {
+      if (s.contains(k)) k += 1;
+      else {
+ k += 1;
+ i -= 1;
+      }
+    }
+    assert(k < n);
+    assert(!s.contains(k));
+    s.insert(k);
+    m -= 1;
+  }
+}
+void RNG::select_variable_set
+(index_set& s, index_type m, index_type n)
+{
+  assert(n > 0);
+  s.clear();
+  for (index_type k = 0; k < n; k++)
+    if (random_in_range(n) < m) s.insert(k);
+}
+void RNG::select_non_empty_variable_set
+(index_set& s, index_type m, index_type n)
+{
+  assert(n > 0);
+  assert(m > 0);
+  s.clear();
+  index_type i = random_in_range(n);
+  s.insert(i);
+  if (m > 1) {
+    for (index_type k = 0; k < n; k++)
+      if ((k != i) && (random_in_range(n - 1) < (m - 1))) s.insert(k);
+  }
+}
+void LC_RNG::seed(unsigned long s)
+{
+  x = s;
+}
+unsigned long LC_RNG::seed_value()
+{
+  return x;
+}
+unsigned long LC_RNG::random()
+{
+  x = ((a * x) + b) % mod;
+  return x;
+}
+unsigned long LC_RNG::max()
+{
+  return mod - 1;
+}
+}

--- a/pr/seq-opt-hspsf/scanner.ccx
+++ b/pr/seq-opt-hspsf/scanner.ccx
@@ -1,0 +1,8339 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdio.h>
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+#include <stdio.h>
+#include <stdlib.h>
+namespace hsps {
+typedef zero_init_pair<void*> ptr_pair;
+class ptr_table {
+  void* _key;
+  ptr_table* _left;
+  ptr_table* _right;
+  ptr_table* _up;
+  ptr_table* _prev;
+  ptr_table* _next;
+  index_type _count;
+ public:
+  void* val;
+ private:
+  ptr_table(void* k, ptr_table* u, ptr_table* p)
+    : _key(k), _left(0), _right(0), _up(u), _prev(p), _next(0),
+    _count(1), val(0) { };
+ public:
+  typedef lvector<void*> key_vec;
+  typedef lvector<void*> value_vec;
+  typedef lvector<ptr_table*> cell_vec;
+  ptr_table()
+    : _key(0), _left(0), _right(0), _up(0), _prev(0), _next(0),
+    _count(0), val(0) { };
+  ~ptr_table();
+  void* key() { return _key; };
+  ptr_table* enum_key_first();
+  ptr_table* enum_key_next();
+  void key_sequence(key_vec&);
+  key_vec* key_sequence();
+  ptr_table* root();
+  ptr_table* next() { return _next; };
+  ptr_table* insert(void* k);
+  ptr_table* insert_next(void* k);
+  ptr_table* insert(void** k, index_type l);
+  ptr_table* insert(key_vec& k);
+  ptr_table* find(void* k);
+  ptr_table* find_next(void* k);
+  ptr_table* find(void** k, index_type l);
+  ptr_table* find(key_vec& k);
+  bool contains(void* k);
+  bool contains(void** k, index_type l);
+  bool contains(key_vec& k);
+  void set(void* k, void* v);
+  void set(void** k, index_type l, void* v);
+  void set(key_vec& k, void* v);
+  void* find_val(void** k, index_type l);
+  void* find_val(key_vec& k);
+  void*& operator[](void* k);
+  void*& operator[](key_vec& k);
+  void dump(cell_vec& vec);
+  index_type count_keys();
+  void dump_keys(key_vec& vec);
+  key_vec* keys();
+  index_type count_values();
+  void dump_values(value_vec& vec);
+  value_vec* values();
+};
+inline bool ptr_table::contains(void* k) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(void** k, index_type l) {
+  return (find(k) != 0);
+}
+inline bool ptr_table::contains(key_vec& k) {
+  return (find(k) != 0);
+}
+inline void ptr_table::set(void* k, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(void** k, index_type l, void* v) {
+  insert(k)->val = v;
+}
+inline void ptr_table::set(key_vec& k, void* v) {
+  insert(k)->val = v;
+}
+inline void*& ptr_table::operator[](void* k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void*& ptr_table::operator[](key_vec& k) {
+  ptr_table* a = insert(k);
+  return a->val;
+}
+inline void* ptr_table::find_val(void** k, index_type l) {
+  ptr_table* a = find(k, l);
+  if (a) return a->val;
+  else return 0;
+}
+inline void* ptr_table::find_val(key_vec& k) {
+  ptr_table* a = find(k);
+  if (a) return a->val;
+  else return 0;
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class PDDL_Name;
+class PDDL_Base {
+ public:
+  static bool use_default_function_value;
+  static hsps::rational default_function_value;
+  static bool use_strict_borrow_definition;
+  static bool use_extended_borrow_definition;
+  static bool del_before_add_semantics;
+  static bool compact_resource_effects;
+  static bool compile_away_disjunctive_preconditions;
+  static bool check_precondition_consistency;
+  static bool compile_away_conditional_effects;
+  static bool compile_away_plan_constraints;
+  static bool compile_away_object_functions;
+  static bool compile_for_validator;
+  static bool create_all_atoms;
+  static bool create_all_actions;
+  static bool number_multiple_action_instances;
+  static bool exclude_all_dkel_items;
+  static string_set excluded_dkel_tags;
+  static string_set required_dkel_tags;
+  static bool strict_set_export;
+  static bool best_effort;
+  static bool write_PDDL31;
+  static bool write_warnings;
+  static bool write_info;
+  static bool write_trace;
+  static bool trace_print_context;
+  static bool name_instance_by_problem_file;
+  static const char* instance_name_prefix;
+  enum symbol_class {
+    sym_object,
+    sym_typename,
+    sym_predicate,
+    sym_object_function,
+    sym_function,
+    sym_action,
+    sym_variable,
+    sym_misc,
+    sym_preference,
+    sym_set,
+    sym_meta_variable
+  };
+  enum metric_class {
+    metric_none,
+    metric_makespan,
+    metric_minimize,
+    metric_maximize
+  };
+  enum mode_keyword {
+    md_none,
+    md_start,
+    md_end,
+    md_all,
+    md_init,
+    md_pos_goal,
+    md_neg_goal
+  };
+  enum partial_value { p_false, p_true, p_unknown };
+  enum expression_class {
+    exp_fun,
+    exp_list,
+    exp_const,
+    exp_add,
+    exp_sub,
+    exp_mul,
+    exp_div,
+    exp_time,
+    exp_preference
+  };
+  enum relation_type {
+    rel_equal,
+    rel_greater,
+    rel_greater_equal,
+    rel_less,
+    rel_less_equal
+  };
+  enum formula_class { fc_false,
+         fc_true,
+         fc_atom,
+         fc_equality,
+         fc_negation,
+         fc_conjunction,
+         fc_disjunction,
+         fc_equivalence,
+         fc_implication,
+         fc_universal,
+         fc_existential,
+         fc_list
+  };
+  struct Symbol;
+  struct TypeSymbol;
+  struct Atom;
+  struct FTerm;
+  struct FChangeAtom;
+  struct SetOf;
+  struct ListExpression;
+  struct ActionSymbol;
+  struct Reference;
+  struct IrrelevantItem;
+  typedef lvector<TypeSymbol*> type_vec;
+  typedef lvector<Atom*> atom_vec;
+  typedef lvector<FChangeAtom*> ch_atom_vec;
+  typedef lvector<SetOf*> atom_set_vec;
+  typedef lvector<Reference*> ref_vec;
+  typedef lvector<IrrelevantItem*> irrelevant_vec;
+  struct TypeSet : public type_vec {
+    TypeSet() : type_vec(0, 0) { };
+    TypeSet(const TypeSet& s) : type_vec(s) { };
+    TypeSet(TypeSymbol* t) : type_vec(t, 1) { };
+    index_type n_elements() const;
+    Symbol* get_element(index_type n);
+    bool is_object() const;
+    bool subtype_or_equal(const TypeSet& s) const;
+    bool subtype_or_equal(TypeSymbol* t) const;
+    void print(std::ostream& s) const;
+    void write_type(std::ostream& s) const;
+  };
+  struct Symbol {
+    symbol_class sym_class;
+    char* print_name;
+    TypeSet sym_types;
+    bool defined_in_problem;
+    bool visible;
+    Symbol(symbol_class c, char* n)
+      : sym_class(c), print_name(n), defined_in_problem(false), visible(true) { };
+    Symbol(char* n)
+      : sym_class(sym_object), print_name(n), defined_in_problem(false), visible(true) { };
+    void print(std::ostream& s) const;
+  };
+  typedef zero_init_pair<Symbol*> symbol_pair;
+  typedef lvector<Symbol*> symbol_vec;
+  typedef svector<Symbol*> symbol_set;
+  typedef lvector<symbol_pair> symbol_pair_vec;
+  static bool extend_substitution(Symbol* out, Symbol* in, symbol_pair_vec& u);
+  static bool print_substitution(std::ostream& s, const symbol_pair_vec& u);
+  static bool print_inequality(std::ostream& s, const symbol_pair_vec& neq);
+  static bool substitution_violates_inequality(const symbol_pair_vec& neq,
+            const symbol_pair_vec& u);
+  static index_type find_matching_atom(Atom* a, atom_vec& v);
+  static index_type find_matching_atom(Atom* a, mode_keyword m, atom_vec& v);
+  static index_type find_matching_fluent_atom
+    (FChangeAtom* a, mode_keyword m, ch_atom_vec& v);
+  struct TypeSymbol : public Symbol {
+    symbol_vec elements;
+    bool is_base_type;
+    TypeSymbol(char* n) : Symbol(sym_typename, n), elements(0, 0),
+  is_base_type(false) { };
+    void add_element(Symbol* e);
+    bool is_object() const { return (strcmp(print_name, "object") == 0); };
+    bool subtype_or_equal(TypeSymbol* t) const;
+    bool subtype_or_equal(const TypeSet& t) const;
+    void print(std::ostream& s) const;
+  };
+  struct VariableSymbol : public Symbol {
+    Symbol* value;
+    FTerm* binding;
+    VariableSymbol(char* n) : Symbol(sym_variable, n), value(0), binding(0) {};
+    bool equality_type_check(Symbol* s);
+    void print(std::ostream& s);
+  };
+  typedef lvector<VariableSymbol*> variable_vec;
+  struct ParamSymbol : public Symbol {
+    variable_vec param;
+    ParamSymbol(symbol_class c, char* n) : Symbol(c, n), param(0, 0) { };
+  };
+  struct PredicateSymbol : public ParamSymbol {
+    bool pos_pre;
+    bool neg_pre;
+    bool added;
+    bool deleted;
+    bool locked;
+    bool modded;
+    ptr_table init;
+    ptr_table pos_goal;
+    ptr_table neg_goal;
+    ptr_table pos_prop;
+    ptr_table neg_prop;
+    irrelevant_vec irr_ins;
+    PredicateSymbol(char* n) : ParamSymbol(sym_predicate, n),
+  pos_pre(false), neg_pre(false), added(false), deleted(false),
+  locked(false), modded(false), irr_ins(0, 0) { };
+    bool is_static() const { return !modded; };
+    bool is_equality() const { return (strcmp(print_name, "=") == 0); };
+    void instantiate(Instance& ins);
+    void initialise_missing(const symbol_vec& p,
+       atom_vec* created,
+       index_type i = 0);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+  };
+  struct ObjectFunctionSymbol : public ParamSymbol {
+    bool modded;
+    ptr_table init;
+    ObjectFunctionSymbol(char* n)
+      : ParamSymbol(sym_object_function, n), modded(false) { };
+    bool is_static() const { return !modded; };
+    void print(std::ostream& s);
+  };
+  struct FunctionSymbol : public ParamSymbol {
+    bool modified;
+    bool integral;
+    bool linear;
+    bool conditioned;
+    bool increased;
+    bool decreased;
+    bool assigned;
+    bool borrowed;
+    ptr_table init;
+    FunctionSymbol(char* n) : ParamSymbol(sym_function, n),
+  modified(false), integral(true), linear(true), conditioned(false),
+  increased(false), decreased(false), assigned(false), borrowed(false)
+    { };
+    bool is_static() const
+    { return !modified; };
+    bool is_reusable() const
+    { return borrowed && !increased && !decreased && !assigned; };
+    bool is_consumable() const
+    { return !borrowed && !increased && decreased && !assigned; };
+    interval eval_init_bounds(ptr_table* p, index_type i, ListExpression* r);
+    void print(std::ostream& s);
+  };
+  struct AtomBase {
+    symbol_vec param;
+    mode_keyword at;
+    hsps::rational at_time;
+    AtomBase() : param(0, 0), at(md_none), at_time(0) { };
+    AtomBase(mode_keyword t) : param(0, 0), at(t), at_time(0) { };
+    AtomBase(AtomBase* b);
+    bool equals(AtomBase& b);
+    void free_variables(variable_vec& v);
+    bool occurs(Symbol* s);
+    void fill_in_args(AtomBase* b);
+    void collect_bound_variables(variable_vec& v);
+    void insert(ptr_table& t);
+    static bool print_bindings;
+    void print(std::ostream& s) const;
+    void print_instance(std::ostream& s);
+  };
+  typedef lvector<AtomBase*> atom_base_vec;
+  struct Atom : AtomBase {
+    PredicateSymbol* pred;
+    Atom(PredicateSymbol* p) : pred(p) { };
+    Atom(PredicateSymbol* p, mode_keyword t) : AtomBase(t), pred(p) { };
+    Atom(PredicateSymbol* p, variable_vec& a, bool as_value)
+      : pred(p)
+    {
+      param.set_length(a.length());
+      for (index_type k = 0; k < a.length(); k++)
+ param[k] = (as_value ? a[k]->value : a[k]);
+    };
+    Atom(PredicateSymbol* p, Symbol* a0)
+      : pred(p)
+    {
+      param.append(a0);
+    };
+    Atom(Atom* a) : AtomBase(a), pred(a->pred) { };
+    bool equals(Atom& a);
+    bool is_static() const {
+      return ((at == md_init) ||
+       (at == md_pos_goal) ||
+       (at == md_neg_goal) ||
+       pred->is_static());
+    };
+    bool check();
+    Instance::Atom* find_prop(Instance& ins, bool neg, bool create);
+    void build(Instance& ins, bool neg, index_type p);
+    Atom* instantiate_partially();
+    partial_value partial_eval(ptr_table* r, index_type p);
+    partial_value partial_eval();
+    bool initial_value();
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    void print(std::ostream& s, bool neg) const;
+    void print(std::ostream& s) const { print(s, false); };
+  };
+  struct CAtom : public Atom {
+    symbol_pair_vec neq;
+    CAtom(Atom* a) : Atom(a), neq(symbol_pair(0, 0), 0) { };
+    CAtom(CAtom* s) : Atom(s), neq(s->neq) { };
+    CAtom(const Atom* a, symbol_pair_vec& u);
+    CAtom(const Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+    bool instance_of(Atom* a, symbol_pair_vec& u);
+    bool instance_of(Atom* a, const symbol_pair_vec& neq, symbol_pair_vec& u);
+    bool instance_of(CAtom* a, symbol_pair_vec& u);
+    bool unify(Atom* a, symbol_pair_vec& u);
+    bool unify(CAtom* a, symbol_pair_vec& u);
+    void print(std::ostream& s);
+  };
+  typedef lvector<CAtom*> catom_vec;
+  struct FTerm : AtomBase {
+    ObjectFunctionSymbol* fun;
+    FTerm(ObjectFunctionSymbol* f) : fun(f) { };
+    bool equals(FTerm& a);
+    void print(std::ostream& s) const;
+  };
+  struct OInitAtom : AtomBase {
+    ObjectFunctionSymbol* fun;
+    Symbol* val;
+    OInitAtom(ObjectFunctionSymbol* f) : fun(f), val(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<OInitAtom*> obj_init_atom_vec;
+  struct FInitAtom : AtomBase {
+    FunctionSymbol* fun;
+    hsps::rational val;
+    Instance::resource_ref res;
+    FInitAtom(FunctionSymbol* f) : fun(f), val(0) { };
+    FInitAtom(FChangeAtom* a);
+    bool is_static() const { return fun->is_static(); };
+    void print(std::ostream& s);
+  };
+  typedef lvector<FInitAtom*> fun_init_atom_vec;
+  struct Expression;
+  typedef lvector<Expression*> exp_vec;
+  struct Expression {
+    expression_class exp_class;
+    Expression(expression_class c) : exp_class(c) { };
+    static bool print_nary;
+    bool is_static();
+    bool is_constant();
+    bool is_integral();
+    hsps::rational eval_static();
+    bool eval_partial(hsps::rational& val);
+    interval eval_bounds();
+    hsps::rational eval_init();
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    hsps::rational eval_delta(Symbol* preference, hsps::rational p_value, hsps::rational d_value);
+    Expression* copy();
+    Expression* simplify();
+    void collect_constants(exp_vec& c);
+    void mark_functions_in_condition();
+    hsps::rational integrify();
+    void substitute_for_time(Expression* e);
+    Expression* substitute_for_preference(Symbol* n, Expression* e);
+    bool equals(Expression* e);
+    void print_sum(std::ostream& s, bool grnd);
+    void print_product(std::ostream& s, bool grnd);
+    void print(std::ostream& s, bool grnd);
+  };
+  struct ListExpression : public Expression {
+    Symbol* sym;
+    ListExpression* rest;
+    ListExpression(Symbol* s, ListExpression* r) :
+      Expression(exp_list), sym(s), rest(r) { };
+    bool match(AtomBase* atom);
+  };
+  struct FunctionExpression : public Expression {
+    FunctionSymbol* fun;
+    ListExpression* args;
+    FunctionExpression(FunctionSymbol* f, ListExpression* a) :
+      Expression(exp_fun), fun(f), args(a) { };
+    bool match(FChangeAtom* atom);
+    hsps::rational eval_delta(ch_atom_vec& incs, ch_atom_vec& decs);
+    FChangeAtom* make_atom_base();
+  };
+  struct ConstantExpression : public Expression {
+    hsps::rational val;
+    ConstantExpression(hsps::rational v) :
+      Expression(exp_const), val(v) { };
+  };
+  struct TimeExpression : public Expression {
+    Expression* time_exp;
+    TimeExpression() :
+      Expression(exp_time), time_exp(0) { };
+    TimeExpression(Expression* e) :
+      Expression(exp_time), time_exp(e) { };
+  };
+  struct BinaryExpression : public Expression {
+    Expression* first;
+    Expression* second;
+    BinaryExpression(expression_class c, Expression* e1, Expression* e2) :
+      Expression(c), first(e1), second(e2) { };
+  };
+  struct PreferenceExpression : public Expression {
+    Symbol* name;
+    PreferenceExpression(Symbol* n) :
+      Expression(exp_preference), name(n) { };
+  };
+  struct Relation {
+    relation_type rel;
+    mode_keyword at;
+    Expression* first;
+    Expression* second;
+    Relation(relation_type r, Expression* e1, Expression* e2) :
+      rel(r), at(md_none), first(e1), second(e2) { };
+    Relation(relation_type r, mode_keyword m, Expression* e1, Expression* e2) :
+      rel(r), at(m), first(e1), second(e2) { };
+    Expression* match_gteq_constant(FChangeAtom* atom);
+    FunctionExpression* match_lteq_fun(FChangeAtom* atom);
+    bool is_static();
+    partial_value partial_eval();
+    void print(std::ostream& s, bool grnd);
+  };
+  typedef lvector<Relation*> relation_vec;
+  struct FChangeAtom : AtomBase {
+    FunctionSymbol* fun;
+    Expression* val;
+    FChangeAtom(FunctionSymbol* f) :
+      fun(f), val(0) { };
+    FChangeAtom(FunctionSymbol* f, mode_keyword t) :
+      AtomBase(t), fun(f), val(0) { };
+    FChangeAtom(FChangeAtom* a, hsps::rational v) :
+      AtomBase(a), fun(a->fun), val(new ConstantExpression(v)) { };
+    bool equals(FChangeAtom& a);
+    bool fluent_equals(FChangeAtom& a);
+    bool fluent_and_mode_equals(FChangeAtom& a);
+    FChangeAtom* find_fluent_equals(ch_atom_vec& vec);
+    Instance::Resource* find_resource(Instance& ins);
+    void print(std::ostream& s);
+  };
+  struct Formula {
+    formula_class fc;
+    Formula(formula_class c) : fc(c) { };
+    void rename_variables_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_variables_2(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_1(PDDL_Base::symbol_pair_vec& sub);
+    void rename_predicates_2(PDDL_Base::symbol_pair_vec& sub);
+    Formula* simplify();
+    void write_otter(std::ostream& s) const;
+    void print(std::ostream& s) const;
+    void untype(PDDL_Base* base);
+  };
+  typedef lvector<Formula*> formula_vec;
+  struct AFormula : public Formula, public Atom {
+    AFormula(Atom* a) :
+      Formula(fc_atom), Atom(a) { };
+    AFormula(PredicateSymbol* p) :
+      Formula(fc_atom), Atom(p) { };
+    AFormula(PredicateSymbol* p, variable_vec& a) :
+      Formula(fc_atom), Atom(p, a, false) { };
+    void print(std::ostream& s) const;
+    void write_otter(std::ostream& s) const;
+  };
+  struct EqFormula : public Formula {
+    Symbol* t1;
+    Symbol* t2;
+    EqFormula(Symbol* s1, Symbol* s2) :
+      Formula(fc_equality), t1(s1), t2(s2) { };
+    void write_otter(std::ostream& s) const;
+  };
+  struct NFormula : public Formula {
+    Formula* f;
+    NFormula(Formula* g) : Formula(fc_negation), f(g) { };
+  };
+  struct BFormula : public Formula {
+    Formula* f1;
+    Formula* f2;
+    BFormula(formula_class c, Formula* g1, Formula* g2) :
+      Formula(c), f1(g1), f2(g2) { };
+  };
+  struct CFormula : public Formula {
+    formula_vec parts;
+    CFormula(formula_class c) : Formula(c), parts(0, 0) { };
+    CFormula(formula_class c, Formula* f1, Formula* f2) :
+      Formula(c), parts(0, 0)
+    {
+      parts.append(f1);
+      parts.append(f2);
+    };
+    void add(Formula* f) { parts.append(f); };
+    void add(formula_vec& f) { parts.append(f); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct QFormula : public Formula {
+    variable_vec vars;
+    Formula* f;
+    QFormula(formula_class c) : Formula(c), vars(0, 0), f(0) { };
+    QFormula(formula_class c, Formula* g) : Formula(c), vars(0, 0), f(g) { };
+    QFormula(formula_class c, variable_vec& v, Formula* g) :
+      Formula(c), vars(0, 0), f(g)
+    {
+      for (index_type k = 0; k < v.length(); k++) vars.append(v[k]);
+    };
+    void add(PDDL_Base::VariableSymbol* v) { vars.append(v); };
+    void add(PDDL_Base::variable_vec& v) { vars.append(v); };
+    void write_otter(std::ostream& s) const;
+  };
+  struct TypeConstraint {
+    VariableSymbol* var;
+    TypeSymbol* typ;
+    TypeConstraint(VariableSymbol* v, TypeSymbol* t) : var(v), typ(t) { };
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+  };
+  typedef lvector<TypeConstraint*> type_constraint_vec;
+  struct Context {
+    variable_vec param;
+    atom_vec pos_con;
+    atom_vec neg_con;
+    type_constraint_vec type_con;
+    Context() : param(0, 0), pos_con(0, 0), neg_con(0, 0), type_con(0, 0) { };
+    Context(const Context* c) : param(c->param), pos_con(c->pos_con),
+  neg_con(c->neg_con), type_con(c->type_con) { };
+    bool context_is_static() const;
+    bool occurs_in_context(Symbol* s);
+    void clear_arguments();
+    void set_mode(mode_keyword m);
+    bool is_true();
+    partial_value partial_eval();
+    void print(std::ostream& s);
+    void print_assignment(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct DKEL_Item : public Context {
+    char* item_name;
+    Symbol* name;
+    string_set item_tags;
+    bool defined_in_problem;
+    bool included;
+    DKEL_Item(char* name) : item_name(name), name(0),
+  defined_in_problem(false), included(true) { };
+    DKEL_Item(const DKEL_Item* i) : Context(i), item_name(i->item_name),
+  name(i->name), item_tags(i->item_tags),
+  defined_in_problem(i->defined_in_problem), included(i->included) { };
+    bool item_is_included(string_set& ex_tags, string_set& req_tags);
+    void print_begin(std::ostream& s);
+    void print_end(std::ostream& s);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SetOf : public Context {
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    SetOf() : pos_atoms(0, 0), neg_atoms(0, 0) { };
+    SetOf(const SetOf* s)
+      : Context(s), pos_atoms(s->pos_atoms), neg_atoms(s->neg_atoms)
+    { };
+    SetOf(Atom* a)
+    { pos_atoms.append(a); };
+    SetOf(Atom* a, bool n)
+    { if (n) neg_atoms.append(a); else pos_atoms.append(a); };
+    bool is_static() const;
+    void set_mode(mode_keyword m);
+    partial_value partial_eval(bool as_disjunction = false);
+    partial_value partial_eval(index_type p, bool as_disjunction = false);
+    void instantiate_as_set(Instance& ins, index_set& s);
+    void instantiate_as_effect(Instance& ins, index_set& s_add,
+          index_set& s_del);
+    void instantiate_conditional(Instance& ins, rule_set& s_pos,
+     rule_set& s_neg);
+    SetOf* instantiate_partially();
+    void compile(atom_vec& pos_ins, atom_vec& neg_ins, index_type p);
+    void compile_non_static(atom_set_vec& ins, index_type p);
+    void print(std::ostream& s);
+    void print_as_disjunction(std::ostream& s);
+    void build_set(Instance& ins, index_set& s, index_type p);
+    void build_effect(Instance& ins, index_set& s_add, index_set& s_del,
+        index_type p);
+    void build_conditional(Instance& ins, rule_set& s_pos, rule_set& s_neg,
+      index_type p);
+  };
+  struct QCNumericEffect : public Context {
+    FChangeAtom* atom;
+    QCNumericEffect() : atom(0) { };
+    QCNumericEffect(FChangeAtom* a) : atom(a) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<QCNumericEffect*> qc_numeric_effect_vec;
+  enum set_constraint_keyword { sc_at_least, sc_at_most, sc_exactly };
+  struct SetConstraint : public DKEL_Item {
+    set_constraint_keyword sc_type;
+    index_type sc_count;
+    atom_vec pos_atoms;
+    atom_vec neg_atoms;
+    atom_set_vec atom_sets;
+    SetConstraint() : DKEL_Item(":invariant"), sc_type(sc_at_least),
+  sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0), atom_sets(0, 0) { };
+    SetConstraint(const DKEL_Item* item) : DKEL_Item(item),
+  sc_type(sc_at_least), sc_count(0), pos_atoms(0, 0), neg_atoms(0, 0),
+  atom_sets(0, 0) { };
+    void build(Instance& ins, index_type p);
+    void instantiate(Instance& ins);
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InvariantFormula : public DKEL_Item {
+    Formula* f;
+    InvariantFormula(Formula* g)
+      : DKEL_Item(":invariant"), f(g) { };
+    InvariantFormula(const DKEL_Item* item, Formula* g)
+      : DKEL_Item(item), f(g) { };
+    void write_dkel(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct Reference : public AtomBase {
+    Symbol* name;
+    bool neg;
+    bool has_args;
+    index_set index;
+    Reference(Symbol* n) : name(n), neg(false), has_args(true) { };
+    Reference(Symbol* n, bool ng, bool ha)
+      : name(n), neg(ng), has_args(ha) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    void* find_action();
+    void find(const name_vec& names, index_set& ind);
+    Reference* instantiate_partially();
+    void print(std::ostream& s);
+  };
+  struct IrrelevantItem : public DKEL_Item {
+    Reference* entity;
+    IrrelevantItem() : DKEL_Item(":irrelevant"), entity(0) { };
+    bool match(symbol_vec& args);
+    bool match(variable_vec& args);
+    IrrelevantItem* instantiate_partially();
+    void print(std::ostream& s);
+    void write_dkel(std::ostream& s);
+  };
+  struct SequentialTaskNet : public Context {
+    ref_vec tasks;
+    ActionSymbol* abs_act;
+    SequentialTaskNet() : tasks(0, 0), abs_act(0) { };
+    void print(std::ostream& s);
+  };
+  typedef lvector<SequentialTaskNet*> task_net_vec;
+  struct SetSymbol : public Symbol {
+    ptr_table set_table;
+    lvector<index_set*> sets;
+    name_vec names;
+    SetSymbol(char* n) : Symbol(sym_set, n), sets(0, 0), names(0, 0) { };
+  };
+  struct SetName : public AtomBase {
+    SetSymbol* sym;
+    SetName(SetSymbol* s) : sym(s) { };
+    index_set* find();
+    SetName* instantiate_partially();
+    void print(std::ostream& s);
+    void print_instance(std::ostream& s);
+  };
+  struct ActionSymbol : public ParamSymbol {
+    atom_vec pos_pre;
+    atom_vec neg_pre;
+    atom_set_vec set_pre;
+    atom_set_vec dis_pre;
+    relation_vec num_pre;
+    atom_vec adds;
+    atom_vec dels;
+    atom_set_vec set_eff;
+    atom_vec cons;
+    atom_set_vec cond_eff;
+    atom_vec locks;
+    atom_vec enables;
+    ch_atom_vec reqs;
+    ch_atom_vec incs;
+    ch_atom_vec decs;
+    ch_atom_vec fass;
+    qc_numeric_effect_vec qc_incs;
+    qc_numeric_effect_vec qc_decs;
+    qc_numeric_effect_vec qc_fass;
+    Expression* dmin;
+    Expression* dmax;
+    irrelevant_vec irr_ins;
+    ref_vec refs;
+    task_net_vec exps;
+    ptr_table instances;
+    SetName* part;
+    const char* assoc;
+    ActionSymbol(char* n) : ParamSymbol(sym_action, n), pos_pre(0, 0),
+  neg_pre(0, 0), set_pre(0, 0), dis_pre(0, 0), num_pre(0, 0),
+  adds(0, 0), dels(0, 0), set_eff(0, 0), cons(0, 0), cond_eff(0, 0),
+  locks(0, 0), enables(0, 0), reqs(0, 0), incs(0, 0), decs(0, 0),
+  fass(0, 0), qc_incs(0, 0), qc_decs(0, 0), qc_fass(0, 0), dmin(0),
+  dmax(0), irr_ins(0, 0), refs(0, 0), exps(0, 0), part(0), assoc(0) { };
+    void build(Instance& ins, index_type p, Expression* cost_exp);
+    Instance::Action& build_action(Instance& ins,
+       PDDL_Name* name,
+       index_type& count,
+       const index_set& pre,
+       const index_set& add,
+       const index_set& del,
+       const index_set& lck,
+       const index_cost_vec& r_use,
+       const index_cost_vec& r_cons,
+       hsps::rational dmin,
+       hsps::rational dmax,
+       hsps::rational dur,
+       hsps::rational cost);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          index_vec& s,
+          index_type p);
+    void build_actions_with_dc(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc);
+    void build_actions_with_dc_and_ce(Instance& ins,
+          PDDL_Name* name,
+          index_type& count,
+          const index_set& pre,
+          const index_set& add,
+          const index_set& del,
+          const index_set& lck,
+          const index_cost_vec& r_use,
+          const index_cost_vec& r_cons,
+          hsps::rational dmin,
+          hsps::rational dmax,
+          hsps::rational dur,
+          hsps::rational cost,
+          const index_set_vec& dc,
+          const rule_set& pce,
+          const rule_set& nce,
+          const bool_vec& ece);
+    index_type param_index(VariableSymbol* p);
+    void get_param_inequalities(symbol_pair_vec& neq);
+    void set_arguments(const symbol_vec& args);
+    void set_arguments(const ptr_table::key_vec& args);
+    void clear_arguments();
+    void* find_instance();
+    bool is_abstract();
+    void post_process();
+    void instantiate(Instance& ins, Expression* cost_exp);
+    void write_prototype(std::ostream& s);
+    void print(std::ostream& s);
+    void untype(PDDL_Base* base);
+  };
+  struct InputPlanStep {
+    Reference* act;
+    hsps::rational start_time;
+    InputPlanStep() : act(0), start_time(0) { };
+    InputPlanStep(Reference* a, hsps::rational t) : act(a), start_time(t) { };
+  };
+  struct InputPlan {
+    Symbol* name;
+    bool is_opt;
+    lvector<InputPlanStep*> steps;
+    InputPlan() : name(0), is_opt(false), steps(0, 0) { };
+    bool export_to_instance(Instance& ins, const index_vec& map, Plan& p);
+    void print(std::ostream& s);
+  };
+  struct HTableEntry {
+    atom_vec atoms;
+    bool_vec neg;
+    hsps::rational cost;
+    bool opt;
+    HTableEntry() : atoms(0, 0), neg(false, 0), cost(0), opt(false) { };
+  };
+  struct SimpleReferenceSet : public Context {
+    Reference* ref;
+    SimpleReferenceSet(Reference* r) : ref(r) { };
+    bool build(const name_vec& names, index_set& set, index_type p);
+    void print(std::ostream& s);
+  };
+  typedef lvector<SimpleReferenceSet*> refs_vec;
+  struct ReferenceSet : public Context {
+    refs_vec refs;
+    Symbol* name;
+    ReferenceSet() : refs(0, 0), name(0) { };
+    void add(SimpleReferenceSet* ref) { refs.append(ref); };
+    void build(const name_vec& names, index_set_vec& sets, index_type p);
+    void print(std::ostream& s);
+  };
+  struct CPG {
+    atom_vec atoms;
+    index_vec atom_first_arg;
+    bool_vec neg;
+    symbol_vec args;
+    type_vec arg_types;
+    CPG() : atoms(0, 0), neg(false, 0), args(0, 0), arg_types(0, 0) { };
+    CPG(CPG& g, index_vec& s);
+    void make_key(ptr_table::key_vec& key);
+    void make_typed_key(ptr_table::key_vec& key);
+    void make_parameters(variable_vec& params);
+    ListExpression* make_argument_list(index_type first);
+    void add_asserting_effects(ActionSymbol* act,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          bool strict);
+    void add_destroying_effects(ActionSymbol* act,
+    ParamSymbol* pf,
+    PredicateSymbol* p,
+    bool p_val,
+    PredicateSymbol* g,
+    FunctionSymbol* f,
+    Expression* f_val,
+    bool strict);
+    bool initial_value();
+    void add_asserting_effects(index_type c_atom,
+          ActionSymbol* act,
+          index_type c_eff,
+          bool_vec& sat,
+          PredicateSymbol* p,
+          bool p_val,
+          PredicateSymbol* g,
+          FunctionSymbol* f,
+          Expression* f_val,
+          symbol_pair_vec& eq,
+          symbol_pair_vec& neq,
+          bool strict);
+    void add_propositional_effect(ActionSymbol* act,
+      PredicateSymbol* p, bool p_val,
+      index_type c_atom, Atom* a_eff,
+      bool strict);
+    void add_fluent_effect(ActionSymbol* act,
+      FunctionSymbol* f, Expression* f_val,
+      index_type c_atom, Atom* a_eff);
+    void add_effect_conditions(Context* e, ParamSymbol* pf, bool_vec& sat,
+          symbol_vec& subs, symbol_pair_vec& eq,
+          symbol_pair_vec& neq);
+  };
+  enum goal_class { goal_pos_atom, goal_neg_atom, goal_relation, goal_task,
+      goal_conjunction, goal_disjunction, goal_forall,
+      goal_exists, goal_always, goal_sometime,
+      goal_at_most_once, goal_within, goal_always_within,
+      goal_sometime_before, goal_sometime_after };
+  struct Goal {
+    goal_class g_class;
+    Goal(goal_class c) : g_class(c) { };
+    bool is_state();
+    bool is_propositional();
+    bool is_singular();
+    bool makeCPG(CPG& g);
+    bool makeCPG(CPG& g, index_vec& s);
+    void instantiate(Instance& ins, hsps::rational deadline);
+    void instantiate(Instance& ins, index_set& set, Symbol* p, index_type i);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Goal*> goal_vec;
+  struct AtomicGoal : public Goal {
+    Atom* atom;
+    AtomicGoal(Atom* a, bool neg)
+      : Goal(neg ? goal_neg_atom : goal_pos_atom), atom(a) { };
+    void print(std::ostream& s);
+  };
+  struct NumericGoal : public Goal {
+    Relation* rel;
+    NumericGoal(Relation* r) : Goal(goal_relation), rel(r) { };
+    void print(std::ostream& s);
+  };
+  struct TaskGoal : public Goal {
+    Reference* task;
+    TaskGoal(Reference* r) : Goal(goal_task), task(r) { };
+    void print(std::ostream& s);
+  };
+  struct ConjunctiveGoal : public Goal {
+    goal_vec goals;
+    ConjunctiveGoal() : Goal(goal_conjunction), goals(0, 0) { };
+    ConjunctiveGoal(goal_class gc) : Goal(gc), goals(0, 0) { };
+    void print(std::ostream& s);
+  };
+  struct DisjunctiveGoal : public ConjunctiveGoal {
+    DisjunctiveGoal() : ConjunctiveGoal(goal_disjunction) { };
+    void print(std::ostream& s);
+  };
+  struct QuantifiedGoal : public Goal, public Context {
+    Goal* goal;
+    QuantifiedGoal() : Goal(goal_forall), goal(0) { };
+    QuantifiedGoal(goal_class gc) : Goal(gc), goal(0) { };
+    void print(std::ostream& s);
+  };
+  struct SimpleSequenceGoal : public Goal {
+    Goal* constraint;
+    SimpleSequenceGoal(goal_class c, Goal* g) : Goal(c), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredSequenceGoal : public Goal {
+    Goal* trigger;
+    Goal* constraint;
+    TriggeredSequenceGoal(goal_class c, Goal* t, Goal* g)
+      : Goal(c), trigger(t), constraint(g) { };
+    void print(std::ostream& s);
+  };
+  struct DeadlineGoal : public Goal {
+    Goal* goal;
+    hsps::rational at;
+    DeadlineGoal(hsps::rational t, Goal* g) : Goal(goal_within), goal(g), at(t) { };
+    void print(std::ostream& s);
+  };
+  struct TriggeredDeadlineGoal : public Goal {
+    Goal* trigger;
+    Goal* goal;
+    hsps::rational delay;
+    TriggeredDeadlineGoal(Goal* t, hsps::rational d, Goal* g)
+      : Goal(goal_always_within), trigger(t), delay(d), goal(g) { };
+    void print(std::ostream& s);
+  };
+  struct Preference {
+    Symbol* name;
+    Goal* goal;
+    Preference() : name(0), goal(0) { };
+    Preference(Symbol* n) : name(n), goal(0) { };
+    Preference(Symbol* n, Goal* g) : name(n), goal(g) { };
+    bool is_state() { return goal->is_state(); };
+    bool is_propositional() { return goal->is_propositional(); };
+    hsps::rational value(metric_class metric_type, Expression* m);
+    void instantiate(SoftInstance& ins,
+       metric_class metric_type,
+       Expression* m);
+    void print(std::ostream& s);
+  };
+  typedef lvector<Preference*> preference_vec;
+  char* domain_name;
+  char* problem_name;
+  char* domain_file;
+  char* problem_file;
+  bool ready_to_instantiate;
+  char* problem_file_basename();
+  char* enum_problem_filename(const char* s, index_type i);
+  StringTable& tab;
+  type_vec dom_types;
+  type_vec dom_base_types;
+  TypeSymbol* dom_top_type;
+  symbol_vec dom_constants;
+  PredicateSymbol* dom_eq_pred;
+  PredicateSymbol* dom_assign_pred;
+  Symbol* dom_undefined_obj;
+  static PredicateSymbol* current_eq_predicate;
+  lvector<PredicateSymbol*> dom_predicates;
+  lvector<ObjectFunctionSymbol*> dom_object_functions;
+  lvector<FunctionSymbol*> dom_functions;
+  lvector<ActionSymbol*> dom_actions;
+  lvector<SetConstraint*> dom_sc_invariants;
+  lvector<InvariantFormula*> dom_f_invariants;
+  lvector<IrrelevantItem*> dom_irrelevant;
+  atom_vec dom_init;
+  obj_init_atom_vec dom_obj_init;
+  fun_init_atom_vec dom_fun_init;
+  goal_vec dom_goals;
+  preference_vec dom_preferences;
+  ref_vec goal_tasks;
+  metric_class metric_type;
+  Expression* metric;
+  hsps::rational serial_length;
+  hsps::rational parallel_length;
+  lvector<InputPlan*> input_plans;
+  lvector<HTableEntry*> h_table;
+  lvector<ReferenceSet*> input_sets;
+  lvector<SetSymbol*> partitions;
+  static ActionSymbol* src_action_symbol(ptr_pair* p);
+  TypeSymbol* find_type(const char* name);
+  PredicateSymbol* find_predicate(const char* name);
+  FunctionSymbol* find_function(const char* name);
+  bool find_initial_fact(const char* pname, const symbol_vec& arg);
+  hsps::rational find_function_value(const char* fname, const symbol_vec& arg);
+  index_type find_element_satisfying(const symbol_vec& elements,
+         const char* pname,
+         symbol_vec& arg,
+         index_type element_arg_p);
+  void find_elements_satisfying(const symbol_vec& elements,
+    const char* pname,
+    symbol_vec& arg,
+    index_type element_arg_p,
+    index_set& sats);
+  Atom* goal_to_atom(Goal* g);
+  bool goal_to_atom_vec(Goal* g, atom_vec& av);
+  PDDL_Base(StringTable& t);
+  ~PDDL_Base();
+  void set_variable_type(variable_vec& vec, TypeSymbol* t);
+  void set_variable_type(variable_vec& vec, const TypeSet& t);
+  void set_type_type(type_vec& vec, TypeSymbol* t);
+  void set_constant_type(symbol_vec& vec, TypeSymbol* t);
+  void clear_context(variable_vec& vec);
+  void clear_context(variable_vec& vec, index_type n_min, index_type n_max);
+  bool merge_type_vectors(type_vec& v0, type_vec& v1);
+  void make_parameters(type_vec& t, const char* prefix, variable_vec& v);
+  Atom* make_atom_from_prop(ptr_pair& src, bool& neg);
+  Symbol* gensym(symbol_class c, const char* p, const TypeSet& t);
+  Symbol* gensym(symbol_class c, const char* p, TypeSymbol* t);
+  Symbol* gensym_i(symbol_class c, const char* p, index_type i, TypeSymbol* t);
+  Symbol* gensym_s(symbol_class c, const char* p, const Symbol* s, TypeSymbol* t);
+  Symbol* gensym_n(symbol_class c, const char* p, const Name* n, TypeSymbol* t);
+  void new_variable_substitution(Atom* a,
+     symbol_pair_vec& u,
+     symbol_pair_vec& new_u);
+  Atom* new_meta_atom(PredicateSymbol* p);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& u);
+  CAtom* new_CAtom(Atom* a, symbol_pair_vec& n, symbol_pair_vec& u);
+  void extend_cc(CAtom* l, catom_vec& m, catom_vec& nm,
+   lvector< swapable_pair<catom_vec> >& x,
+   index_type d);
+  void find_cc();
+  void post_process();
+  void instantiate(Instance& ins);
+  void instantiate_soft(SoftInstance& ins);
+  void instantiate_atom_set(Instance& ins, atom_vec& a, index_set& s);
+  index_type n_plans() const { return input_plans.length(); };
+  bool export_plan(index_type i, Instance& ins, const index_vec& map, Plan& p);
+  bool export_plan(index_type i, Instance& ins, Plan& p);
+  void export_heuristic(Instance& ins,
+   const index_vec& map,
+   bool opt_maximize,
+   Heuristic& h);
+  void export_sets(const name_vec& names, index_set_vec& sets);
+  void export_action_partitions(name_vec& names, index_set_vec& sets);
+  void lift_DKEL_Items(const Instance& ins);
+  PredicateSymbol* find_type_predicate(Symbol* type_sym);
+  void untype();
+  void compile_preferences();
+  void compile_constraints_1();
+  void compile_constraints_2();
+  void select_preferences(const bool_vec& sel);
+  void metric_to_goal(hsps::rational bound);
+  void compile_set_conditions_and_effects();
+  void compile_object_functions();
+  Expression* replace_violations_1(Expression* exp,
+       CPG* cpg[],
+       FunctionSymbol* f_violated[]);
+  Goal* compile_constraint_1(Goal* g, index_type i, const Symbol* n,
+        symbol_vec& aut_states, index_type n_ra);
+  AtomicGoal* make_automaton_type_a(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_e(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_o(CPG& f, index_type i, const Symbol* n,
+        symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sb(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  AtomicGoal* make_automaton_type_sa(CPG& f, CPG& g,
+         index_type i, const Symbol* n,
+         symbol_vec& aut_state, index_type n_ra);
+  void make_automaton_transition(Symbol* s_from,
+     Symbol* s_to,
+     bool is_accept,
+     CPG* f, bool neg_f,
+     CPG* g, bool neg_g,
+     PredicateSymbol* p_state,
+     PredicateSymbol* p_accept,
+     PredicateSymbol* p_synch);
+  void add_precondition_formula(ActionSymbol* a, CPG* f, bool is_neg);
+  Goal* compile_constraint_2(Goal* g, const Symbol* n);
+  Goal* compile_always_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_sometime_constraint(SimpleSequenceGoal* g, const Symbol* n);
+  Goal* compile_at_most_once_constraint(SimpleSequenceGoal* g,
+     const Symbol* n);
+  Goal* compile_sometime_before_constraint(TriggeredSequenceGoal* g,
+        const Symbol* n);
+  void compile_set_conditions_and_effects(ActionSymbol* act);
+  void compile_set_conditions_and_effects(ActionSymbol* act,
+       variable_vec& i_param,
+       variable_vec& d_param,
+       index_type p);
+  Atom* make_binding_atom(VariableSymbol* v);
+  void compile_object_functions(ActionSymbol* act, Symbol* undefined_value);
+  void compile_object_functions_for_validator(ActionSymbol* act);
+  Goal* compile_object_functions(Goal* g);
+  void write_declarations(std::ostream& s);
+  void write_action(std::ostream& s, ActionSymbol* act);
+  void write_set_precondition(std::ostream& s, SetOf* set);
+  void write_disjunctive_set_precondition(std::ostream& s, SetOf* set);
+  void write_set_effect(std::ostream& s, SetOf* set);
+  void write_QCN_effect(std::ostream& s, const char* effect_type, QCNumericEffect* qcn);
+  void write_objects(std::ostream& s, bool defined_in_problem);
+  void write_init(std::ostream& s);
+  void write_goal(std::ostream& s);
+  void write_metric(std::ostream& s);
+  void write_dkel_items(std::ostream& s, bool defined_in_problem);
+  void write_domain_begin(std::ostream& s);
+  void write_problem_begin(std::ostream& s);
+  void write_end(std::ostream& s);
+  void write_dkel_domain(std::ostream& s, bool leave_open);
+  void write_dkel_problem(std::ostream& s, bool leave_open);
+  void write_plans(std::ostream& s);
+  void write_heuristic_table(std::ostream& s);
+  void write_sets(std::ostream& s);
+  void print(std::ostream& s);
+};
+class InstanceName : public Name {
+  char* domain_name;
+  char* problem_name;
+ public:
+  InstanceName(char* d, char* p) : domain_name(d), problem_name(p) { };
+  virtual ~InstanceName() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class PDDL_Name : public Name {
+ protected:
+  bool neg;
+  PDDL_Base::Symbol* sym;
+  PDDL_Base::symbol_vec arg;
+  bool vis;
+  bool_vec avis;
+ public:
+  static char catc;
+  static bool obscure_symbol_names;
+  PDDL_Name(PDDL_Base::Symbol* s)
+    : neg(false), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, bool n)
+    : neg(n), sym(s), arg(0, 0), vis(true), avis(true, 0) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::symbol_vec a, bool n)
+    : neg(n), sym(s), arg(a), vis(true), avis(true, a.length()) { };
+  PDDL_Name(PDDL_Base::Symbol* s, PDDL_Base::variable_vec a, bool n);
+  void add(PDDL_Base::Symbol* s);
+  void add(PDDL_Base::Symbol* s, bool v);
+  PDDL_Base::Symbol* symbol() { return sym; };
+  PDDL_Base::symbol_vec& args() { return arg; };
+  index_type argc() { return arg.length(); };
+  bool is_neg() { return neg; };
+  virtual ~PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+  virtual const Name* cast_to(const char* cname) const;
+};
+class Numbered_PDDL_Name : public PDDL_Name {
+  index_type copy;
+ public:
+  Numbered_PDDL_Name(PDDL_Base::Symbol* sym, index_type c)
+    : PDDL_Name(sym), copy(c) { };
+  Numbered_PDDL_Name(PDDL_Name* n, index_type c);
+  virtual ~Numbered_PDDL_Name() { };
+  virtual void write(std::ostream& s, unsigned int c) const;
+};
+}
+#include <sstream>
+typedef union {
+  hsps::StringTable::Cell* sym;
+  hsps::PDDL_Base::Expression* exp;
+  hsps::PDDL_Base::ListExpression* lst;
+  hsps::PDDL_Base::Relation* rel;
+  hsps::PDDL_Base::Goal* goal;
+  hsps::PDDL_Base::Formula* ff;
+  hsps::PDDL_Base::mode_keyword tkw;
+  hsps::PDDL_Base::relation_type rkw;
+  hsps::PDDL_Base::set_constraint_keyword sckw;
+  hsps::rational::XR rval;
+  int ival;
+  char* sval;
+} yy_PDDL_Parser_stype;
+class PDDL_Parser : public hsps::PDDL_Base
+{
+public:
+enum YY_PDDL_Parser_ENUM_TOKEN { YY_PDDL_Parser_NULL_TOKEN=0
+ ,TK_OPEN=258
+ ,TK_CLOSE=259
+ ,TK_OPEN_SQ=260
+ ,TK_CLOSE_SQ=261
+ ,TK_GREATER=262
+ ,TK_GREATEQ=263
+ ,TK_LESS=264
+ ,TK_LESSEQ=265
+ ,TK_COLON=266
+ ,TK_HASHT=267
+ ,TK_EQ=268
+ ,TK_HYPHEN=269
+ ,TK_PLUS=270
+ ,TK_MUL=271
+ ,TK_DIV=272
+ ,TK_UMINUS=273
+ ,TK_NEW_SYMBOL=274
+ ,TK_OBJ_SYMBOL=275
+ ,TK_TYPE_SYMBOL=276
+ ,TK_PRED_SYMBOL=277
+ ,TK_OBJFUN_SYMBOL=278
+ ,TK_FUN_SYMBOL=279
+ ,TK_VAR_SYMBOL=280
+ ,TK_ACTION_SYMBOL=281
+ ,TK_MISC_SYMBOL=282
+ ,TK_KEYWORD=283
+ ,TK_NEW_VAR_SYMBOL=284
+ ,TK_PREFERENCE_SYMBOL=285
+ ,TK_SET_SYMBOL=286
+ ,TK_FLOAT=287
+ ,TK_INT=288
+ ,TK_STRING=289
+ ,KW_REQS=290
+ ,KW_CONSTANTS=291
+ ,KW_PREDS=292
+ ,KW_FUNS=293
+ ,KW_TYPES=294
+ ,KW_DEFINE=295
+ ,KW_DOMAIN=296
+ ,KW_ACTION=297
+ ,KW_PROCESS=298
+ ,KW_EVENT=299
+ ,KW_ARGS=300
+ ,KW_PRE=301
+ ,KW_COND=302
+ ,KW_AT_START=303
+ ,KW_AT_END=304
+ ,KW_OVER_ALL=305
+ ,KW_EFFECT=306
+ ,KW_INVARIANT=307
+ ,KW_DURATION=308
+ ,KW_AND=309
+ ,KW_OR=310
+ ,KW_EXISTS=311
+ ,KW_FORALL=312
+ ,KW_IMPLY=313
+ ,KW_NOT=314
+ ,KW_WHEN=315
+ ,KW_EITHER=316
+ ,KW_PROBLEM=317
+ ,KW_FORDOMAIN=318
+ ,KW_OBJECTS=319
+ ,KW_INIT=320
+ ,KW_GOAL=321
+ ,KW_LENGTH=322
+ ,KW_SERIAL=323
+ ,KW_PARALLEL=324
+ ,KW_METRIC=325
+ ,KW_MINIMIZE=326
+ ,KW_MAXIMIZE=327
+ ,KW_DURATION_VAR=328
+ ,KW_TOTAL_TIME=329
+ ,KW_INCREASE=330
+ ,KW_DECREASE=331
+ ,KW_SCALE_UP=332
+ ,KW_SCALE_DOWN=333
+ ,KW_ASSIGN=334
+ ,KW_TAG=335
+ ,KW_NAME=336
+ ,KW_VARS=337
+ ,KW_SET_CONSTRAINT=338
+ ,KW_SETOF=339
+ ,KW_AT_LEAST_N=340
+ ,KW_AT_MOST_N=341
+ ,KW_EXACTLY_N=342
+ ,KW_CONTEXT=343
+ ,KW_FORMULA=344
+ ,KW_IRRELEVANT=345
+ ,KW_PLAN=346
+ ,KW_HEURISTIC=347
+ ,KW_OPT=348
+ ,KW_INF=349
+ ,KW_FACT=350
+ ,KW_SET=351
+ ,KW_EXPANSION=352
+ ,KW_TASKS=353
+ ,KW_PREFERENCE=354
+ ,KW_VIOLATED=355
+ ,KW_WITHIN=356
+ ,KW_ASSOC=357
+ ,KW_CONSTRAINTS=358
+ ,KW_ALWAYS=359
+ ,KW_SOMETIME=360
+ ,KW_AT_MOST_ONCE=361
+ ,KW_SOMETIME_BEFORE=362
+ ,KW_SOMETIME_AFTER=363
+ ,KW_ALWAYS_WITHIN=364
+ ,KW_IFF=365
+ ,KW_FALSE=366
+ ,KW_TRUE=367
+ ,KW_NUMBER=368
+ ,KW_UNDEFINED=369
+     };
+public:
+ int yyparse(void);
+ virtual void log_error(char *msg) = 0;
+ virtual int next_token() = 0;
+ yy_PDDL_Parser_stype yylval;
+ int yynerrs;
+ int yychar;
+public:
+ int yydebug;
+public:
+ PDDL_Parser(hsps::StringTable& t);
+public:
+ public: virtual std::ostream& at_position(std::ostream& s) = 0; virtual char* current_file() = 0; bool error_flag; private: hsps::PDDL_Base::variable_vec current_param; hsps::index_vec stored_n_param; hsps::PDDL_Base::TypeSet current_type_set; hsps::index_type last_n_functions; hsps::PDDL_Base::AtomBase* current_atom; hsps::PDDL_Base::atom_base_vec current_atom_stack; hsps::PDDL_Base::Context* current_context; hsps::lvector<Context*> stored_context; hsps::PDDL_Base::DKEL_Item* current_item; hsps::lvector<ConjunctiveGoal*> current_goal; hsps::PDDL_Base::Symbol* current_preference_name; hsps::PDDL_Base::HTableEntry* current_entry; char* current_plan_file; hsps::index_type n_plans_in_current_file;
+};
+typedef struct yy_buffer_state *YY_BUFFER_STATE;
+class PDDL_Scanner
+{
+ private:
+ char *yy_c_buf_p;
+ char yy_hold_char;
+ int yy_n_chars;
+ int yy_init;
+ int yy_start;
+ int yy_did_buffer_switch_on_eof;
+ private:
+ void yy_initialize();
+ int input();
+ int yyinput() {return input();};
+ int yy_get_next_buffer();
+ void yyunput( char c, char *buf_ptr );
+ long yy_get_previous_state_ ( void );
+ long yy_try_NUL_trans_ ( long current_state_ );
+ protected:
+ YY_BUFFER_STATE YY_CURRENT_BUFFER;
+ void yyrestart ( FILE *input_file );
+ void yy_switch_to_buffer( YY_BUFFER_STATE new_buffer );
+ void yy_load_buffer_state( void );
+ YY_BUFFER_STATE yy_create_buffer( FILE *file, int size );
+ void yy_delete_buffer( YY_BUFFER_STATE b );
+ void yy_init_buffer( YY_BUFFER_STATE b, FILE *file );
+ protected:
+ virtual void yy_echo()
+  ;
+ virtual int yy_input(char *buf,int &result,int max_size)
+  ;
+ virtual void yy_fatal_error(char *msg)
+  ;
+ virtual int yy_wrap()
+  ;
+ public:
+ char *yytext;
+ int yyleng;
+ FILE *yyin;
+ FILE *yyout;
+ int next_token ( yy_PDDL_Parser_stype& val);
+ PDDL_Scanner(hsps::StringTable& t) ;
+ virtual ~PDDL_Scanner() ;
+ int yy_flex_debug;
+ public:
+ private: hsps::StringTable& _tab; bool _reset; char* _filename; int _line_no; bool _trace_line; public: void open_file(char* fname, bool trace); void close_file(); char* current_file() const { return _filename; }; int current_line() const { return _line_no; };
+};
+struct yy_buffer_state
+    {
+    FILE *yy_input_file;
+    char *yy_ch_buf;
+    char *yy_buf_pos;
+    int yy_buf_size;
+    int yy_n_chars;
+    int yy_eof_status;
+    };
+void PDDL_Scanner::yy_echo()
+{fwrite( (char *) yytext, yyleng, 1, yyout );
+}
+int PDDL_Scanner::yy_input(char * buffer,int &result,int max_size)
+{return result= fread( buffer, 1,max_size,yyin );
+}
+void PDDL_Scanner::yy_fatal_error(char *msg)
+{fputs( msg, stderr );putc( '\n', stderr );exit( 1 );
+}
+int PDDL_Scanner::yy_wrap()
+{return 1;
+}
+void PDDL_Scanner::yy_initialize()
+{
+ yyin=0;yyout=0;yy_init = 1;
+ yy_start=0;
+ yytext=0;yyleng=0;
+ YY_CURRENT_BUFFER=0;
+ yy_did_buffer_switch_on_eof=0;
+ yy_c_buf_p=0;yy_hold_char=0;yy_n_chars=0;
+ yy_flex_debug=1;
+}
+PDDL_Scanner::PDDL_Scanner(hsps::StringTable& t) : _tab(t), _reset(false), _filename(0), _line_no(1), _trace_line(false)
+{yy_initialize();
+ ;
+}
+PDDL_Scanner::~PDDL_Scanner()
+{;
+ if(YY_CURRENT_BUFFER)
+  yy_delete_buffer(YY_CURRENT_BUFFER);
+}
+typedef int yy_state_type;
+static const short int yy_accept[544] =
+    { 0,
+      113, 113, 116, 115, 1, 3, 115, 115, 5, 6,
+       11, 9, 10, 12, 113, 17, 2, 15, 19, 13,
+      115, 7, 8, 112, 112, 112, 112, 112, 112, 112,
+      112, 112, 112, 112, 112, 112, 112, 112, 1, 0,
+        4, 0, 18, 113, 114, 111, 111, 111, 111, 111,
+      111, 111, 111, 111, 111, 111, 111, 111, 111, 111,
+      111, 111, 111, 111, 2, 16, 14, 110, 110, 112,
+      112, 112, 112, 112, 112, 112, 112, 112, 112, 112,
+      112, 112, 112, 112, 112, 112, 112, 112, 112, 112,
+       43, 112, 112, 112, 112, 112, 112, 112, 112, 112,
+      112, 4, 114, 111, 111, 111, 111, 111, 111, 111,
+      111, 111, 111, 111, 111, 111, 111, 111, 111, 111,
+      111, 111, 111, 111, 111, 111, 111, 111, 111, 111,
+      111, 111, 111, 111, 110, 110, 110, 112, 42, 112,
+        0, 112, 112, 112, 112, 112, 112, 112, 112, 112,
+      112, 47, 112, 112, 112, 112, 112, 48, 112, 112,
+      112, 112, 112, 112, 112, 112, 112, 112, 112, 112,
+      111, 111, 111, 111, 111, 111, 111, 111, 111, 111,
+      111, 111, 111, 98, 111, 111, 111, 111, 111, 111,
+      111, 111, 97, 111, 111, 111, 111, 111, 111, 99,
+       79, 111, 111, 111, 110, 112, 112, 0, 0, 112,
+      112, 112, 112, 112, 112, 112, 112, 112, 112, 112,
+      112, 112, 112, 112, 112, 112, 112, 112, 112, 112,
+      112, 112, 112, 49, 112, 51, 112, 111, 111, 111,
+      111, 111, 111, 111, 111, 111, 111, 93, 111, 111,
+       57, 111, 56, 111, 111, 81, 111, 111, 78, 111,
+      111, 95, 111, 111, 111, 111, 111, 111, 111, 80,
+       82, 110, 112, 112, 0, 0, 112, 112, 112, 112,
+      112, 112, 112, 112, 112, 50, 112, 46, 112, 112,
+      112, 112, 112, 0, 112, 112, 112, 92, 112, 112,
+      112, 112, 111, 94, 111, 111, 111, 111, 111, 111,
+       29, 111, 111, 111, 111, 111, 111, 111, 111, 111,
+      111, 111, 111, 111, 111, 111, 111, 111, 41, 24,
+      110, 104, 73, 35, 0, 112, 112, 72, 112, 25,
+       26, 52, 112, 44, 45, 112, 112, 112, 112, 74,
+        0, 112, 112, 112, 112, 112, 112, 100, 27, 111,
+      111, 111, 111, 54, 111, 37, 111, 111, 111, 111,
+      111, 111, 58, 63, 111, 111, 111, 111, 111, 111,
+      111, 59, 111, 110, 112, 0, 112, 90, 112, 91,
+      112, 112, 112, 112, 0, 112, 53, 112, 112, 112,
+      112, 112, 111, 111, 111, 83, 111, 111, 111, 85,
+      111, 111, 111, 111, 55, 111, 111, 111, 111, 28,
+      111, 111, 111, 110, 112, 34, 89, 112, 69, 112,
+       68, 112, 65, 64, 36, 112, 112, 70, 105, 112,
+      112, 111, 111, 111, 39, 111, 111, 111, 111, 111,
+      111, 60, 111, 111, 111, 111, 111, 111, 66, 112,
+      112, 87, 112, 88, 112, 112, 112, 112, 112, 75,
+       33, 21, 111, 111, 40, 23, 96, 38, 111, 111,
+      111, 111, 111, 111, 111, 111, 112, 86, 112, 112,
+      101, 71, 112, 112, 67, 111, 111, 77, 111, 31,
+      111, 22, 111, 111, 111, 112, 112, 102, 112, 112,
+      103, 111, 111, 111, 111, 111, 111, 112, 106, 112,
+      112, 111, 111, 32, 20, 111, 111, 109, 112, 112,
+      111, 111, 61, 111, 108, 112, 111, 111, 84, 107,
+       30, 62, 0
+    } ;
+static const char yy_ec[128] =
+    { 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 2, 3,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 2, 4, 5, 6, 7, 8, 9, 1, 10,
+       11, 12, 13, 1, 14, 15, 16, 17, 17, 17,
+       17, 17, 17, 17, 17, 17, 17, 18, 19, 20,
+       21, 22, 23, 1, 28, 29, 30, 31, 32, 33,
+       34, 35, 36, 37, 38, 39, 40, 41, 42, 43,
+       44, 45, 46, 47, 48, 49, 50, 51, 52, 53,
+       24, 25, 26, 1, 27, 1, 28, 29, 30, 31,
+       32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
+       42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
+       52, 53, 1, 54, 1, 55, 1
+    } ;
+static const char yy_meta[56] =
+    { 0,
+        1, 1, 2, 3, 1, 3, 3, 3, 3, 1,
+        1, 3, 3, 3, 3, 3, 3, 1, 1, 1,
+        3, 1, 1, 1, 3, 1, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 3, 3
+    } ;
+static const short int yy_base[553] =
+    { 0,
+        0, 0, 923, 1829, 912, 1829, 51, 854, 1829, 1829,
+     1829, 1829, 823, 1829, 42, 50, 0, 814, 1829, 807,
+      792, 1829, 1829, 100, 152, 23, 87, 91, 142, 27,
+      164, 102, 133, 106, 155, 173, 182, 191, 813, 106,
+     1829, 115, 1829, 46, 786, 235, 287, 93, 215, 225,
+      236, 194, 235, 242, 223, 275, 279, 240, 179, 285,
+      286, 290, 298, 299, 0, 1829, 1829, 347, 399, 0,
+      328, 332, 345, 342, 395, 382, 392, 404, 416, 420,
+      429, 432, 441, 450, 453, 467, 464, 477, 480, 489,
+      492, 502, 505, 514, 517, 526, 529, 538, 549, 559,
+      562, 170, 784, 0, 116, 187, 216, 293, 347, 350,
+      319, 400, 455, 268, 419, 479, 389, 289, 574, 548,
+      541, 551, 569, 572, 584, 581, 587, 456, 592, 595,
+      599, 601, 606, 610, 0, 752, 27, 620, 623, 632,
+      458, 240, 635, 644, 656, 647, 665, 668, 677, 680,
+      689, 692, 701, 704, 748, 716, 720, 729, 740, 743,
+      752, 763, 766, 775, 779, 791, 795, 807, 804, 817,
+      607, 612, 829, 750, 778, 714, 803, 801, 707, 825,
+      650, 683, 728, 695, 827, 838, 837, 831, 848, 840,
+      849, 857, 842, 862, 850, 867, 863, 869, 870, 888,
+      874, 881, 875, 880, 249, 883, 897, 754, 747, 751,
+      735, 906, 909, 918, 922, 934, 931, 943, 947, 956,
+      959, 969, 736, 973, 982, 985, 994, 998, 1007, 1010,
+     1019, 1022, 1031, 1034, 1043, 1046, 1055, 941, 882, 903,
+     1053, 930, 1067, 1058, 921, 1065, 997, 961, 988, 1068,
+      979, 1080, 1025, 1076, 1078, 1077, 1088, 1095, 1090, 1097,
+     1098, 1099, 1100, 1103, 1118, 1117, 1124, 741, 1110, 1121,
+     1125, 299, 1119, 1133, 734, 736, 706, 686, 1136, 1145,
+     1149, 1158, 1161, 1170, 1173, 1182, 1185, 1194, 1197, 678,
+     1206, 1210, 1219, 108, 1222, 1238, 1234, 1247, 1251, 1260,
+     1264, 1273, 1148, 1139, 1225, 1285, 1188, 1157, 1272, 1279,
+     1232, 1286, 1294, 1291, 1292, 1293, 1304, 1311, 1298, 1305,
+     1315, 1317, 1312, 1313, 1318, 1325, 1326, 668, 1330, 1332,
+      168, 1352, 1328, 1829, 663, 659, 654, 1338, 1341, 1355,
+     1364, 1367, 1376, 1379, 1388, 1391, 660, 1400, 1403, 1413,
+      648, 1416, 1425, 74, 1428, 637, 1437, 1440, 1343, 1415,
+     1351, 1452, 1443, 1370, 1394, 1447, 1455, 1464, 1458, 1465,
+     1469, 1472, 1473, 1476, 1477, 1484, 1478, 1496, 1501, 1487,
+     1502, 1506, 636, 23, 622, 618, 616, 646, 1512, 1499,
+     1522, 629, 1525, 1535, 612, 1538, 1547, 608, 583, 1551,
+      583, 1563, 1545, 1509, 1569, 1519, 1532, 1571, 1566, 1570,
+     1577, 1583, 1581, 1596, 1584, 1595, 1601, 1602, 1590, 1598,
+     1605, 574, 543, 244, 547, 1829, 560, 316, 1611, 528,
+     1614, 515, 1623, 1626, 1829, 1636, 509, 0, 1640, 517,
+     1649, 1648, 1610, 1661, 1613, 1654, 1662, 1655, 1663, 1667,
+     1669, 1690, 1676, 1681, 1686, 1687, 522, 503, 497, 493,
+      491, 0, 481, 0, 485, 1698, 471, 370, 475, 1701,
+     1695, 1704, 1705, 467, 1708, 1713, 1716, 1719, 1723, 433,
+     1725, 1727, 1726, 1734, 428, 413, 417, 0, 410, 406,
+     1735, 0, 394, 394, 0, 1731, 388, 1737, 372, 1738,
+     1748, 1749, 1755, 366, 366, 354, 353, 0, 323, 333,
+     1757, 301, 302, 1758, 1759, 293, 302, 269, 0, 274,
+      233, 237, 220, 1761, 1762, 200, 190, 0, 168, 145,
+      144, 129, 0, 124, 0, 131, 116, 89, 0, 0,
+        0, 0, 1829, 1808, 1812, 114, 1814, 1816, 1818, 1820,
+     1822, 1824
+    } ;
+static const short int yy_def[553] =
+    { 0,
+      543, 1, 543, 543, 543, 543, 544, 543, 543, 543,
+      543, 543, 543, 543, 543, 543, 545, 543, 543, 543,
+      546, 543, 543, 547, 547, 25, 25, 25, 25, 25,
+       25, 25, 25, 25, 25, 25, 25, 25, 543, 544,
+      543, 544, 543, 543, 543, 548, 548, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 545, 543, 543, 549, 549, 550,
+       25, 25, 25, 25, 25, 25, 25, 25, 25, 25,
+       25, 25, 25, 25, 25, 25, 25, 25, 25, 25,
+       25, 25, 25, 25, 25, 25, 25, 25, 25, 25,
+       25, 544, 543, 551, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 552, 69, 69, 25, 25, 25,
+      543, 550, 25, 25, 25, 25, 25, 25, 25, 25,
+       25, 25, 25, 25, 550, 25, 25, 25, 25, 25,
+       25, 25, 25, 25, 25, 25, 25, 25, 25, 25,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 69, 25, 25, 543, 543, 550,
+      550, 25, 25, 25, 25, 25, 25, 25, 25, 25,
+       25, 25, 550, 25, 25, 25, 25, 25, 25, 25,
+       25, 25, 25, 25, 25, 25, 25, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 551, 47, 47,
+       47, 69, 25, 25, 543, 543, 550, 550, 25, 25,
+       25, 25, 25, 25, 25, 25, 25, 25, 25, 550,
+       25, 25, 25, 543, 25, 25, 25, 25, 25, 25,
+       25, 25, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 551, 47, 47,
+       69, 25, 25, 543, 543, 550, 550, 25, 25, 25,
+       25, 25, 25, 25, 25, 25, 550, 25, 25, 25,
+      543, 25, 25, 550, 25, 550, 25, 25, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 551, 69, 550, 543, 550, 550, 25, 25,
+       25, 550, 25, 25, 543, 25, 25, 550, 550, 25,
+      550, 25, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 551, 551, 69, 550, 543, 550, 550, 25, 550,
+       25, 550, 25, 25, 543, 25, 550, 550, 25, 550,
+       25, 47, 47, 47, 47, 47, 47, 47, 47, 47,
+       47, 47, 47, 47, 47, 47, 551, 551, 69, 550,
+      550, 550, 550, 550, 550, 25, 550, 550, 550, 25,
+       47, 47, 47, 551, 47, 47, 47, 47, 47, 551,
+       47, 47, 47, 47, 551, 551, 550, 550, 550, 550,
+       25, 550, 550, 550, 550, 47, 551, 47, 551, 47,
+       47, 47, 47, 551, 551, 550, 550, 550, 550, 550,
+       47, 551, 551, 47, 47, 551, 551, 550, 550, 550,
+      550, 551, 551, 47, 47, 551, 551, 550, 550, 550,
+      551, 551, 551, 551, 550, 550, 551, 551, 551, 550,
+      551, 551, 0, 543, 543, 543, 543, 543, 543, 543,
+      543, 543
+    } ;
+static const short int yy_nxt[1885] =
+    { 0,
+        4, 5, 6, 4, 7, 8, 4, 4, 4, 9,
+       10, 11, 12, 13, 4, 14, 15, 16, 17, 18,
+       19, 20, 21, 22, 4, 23, 24, 25, 24, 26,
+       27, 28, 29, 24, 24, 30, 24, 24, 24, 31,
+       32, 33, 34, 24, 24, 35, 36, 37, 24, 38,
+       24, 24, 24, 4, 4, 41, 45, 76, 44, 83,
+       45, 71, 44, 71, 424, 71, 84, 85, 71, 71,
+      136, 205, 86, 71, 136, 42, 46, 47, 46, 48,
+       49, 50, 51, 52, 53, 54, 46, 55, 56, 57,
+       58, 59, 60, 46, 61, 62, 63, 46, 64, 46,
+       46, 46, 46, 70, 398, 70, 70, 70, 70, 294,
+       41, 70, 70, 70, 70, 70, 70, 68, 77, 102,
+       70, 399, 105, 542, 70, 71, 79, 71, 78, 71,
+       42, 71, 71, 71, 108, 351, 71, 71, 105, 42,
+       71, 80, 71, 89, 71, 105, 71, 71, 71, 90,
+       93, 71, 71, 70, 70, 70, 541, 70, 70, 70,
+       70, 105, 540, 70, 70, 70, 70, 70, 70, 81,
+      539, 71, 70, 71, 41, 538, 70, 91, 71, 71,
+       71, 92, 71, 82, 94, 537, 95, 71, 71, 536,
+       72, 87, 73, 71, 42, 71, 96, 74, 75, 88,
+       71, 71, 71, 384, 71, 70, 70, 125, 105, 71,
+       71, 71, 535, 71, 97, 136, 105, 98, 71, 71,
+       71, 126, 99, 105, 105, 100, 101, 71, 71, 71,
+      534, 71, 105, 171, 533, 117, 71, 71, 104, 105,
+      104, 104, 104, 104, 105, 105, 104, 104, 104, 104,
+      104, 104, 105, 532, 105, 104, 109, 111, 121, 104,
+      105, 172, 110, 114, 105, 105, 118, 124, 105, 105,
+      105, 105, 531, 112, 530, 113, 272, 115, 210, 211,
+      105, 105, 119, 116, 459, 105, 120, 105, 104, 104,
+      104, 136, 104, 104, 104, 104, 136, 179, 104, 104,
+      104, 104, 104, 104, 105, 529, 122, 104, 105, 528,
+      123, 104, 127, 105, 105, 105, 106, 130, 105, 105,
+      105, 131, 105, 128, 105, 132, 134, 105, 105, 129,
+      105, 105, 107, 173, 105, 105, 183, 527, 105, 526,
+      104, 104, 523, 105, 105, 331, 136, 522, 105, 133,
+      135, 176, 135, 135, 135, 135, 462, 463, 135, 135,
+      135, 135, 135, 135, 105, 521, 71, 135, 71, 520,
+       71, 135, 71, 71, 71, 139, 105, 71, 71, 105,
+       71, 138, 71, 71, 519, 71, 174, 140, 71, 518,
+       71, 71, 105, 517, 175, 105, 141, 493, 494, 516,
+      135, 135, 135, 513, 135, 135, 135, 135, 142, 143,
+      135, 135, 135, 135, 135, 135, 182, 512, 105, 135,
+       71, 144, 71, 135, 145, 510, 509, 71, 71, 105,
+       71, 177, 71, 71, 105, 71, 508, 71, 71, 507,
+       71, 71, 71, 146, 71, 105, 137, 148, 105, 71,
+       71, 506, 135, 135, 71, 149, 71, 505, 71, 141,
+       71, 71, 147, 180, 105, 71, 71, 150, 504, 71,
+       71, 499, 71, 152, 71, 71, 151, 71, 71, 71,
+      155, 71, 154, 195, 105, 105, 71, 71, 71, 208,
+       71, 71, 153, 71, 497, 71, 71, 178, 71, 71,
+      105, 105, 71, 209, 71, 71, 495, 71, 105, 71,
+       71, 492, 71, 71, 156, 71, 490, 157, 71, 181,
+       71, 489, 71, 71, 105, 71, 158, 71, 159, 71,
+       71, 488, 71, 160, 71, 71, 161, 71, 71, 487,
+       71, 163, 71, 71, 136, 71, 162, 71, 71, 486,
+       71, 71, 71, 485, 71, 71, 469, 71, 467, 71,
+       71, 465, 71, 164, 71, 165, 71, 71, 464, 71,
+      105, 71, 71, 461, 71, 166, 71, 105, 71, 168,
+      105, 188, 460, 71, 71, 167, 105, 71, 458, 71,
+      169, 189, 187, 105, 71, 71, 105, 71, 105, 71,
+       71, 105, 71, 105, 71, 71, 184, 71, 170, 185,
+      105, 191, 457, 105, 105, 190, 105, 105, 440, 105,
+      192, 105, 186, 196, 105, 438, 105, 193, 105, 105,
+      105, 194, 105, 197, 201, 105, 105, 105, 198, 105,
+      105, 105, 238, 199, 105, 200, 202, 206, 203, 437,
+      435, 105, 105, 239, 204, 105, 432, 105, 71, 428,
+       71, 71, 427, 71, 426, 71, 71, 207, 71, 71,
+       71, 425, 71, 71, 215, 212, 423, 71, 71, 250,
+       71, 71, 71, 401, 71, 71, 395, 71, 213, 71,
+       71, 214, 71, 71, 71, 105, 71, 217, 392, 216,
+      388, 71, 71, 71, 387, 71, 71, 386, 71, 383,
+       71, 71, 105, 71, 71, 71, 220, 71, 71, 347,
+       71, 251, 218, 71, 105, 219, 71, 71, 105, 71,
+       71, 337, 71, 336, 71, 71, 105, 71, 71, 221,
+      105, 71, 71, 105, 71, 245, 71, 71, 222, 71,
+       71, 224, 105, 248, 71, 225, 71, 105, 71, 105,
+       71, 71, 71, 335, 334, 71, 71, 71, 226, 71,
+      328, 290, 252, 105, 71, 71, 278, 243, 71, 105,
+       71, 71, 277, 71, 228, 71, 71, 227, 71, 71,
+       71, 229, 71, 276, 275, 105, 223, 71, 71, 136,
+      103, 71, 103, 71, 230, 244, 71, 105, 71, 71,
+      232, 71, 71, 71, 39, 71, 231, 71, 233, 71,
+       71, 71, 69, 105, 71, 71, 234, 67, 247, 71,
+      105, 71, 105, 71, 66, 71, 71, 71, 235, 44,
+       71, 71, 71, 246, 236, 71, 105, 71, 105, 71,
+       71, 237, 71, 71, 105, 71, 105, 71, 105, 240,
+      105, 256, 71, 71, 249, 254, 105, 105, 255, 105,
+      105, 105, 105, 253, 241, 242, 105, 105, 105, 105,
+      259, 257, 105, 105, 258, 105, 105, 105, 260, 261,
+      262, 105, 265, 105, 105, 105, 263, 264, 105, 105,
+       43, 268, 105, 105, 105, 267, 270, 105, 105, 105,
+      105, 304, 105, 39, 105, 105, 266, 105, 269, 105,
+      105, 71, 543, 71, 543, 271, 105, 105, 71, 71,
+      274, 543, 105, 105, 273, 71, 543, 71, 305, 279,
+      280, 543, 71, 71, 71, 543, 71, 71, 105, 71,
+      310, 71, 71, 543, 71, 71, 71, 282, 281, 105,
+       71, 307, 71, 71, 71, 283, 105, 71, 71, 71,
+      105, 71, 71, 543, 71, 105, 71, 284, 286, 71,
+       71, 71, 303, 71, 543, 71, 105, 71, 71, 285,
+      105, 543, 71, 71, 287, 294, 71, 71, 543, 71,
+      289, 71, 71, 543, 71, 71, 105, 71, 105, 71,
+      288, 71, 291, 71, 71, 71, 293, 105, 71, 71,
+       71, 292, 71, 71, 105, 71, 105, 71, 71, 295,
+       71, 71, 71, 105, 71, 313, 71, 312, 71, 71,
+       71, 297, 105, 71, 71, 296, 543, 71, 71, 543,
+       71, 298, 71, 71, 105, 71, 71, 71, 543, 71,
+       71, 543, 71, 543, 71, 71, 543, 71, 299, 300,
+      105, 71, 71, 543, 71, 301, 71, 71, 543, 71,
+       71, 71, 105, 71, 71, 543, 71, 105, 71, 71,
+      302, 71, 71, 71, 105, 71, 105, 105, 105, 306,
+       71, 71, 308, 105, 309, 105, 105, 105, 543, 105,
+      105, 311, 105, 105, 314, 315, 317, 105, 543, 105,
+      316, 105, 105, 105, 105, 105, 320, 105, 105, 105,
+      319, 543, 105, 105, 318, 105, 321, 322, 324, 105,
+      105, 323, 105, 105, 105, 105, 105, 105, 105, 325,
+      105, 327, 326, 105, 105, 329, 543, 71, 543, 71,
+      543, 543, 105, 105, 332, 71, 330, 338, 105, 105,
+      105, 71, 339, 333, 71, 543, 71, 105, 71, 71,
+      340, 71, 71, 71, 105, 71, 105, 71, 359, 71,
+       71, 71, 543, 105, 71, 71, 71, 364, 341, 71,
+      543, 71, 105, 71, 71, 342, 71, 71, 343, 543,
+       71, 71, 543, 71, 543, 71, 71, 105, 344, 71,
+       71, 543, 71, 345, 346, 71, 543, 71, 71, 543,
+       71, 71, 71, 105, 71, 71, 543, 71, 363, 71,
+       71, 348, 71, 71, 71, 349, 71, 354, 71, 543,
+       71, 71, 71, 543, 105, 71, 71, 71, 543, 71,
+       71, 105, 71, 350, 71, 71, 352, 71, 71, 353,
+      105, 360, 71, 356, 71, 543, 71, 105, 71, 71,
+       71, 543, 543, 71, 71, 71, 355, 71, 543, 71,
+      543, 71, 71, 71, 543, 543, 71, 71, 71, 357,
+       71, 105, 71, 543, 71, 71, 71, 365, 105, 71,
+       71, 71, 361, 358, 105, 105, 543, 105, 71, 71,
+      105, 105, 105, 105, 105, 366, 369, 374, 371, 362,
+      105, 367, 368, 105, 105, 372, 105, 370, 105, 105,
+      105, 105, 379, 105, 105, 373, 105, 105, 377, 105,
+      105, 375, 378, 376, 105, 105, 105, 105, 105, 105,
+      105, 105, 105, 380, 382, 385, 71, 543, 71, 381,
+      105, 105, 105, 71, 71, 105, 71, 105, 71, 71,
+      105, 71, 543, 71, 71, 543, 389, 71, 105, 543,
+       71, 404, 71, 71, 543, 71, 105, 71, 71, 105,
+       71, 71, 71, 543, 71, 71, 543, 71, 543, 71,
+       71, 543, 71, 71, 71, 105, 71, 71, 543, 71,
+      543, 71, 71, 105, 71, 71, 71, 390, 71, 71,
+      543, 71, 543, 71, 71, 407, 391, 71, 71, 105,
+       71, 71, 408, 71, 105, 71, 71, 396, 71, 71,
+      403, 71, 393, 71, 71, 394, 71, 543, 71, 71,
+      105, 71, 71, 71, 397, 71, 71, 400, 71, 543,
+       71, 71, 105, 71, 71, 71, 105, 402, 71, 405,
+       71, 105, 71, 71, 105, 71, 71, 105, 105, 406,
+      409, 410, 105, 105, 105, 543, 413, 105, 105, 411,
+      105, 105, 105, 105, 543, 105, 105, 105, 543, 105,
+      105, 412, 430, 105, 105, 416, 105, 105, 105, 422,
+      414, 105, 415, 105, 417, 105, 418, 543, 419, 105,
+      105, 105, 420, 421, 543, 105, 543, 71, 105, 71,
+      543, 105, 543, 429, 71, 71, 105, 105, 105, 543,
+       71, 105, 71, 431, 105, 443, 433, 71, 71, 543,
+       71, 105, 71, 71, 105, 71, 434, 71, 71, 543,
+       71, 71, 445, 71, 105, 71, 71, 105, 436, 543,
+       71, 71, 439, 71, 71, 71, 442, 71, 543, 71,
+      105, 71, 71, 71, 441, 105, 71, 71, 105, 105,
+      105, 71, 446, 71, 444, 543, 105, 447, 71, 71,
+      105, 105, 105, 105, 105, 105, 105, 448, 449, 105,
+      543, 450, 105, 451, 105, 105, 105, 105, 105, 105,
+      105, 105, 453, 452, 105, 105, 455, 454, 543, 105,
+      105, 105, 105, 105, 456, 543, 105, 105, 543, 71,
+      105, 71, 71, 468, 71, 472, 71, 71, 105, 71,
+       71, 71, 543, 71, 71, 466, 71, 474, 71, 71,
+      543, 71, 71, 543, 71, 543, 71, 105, 71, 470,
+       71, 71, 71, 105, 105, 71, 71, 71, 471, 71,
+      105, 105, 477, 105, 71, 71, 105, 543, 105, 105,
+      476, 473, 475, 480, 543, 105, 105, 105, 105, 479,
+      105, 543, 105, 478, 105, 105, 105, 483, 484, 105,
+      481, 105, 543, 543, 105, 543, 105, 482, 543, 491,
+      543, 105, 105, 105, 105, 105, 71, 105, 71, 71,
+      105, 71, 105, 71, 71, 105, 71, 71, 105, 105,
+      105, 496, 105, 105, 105, 105, 105, 543, 105, 543,
+      105, 105, 501, 105, 105, 543, 105, 105, 105, 498,
+      500, 502, 105, 71, 503, 71, 511, 105, 105, 105,
+       71, 71, 105, 105, 105, 543, 105, 105, 105, 514,
+      105, 105, 543, 105, 105, 543, 543, 543, 524, 543,
+      105, 515, 105, 105, 525, 543, 105, 105, 40, 40,
+       40, 40, 65, 543, 65, 65, 71, 71, 105, 105,
+      136, 136, 70, 70, 104, 104, 135, 135, 3, 543,
+      543, 543, 543, 543, 543, 543, 543, 543, 543, 543,
+      543, 543, 543, 543, 543, 543, 543, 543, 543, 543,
+      543, 543, 543, 543, 543, 543, 543, 543, 543, 543,
+      543, 543, 543, 543, 543, 543, 543, 543, 543, 543,
+      543, 543, 543, 543, 543, 543, 543, 543, 543, 543,
+      543, 543, 543, 543
+    } ;
+static const short int yy_chk[1885] =
+    { 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 7, 15, 26, 15, 30,
+       44, 26, 44, 26, 384, 30, 30, 30, 26, 26,
+      384, 137, 30, 30, 137, 7, 16, 16, 16, 16,
+       16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
+       16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
+       16, 16, 16, 24, 354, 24, 24, 24, 24, 294,
+       40, 24, 24, 24, 24, 24, 24, 546, 27, 42,
+       24, 354, 48, 538, 24, 27, 28, 27, 27, 28,
+       40, 28, 27, 27, 48, 294, 28, 28, 48, 42,
+       32, 28, 32, 32, 34, 105, 34, 32, 32, 32,
+       34, 34, 34, 24, 24, 25, 537, 25, 25, 25,
+       25, 105, 536, 25, 25, 25, 25, 25, 25, 29,
+      534, 33, 25, 33, 102, 532, 25, 33, 33, 33,
+       29, 33, 29, 29, 35, 531, 35, 29, 29, 530,
+       25, 31, 25, 35, 102, 35, 35, 25, 25, 31,
+       35, 35, 31, 331, 31, 25, 25, 59, 59, 31,
+       31, 36, 529, 36, 36, 331, 106, 36, 36, 36,
+       37, 59, 37, 52, 59, 38, 38, 37, 37, 38,
+      527, 38, 106, 106, 526, 52, 38, 38, 46, 52,
+       46, 46, 46, 46, 49, 107, 46, 46, 46, 46,
+       46, 46, 55, 523, 50, 46, 49, 50, 55, 46,
+       49, 107, 49, 51, 53, 51, 53, 58, 55, 58,
+       50, 54, 522, 50, 521, 50, 205, 51, 142, 142,
+       53, 51, 54, 51, 424, 58, 54, 54, 46, 46,
+       47, 424, 47, 47, 47, 47, 205, 114, 47, 47,
+       47, 47, 47, 47, 56, 520, 56, 47, 57, 518,
+       57, 47, 60, 114, 60, 61, 47, 61, 118, 62,
+       56, 62, 108, 60, 57, 63, 64, 63, 64, 60,
+       60, 61, 47, 108, 118, 62, 118, 517, 108, 516,
+       47, 47, 513, 63, 64, 272, 272, 512, 111, 63,
+       68, 111, 68, 68, 68, 68, 428, 428, 68, 68,
+       68, 68, 68, 68, 111, 510, 71, 68, 71, 509,
+       72, 68, 72, 71, 71, 73, 109, 72, 72, 110,
+       74, 72, 74, 73, 507, 73, 109, 74, 74, 506,
+       73, 73, 109, 505, 110, 110, 75, 468, 468, 504,
+       68, 68, 69, 499, 69, 69, 69, 69, 75, 76,
+       69, 69, 69, 69, 69, 69, 117, 497, 117, 69,
+       76, 77, 76, 69, 77, 494, 493, 76, 76, 112,
+       77, 112, 77, 75, 117, 75, 490, 77, 77, 489,
+       75, 75, 78, 78, 78, 112, 69, 80, 115, 78,
+       78, 487, 69, 69, 79, 80, 79, 486, 80, 141,
+       80, 79, 79, 115, 115, 80, 80, 81, 485, 81,
+       82, 480, 82, 83, 81, 81, 82, 82, 82, 83,
+       86, 83, 85, 128, 113, 128, 83, 83, 84, 141,
+       84, 85, 84, 85, 474, 84, 84, 113, 85, 85,
+      113, 128, 87, 141, 87, 86, 469, 86, 116, 87,
+       87, 467, 86, 86, 87, 88, 465, 88, 89, 116,
+       89, 463, 88, 88, 116, 89, 89, 90, 90, 90,
+       91, 461, 91, 92, 90, 90, 93, 91, 91, 460,
+       92, 94, 92, 93, 459, 93, 93, 92, 92, 458,
+       93, 93, 94, 457, 94, 95, 440, 95, 437, 94,
+       94, 432, 95, 95, 96, 96, 96, 97, 430, 97,
+      121, 96, 96, 427, 97, 97, 98, 120, 98, 99,
+      122, 121, 425, 98, 98, 98, 121, 99, 423, 99,
+      100, 122, 120, 120, 99, 99, 122, 100, 123, 100,
+      101, 124, 101, 119, 100, 100, 119, 101, 101, 119,
+      126, 124, 422, 125, 123, 123, 127, 124, 401, 119,
+      125, 129, 119, 129, 130, 399, 126, 126, 131, 125,
+      132, 127, 127, 129, 132, 133, 171, 129, 130, 134,
+      130, 172, 171, 131, 131, 131, 132, 138, 133, 398,
+      395, 133, 171, 172, 134, 134, 392, 172, 138, 388,
+      138, 139, 387, 139, 386, 138, 138, 140, 139, 139,
+      140, 385, 140, 143, 146, 143, 383, 140, 140, 181,
+      143, 143, 144, 356, 144, 146, 351, 146, 144, 144,
+      144, 145, 146, 146, 145, 181, 145, 148, 347, 147,
+      337, 145, 145, 147, 336, 147, 148, 335, 148, 328,
+      147, 147, 182, 148, 148, 149, 151, 149, 150, 290,
+      150, 182, 149, 149, 184, 150, 150, 151, 182, 151,
+      152, 278, 152, 277, 151, 151, 179, 152, 152, 153,
+      184, 153, 154, 176, 154, 176, 153, 153, 154, 154,
+      154, 156, 179, 179, 156, 157, 156, 183, 157, 176,
+      157, 156, 156, 276, 275, 157, 157, 158, 159, 158,
+      268, 223, 183, 183, 158, 158, 211, 174, 159, 174,
+      159, 160, 210, 160, 161, 159, 159, 160, 160, 160,
+      161, 162, 161, 209, 208, 174, 155, 161, 161, 136,
+      103, 162, 45, 162, 163, 175, 163, 175, 162, 162,
+      165, 163, 163, 164, 39, 164, 164, 165, 166, 165,
+      164, 164, 21, 175, 165, 165, 167, 20, 178, 166,
+      178, 166, 177, 167, 18, 167, 166, 166, 168, 13,
+      167, 167, 169, 177, 169, 168, 178, 168, 177, 169,
+      169, 170, 168, 168, 180, 170, 185, 170, 173, 173,
+      188, 188, 170, 170, 180, 186, 187, 186, 187, 190,
+      180, 193, 185, 185, 173, 173, 188, 189, 191, 195,
+      191, 189, 187, 186, 190, 190, 192, 193, 192, 194,
+      195, 194, 197, 189, 191, 195, 196, 196, 198, 199,
+        8, 200, 192, 201, 203, 199, 203, 194, 197, 204,
+      202, 239, 196, 5, 198, 199, 198, 200, 202, 201,
+      203, 206, 3, 206, 0, 204, 202, 239, 206, 206,
+      207, 0, 240, 200, 206, 207, 0, 207, 240, 212,
+      213, 0, 207, 207, 212, 0, 212, 213, 240, 213,
+      245, 212, 212, 0, 213, 213, 214, 215, 214, 242,
+      215, 242, 215, 214, 214, 216, 245, 215, 215, 217,
+      238, 217, 216, 0, 216, 242, 217, 217, 219, 216,
+      216, 218, 238, 218, 0, 219, 238, 219, 218, 218,
+      248, 0, 219, 219, 220, 227, 220, 221, 0, 221,
+      222, 220, 220, 0, 221, 221, 248, 222, 251, 222,
+      221, 224, 224, 224, 222, 222, 226, 249, 224, 224,
+      225, 225, 225, 226, 251, 226, 247, 225, 225, 228,
+      226, 226, 227, 249, 227, 249, 228, 247, 228, 227,
+      227, 230, 247, 228, 228, 229, 0, 229, 230, 0,
+      230, 231, 229, 229, 253, 230, 230, 231, 0, 231,
+      232, 0, 232, 0, 231, 231, 0, 232, 232, 233,
+      253, 233, 234, 0, 234, 235, 233, 233, 0, 234,
+      234, 235, 241, 235, 236, 0, 236, 244, 235, 235,
+      237, 236, 236, 237, 246, 237, 243, 250, 241, 241,
+      237, 237, 243, 244, 244, 254, 256, 255, 0, 252,
+      246, 246, 243, 250, 250, 252, 255, 257, 0, 259,
+      254, 254, 256, 255, 258, 252, 260, 261, 262, 263,
+      258, 0, 264, 257, 257, 259, 261, 261, 264, 269,
+      258, 263, 260, 261, 262, 263, 266, 265, 264, 265,
+      270, 267, 266, 267, 271, 269, 0, 273, 0, 273,
+        0, 0, 266, 265, 273, 273, 270, 279, 304, 267,
+      271, 274, 280, 274, 279, 0, 279, 303, 274, 274,
+      281, 279, 279, 280, 304, 280, 308, 281, 303, 281,
+      280, 280, 0, 303, 281, 281, 282, 308, 282, 283,
+        0, 283, 308, 282, 282, 283, 283, 283, 284, 0,
+      284, 285, 0, 285, 0, 284, 284, 307, 285, 285,
+      286, 0, 286, 287, 289, 287, 0, 286, 286, 0,
+      287, 287, 288, 307, 288, 289, 0, 289, 307, 288,
+      288, 291, 289, 289, 291, 292, 291, 297, 292, 0,
+      292, 291, 291, 0, 305, 292, 292, 293, 0, 293,
+      295, 311, 295, 293, 293, 293, 295, 295, 295, 296,
+      305, 305, 297, 300, 297, 0, 296, 311, 296, 297,
+      297, 0, 0, 296, 296, 298, 299, 298, 0, 299,
+        0, 299, 298, 298, 0, 0, 299, 299, 300, 301,
+      300, 309, 301, 0, 301, 300, 300, 309, 310, 301,
+      301, 302, 306, 302, 306, 312, 0, 309, 302, 302,
+      314, 315, 316, 313, 310, 310, 314, 319, 316, 306,
+      306, 312, 313, 317, 320, 317, 314, 315, 316, 313,
+      318, 323, 324, 319, 321, 318, 322, 325, 322, 317,
+      320, 320, 323, 321, 326, 327, 318, 323, 324, 329,
+      321, 330, 322, 325, 327, 332, 333, 0, 333, 326,
+      326, 327, 359, 333, 333, 329, 338, 330, 338, 339,
+      361, 339, 0, 338, 338, 0, 339, 339, 359, 0,
+      332, 361, 332, 340, 0, 340, 361, 332, 332, 364,
+      340, 340, 341, 0, 341, 342, 0, 342, 0, 341,
+      341, 0, 342, 342, 343, 364, 343, 344, 0, 344,
+        0, 343, 343, 365, 344, 344, 345, 343, 345, 346,
+        0, 346, 0, 345, 345, 365, 346, 346, 348, 365,
+      348, 349, 365, 349, 360, 348, 348, 352, 349, 349,
+      360, 350, 348, 350, 352, 349, 352, 0, 350, 350,
+      360, 352, 352, 353, 353, 353, 355, 355, 355, 0,
+      353, 353, 363, 355, 355, 357, 366, 357, 358, 362,
+      358, 362, 357, 357, 367, 358, 358, 369, 363, 363,
+      367, 368, 366, 368, 370, 0, 371, 362, 371, 369,
+      367, 372, 373, 369, 0, 374, 375, 377, 0, 368,
+      370, 370, 390, 376, 371, 376, 380, 372, 373, 382,
+      372, 374, 375, 377, 377, 378, 378, 0, 379, 376,
+      379, 381, 380, 381, 0, 382, 0, 390, 404, 390,
+        0, 378, 0, 389, 390, 390, 379, 381, 406, 0,
+      389, 382, 389, 391, 404, 404, 393, 389, 389, 0,
+      391, 407, 391, 393, 406, 393, 394, 391, 391, 0,
+      393, 393, 407, 394, 403, 394, 396, 407, 396, 0,
+      394, 394, 400, 396, 396, 397, 403, 397, 0, 400,
+      403, 400, 397, 397, 402, 409, 400, 400, 405, 410,
+      408, 402, 408, 402, 405, 0, 411, 409, 402, 402,
+      413, 409, 412, 415, 405, 410, 408, 411, 412, 419,
+        0, 413, 411, 414, 416, 414, 413, 420, 412, 415,
+      417, 418, 417, 416, 421, 419, 419, 418, 0, 443,
+      416, 414, 445, 420, 421, 0, 417, 418, 0, 429,
+      421, 429, 431, 439, 431, 443, 429, 429, 445, 431,
+      431, 433, 0, 433, 434, 436, 434, 446, 433, 433,
+        0, 434, 434, 0, 436, 0, 436, 442, 439, 441,
+      439, 436, 436, 446, 448, 439, 439, 441, 442, 441,
+      444, 447, 449, 442, 441, 441, 450, 0, 451, 446,
+      448, 444, 447, 452, 0, 453, 444, 447, 449, 451,
+      454, 0, 450, 450, 451, 455, 456, 455, 456, 452,
+      453, 453, 0, 0, 471, 0, 454, 454, 0, 466,
+        0, 455, 456, 472, 473, 452, 466, 475, 466, 470,
+      471, 470, 476, 466, 466, 477, 470, 470, 478, 472,
+      473, 473, 479, 475, 481, 483, 482, 0, 476, 0,
+      496, 477, 482, 484, 478, 0, 498, 500, 479, 479,
+      481, 483, 482, 491, 484, 491, 496, 501, 502, 484,
+      491, 491, 498, 500, 503, 0, 511, 514, 515, 501,
+      524, 525, 0, 501, 502, 0, 0, 0, 514, 0,
+      503, 503, 511, 514, 515, 0, 524, 525, 544, 544,
+      544, 544, 545, 0, 545, 545, 547, 547, 548, 548,
+      549, 549, 550, 550, 551, 551, 552, 552, 543, 543,
+      543, 543, 543, 543, 543, 543, 543, 543, 543, 543,
+      543, 543, 543, 543, 543, 543, 543, 543, 543, 543,
+      543, 543, 543, 543, 543, 543, 543, 543, 543, 543,
+      543, 543, 543, 543, 543, 543, 543, 543, 543, 543,
+      543, 543, 543, 543, 543, 543, 543, 543, 543, 543,
+      543, 543, 543, 543
+    } ;
+static yy_state_type yy_last_accepting_state;
+static char *yy_last_accepting_cpos;
+static const short int yy_rule_linenum[115] =
+    { 0,
+       39, 40, 41, 43, 48, 49, 50, 51, 52, 53,
+       54, 55, 56, 57, 58, 59, 60, 61, 62, 64,
+       65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
+       75, 76, 77, 78, 79, 80, 81, 82, 83, 84,
+       85, 86, 87, 88, 89, 90, 91, 92, 93, 94,
+       95, 96, 97, 98, 99, 100, 101, 102, 103, 104,
+      105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
+      115, 116, 117, 118, 119, 121, 122, 123, 124, 125,
+      126, 127, 128, 129, 130, 131, 132, 133, 134, 135,
+      136, 137, 138, 139, 141, 142, 143, 144, 145, 147,
+      148, 149, 151, 152, 153, 154, 155, 156, 157, 159,
+      167, 172, 205, 206
+    } ;
+int PDDL_Scanner::next_token ( yy_PDDL_Parser_stype& val)
+    {
+    register yy_state_type yy_current_state;
+    register char *yy_cp, *yy_bp;
+    register int yy_act;
+    if ( yy_init )
+ {
+  {
+  ;
+  }
+ if ( ! yy_start )
+     yy_start = 1;
+ if ( ! yyin )
+     yyin = stdin;
+ if ( ! yyout )
+     yyout = stdout;
+ if ( YY_CURRENT_BUFFER )
+     yy_init_buffer( YY_CURRENT_BUFFER, yyin );
+ else
+     YY_CURRENT_BUFFER = yy_create_buffer( yyin, (8192 * 2) );
+ yy_load_buffer_state();
+ yy_init=0;
+ }
+    while ( 1 )
+ {
+ yy_cp = yy_c_buf_p;
+ *yy_cp = yy_hold_char;
+ yy_bp = yy_cp;
+ yy_current_state = yy_start;
+yy_match:
+ do
+     {
+     register char yy_c = yy_ec[*yy_cp];
+     if ( yy_accept[yy_current_state] )
+  {
+  yy_last_accepting_state = yy_current_state;
+  yy_last_accepting_cpos = yy_cp;
+  }
+     while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
+  {
+  yy_current_state = yy_def[yy_current_state];
+  if ( yy_current_state >= 544 )
+      yy_c = yy_meta[yy_c];
+  }
+     yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+     ++yy_cp;
+     }
+ while ( yy_current_state != 543 );
+ yy_cp = yy_last_accepting_cpos;
+ yy_current_state = yy_last_accepting_state;
+yy_find_action:
+ yy_act = yy_accept[yy_current_state];
+ yytext = yy_bp; yyleng = yy_cp - yy_bp; yy_hold_char = *yy_cp; *yy_cp = '\0'; yy_c_buf_p = yy_cp;;
+ ;
+do_action:
+ if ( yy_flex_debug )
+  {
+  if ( yy_act == 0 )
+   fprintf( stderr , "--scanner backtracking\n" );
+  else if ( yy_act < 116 -1 )
+   fprintf( stderr ,
+    "--accepting rule at line %d (\"%s\")\n",
+    yy_rule_linenum[yy_act], yytext );
+  else if ( yy_act == 116 -1 )
+   fprintf( stderr ,
+    "--accepting default rule (\"%s\")\n",
+    yytext );
+  else if ( yy_act == 116 )
+   fprintf( stderr , "--(end of buffer or a NUL)\n" );
+  else
+   fprintf( stderr , "--EOF\n" );
+  }
+ switch ( yy_act )
+     {
+     case 0:
+     *yy_cp = yy_hold_char;
+     yy_cp = yy_last_accepting_cpos;
+     yy_current_state = yy_last_accepting_state;
+     goto yy_find_action;
+case 1:
+;
+ break;
+case 2:
+;
+ break;
+case 3:
+{ _line_no++; if (_trace_line) std::cerr << std::endl << "LINE: " << _line_no << std::endl; }
+ break;
+case 4:
+{
+  val.sval = strndup(yytext + 1, strlen(yytext) - 2);
+  return PDDL_Parser::TK_STRING;
+}
+ break;
+case 5:
+{return PDDL_Parser::TK_OPEN;}
+ break;
+case 6:
+{return PDDL_Parser::TK_CLOSE;}
+ break;
+case 7:
+{return PDDL_Parser::TK_OPEN_SQ;}
+ break;
+case 8:
+{return PDDL_Parser::TK_CLOSE_SQ;}
+ break;
+case 9:
+{return PDDL_Parser::TK_PLUS;}
+ break;
+case 10:
+{return PDDL_Parser::TK_HYPHEN;}
+ break;
+case 11:
+{return PDDL_Parser::TK_MUL;}
+ break;
+case 12:
+{return PDDL_Parser::TK_DIV;}
+ break;
+case 13:
+{return PDDL_Parser::TK_GREATER;}
+ break;
+case 14:
+{return PDDL_Parser::TK_GREATEQ;}
+ break;
+case 15:
+{return PDDL_Parser::TK_LESS;}
+ break;
+case 16:
+{return PDDL_Parser::TK_LESSEQ;}
+ break;
+case 17:
+{return PDDL_Parser::TK_COLON;}
+ break;
+case 18:
+{return PDDL_Parser::TK_HASHT;}
+ break;
+case 19:
+{return PDDL_Parser::TK_EQ;}
+ break;
+case 20:
+{return PDDL_Parser::KW_REQS;}
+ break;
+case 21:
+{return PDDL_Parser::KW_CONSTANTS;}
+ break;
+case 22:
+{return PDDL_Parser::KW_PREDS;}
+ break;
+case 23:
+{return PDDL_Parser::KW_FUNS;}
+ break;
+case 24:
+{return PDDL_Parser::KW_TYPES;}
+ break;
+case 25:
+{return PDDL_Parser::KW_DEFINE;}
+ break;
+case 26:
+{return PDDL_Parser::KW_DOMAIN;}
+ break;
+case 27:
+{return PDDL_Parser::KW_ACTION;}
+ break;
+case 28:
+{return PDDL_Parser::KW_PROCESS;}
+ break;
+case 29:
+{return PDDL_Parser::KW_EVENT;}
+ break;
+case 30:
+{return PDDL_Parser::KW_ACTION;}
+ break;
+case 31:
+{return PDDL_Parser::KW_ARGS;}
+ break;
+case 32:
+{return PDDL_Parser::KW_PRE;}
+ break;
+case 33:
+{return PDDL_Parser::KW_COND;}
+ break;
+case 34:
+{return PDDL_Parser::KW_AT_START;}
+ break;
+case 35:
+{return PDDL_Parser::KW_AT_END;}
+ break;
+case 36:
+{return PDDL_Parser::KW_OVER_ALL;}
+ break;
+case 37:
+{return PDDL_Parser::KW_EFFECT;}
+ break;
+case 38:
+{return PDDL_Parser::KW_INVARIANT;}
+ break;
+case 39:
+{return PDDL_Parser::KW_DURATION;}
+ break;
+case 40:
+{return PDDL_Parser::KW_EXPANSION;}
+ break;
+case 41:
+{return PDDL_Parser::KW_TASKS;}
+ break;
+case 42:
+{return PDDL_Parser::KW_AND;}
+ break;
+case 43:
+{return PDDL_Parser::KW_OR;}
+ break;
+case 44:
+{return PDDL_Parser::KW_EXISTS;}
+ break;
+case 45:
+{return PDDL_Parser::KW_FORALL;}
+ break;
+case 46:
+{return PDDL_Parser::KW_IMPLY;}
+ break;
+case 47:
+{return PDDL_Parser::KW_IFF;}
+ break;
+case 48:
+{return PDDL_Parser::KW_NOT;}
+ break;
+case 49:
+{return PDDL_Parser::KW_TRUE;}
+ break;
+case 50:
+{return PDDL_Parser::KW_FALSE;}
+ break;
+case 51:
+{return PDDL_Parser::KW_WHEN;}
+ break;
+case 52:
+{return PDDL_Parser::KW_EITHER;}
+ break;
+case 53:
+{return PDDL_Parser::KW_PROBLEM;}
+ break;
+case 54:
+{return PDDL_Parser::KW_FORDOMAIN;}
+ break;
+case 55:
+{return PDDL_Parser::KW_OBJECTS;}
+ break;
+case 56:
+{return PDDL_Parser::KW_INIT;}
+ break;
+case 57:
+{return PDDL_Parser::KW_GOAL;}
+ break;
+case 58:
+{return PDDL_Parser::KW_LENGTH;}
+ break;
+case 59:
+{return PDDL_Parser::KW_SERIAL;}
+ break;
+case 60:
+{return PDDL_Parser::KW_PARALLEL;}
+ break;
+case 61:
+{return PDDL_Parser::KW_SERIAL;}
+ break;
+case 62:
+{return PDDL_Parser::KW_PARALLEL;}
+ break;
+case 63:
+{return PDDL_Parser::KW_METRIC;}
+ break;
+case 64:
+{return PDDL_Parser::KW_MINIMIZE;}
+ break;
+case 65:
+{return PDDL_Parser::KW_MAXIMIZE;}
+ break;
+case 66:
+{return PDDL_Parser::KW_DURATION_VAR;}
+ break;
+case 67:
+{return PDDL_Parser::KW_TOTAL_TIME;}
+ break;
+case 68:
+{return PDDL_Parser::KW_INCREASE;}
+ break;
+case 69:
+{return PDDL_Parser::KW_DECREASE;}
+ break;
+case 70:
+{return PDDL_Parser::KW_SCALE_UP;}
+ break;
+case 71:
+{return PDDL_Parser::KW_SCALE_DOWN;}
+ break;
+case 72:
+{return PDDL_Parser::KW_ASSIGN;}
+ break;
+case 73:
+{return PDDL_Parser::KW_ASSIGN;}
+ break;
+case 74:
+{return PDDL_Parser::KW_NUMBER;}
+ break;
+case 75:
+{return PDDL_Parser::KW_UNDEFINED;}
+ break;
+case 76:
+{return PDDL_Parser::KW_INVARIANT;}
+ break;
+case 77:
+{return PDDL_Parser::KW_IRRELEVANT;}
+ break;
+case 78:
+{return PDDL_Parser::KW_NAME;}
+ break;
+case 79:
+{return PDDL_Parser::KW_TAG;}
+ break;
+case 80:
+{return PDDL_Parser::KW_TAG;}
+ break;
+case 81:
+{return PDDL_Parser::KW_TAG;}
+ break;
+case 82:
+{return PDDL_Parser::KW_VARS;}
+ break;
+case 83:
+{return PDDL_Parser::KW_CONTEXT;}
+ break;
+case 84:
+{return PDDL_Parser::KW_SET_CONSTRAINT;}
+ break;
+case 85:
+{return PDDL_Parser::KW_FORMULA;}
+ break;
+case 86:
+{return PDDL_Parser::KW_AT_LEAST_N;}
+ break;
+case 87:
+{return PDDL_Parser::KW_AT_MOST_N;}
+ break;
+case 88:
+{return PDDL_Parser::KW_EXACTLY_N;}
+ break;
+case 89:
+{return PDDL_Parser::KW_AT_LEAST_N;}
+ break;
+case 90:
+{return PDDL_Parser::KW_AT_MOST_N;}
+ break;
+case 91:
+{return PDDL_Parser::KW_EXACTLY_N;}
+ break;
+case 92:
+{return PDDL_Parser::KW_SETOF;}
+ break;
+case 93:
+{return PDDL_Parser::KW_FACT;}
+ break;
+case 94:
+{return PDDL_Parser::KW_ASSOC;}
+ break;
+case 95:
+{return PDDL_Parser::KW_PLAN;}
+ break;
+case 96:
+{return PDDL_Parser::KW_HEURISTIC;}
+ break;
+case 97:
+{return PDDL_Parser::KW_OPT;}
+ break;
+case 98:
+{return PDDL_Parser::KW_INF;}
+ break;
+case 99:
+{return PDDL_Parser::KW_SET;}
+ break;
+case 100:
+{return PDDL_Parser::KW_WITHIN;}
+ break;
+case 101:
+{return PDDL_Parser::KW_PREFERENCE;}
+ break;
+case 102:
+{return PDDL_Parser::KW_VIOLATED;}
+ break;
+case 103:
+{ return PDDL_Parser::KW_CONSTRAINTS; }
+ break;
+case 104:
+{ return PDDL_Parser::KW_ALWAYS; }
+ break;
+case 105:
+{ return PDDL_Parser::KW_SOMETIME; }
+ break;
+case 106:
+{ return PDDL_Parser::KW_AT_MOST_ONCE; }
+ break;
+case 107:
+{ return PDDL_Parser::KW_SOMETIME_BEFORE; }
+ break;
+case 108:
+{ return PDDL_Parser::KW_SOMETIME_AFTER; }
+ break;
+case 109:
+{ return PDDL_Parser::KW_ALWAYS_WITHIN; }
+ break;
+case 110:
+{
+  val.sym = _tab.inserta(yytext);
+  if (val.sym->val == 0) return PDDL_Parser::TK_NEW_VAR_SYMBOL;
+  if (((hsps::PDDL_Base::Symbol*)val.sym->val)->sym_class == hsps::PDDL_Base::sym_variable)
+    return PDDL_Parser::TK_VAR_SYMBOL;
+  return PDDL_Parser::TK_NEW_VAR_SYMBOL;
+}
+ break;
+case 111:
+{
+  val.sym = _tab.inserta(yytext);
+  return PDDL_Parser::TK_KEYWORD;
+}
+ break;
+case 112:
+{
+  val.sym = _tab.inserta(yytext);
+  if (val.sym->val == 0) return PDDL_Parser::TK_NEW_SYMBOL;
+  else {
+    if (yy_flex_debug) {
+      hsps::PDDL_Base::Symbol* s = (hsps::PDDL_Base::Symbol*)val.sym->val;
+      std::cerr << "symbol " << s->print_name
+  << " has class " << s->sym_class
+  << std::endl;
+    }
+    switch (((hsps::PDDL_Base::Symbol*)val.sym->val)->sym_class) {
+    case hsps::PDDL_Base::sym_object:
+      return PDDL_Parser::TK_OBJ_SYMBOL;
+    case hsps::PDDL_Base::sym_typename:
+      return PDDL_Parser::TK_TYPE_SYMBOL;
+    case hsps::PDDL_Base::sym_predicate:
+      return PDDL_Parser::TK_PRED_SYMBOL;
+    case hsps::PDDL_Base::sym_object_function:
+      return PDDL_Parser::TK_OBJFUN_SYMBOL;
+    case hsps::PDDL_Base::sym_function:
+      return PDDL_Parser::TK_FUN_SYMBOL;
+    case hsps::PDDL_Base::sym_action:
+      return PDDL_Parser::TK_ACTION_SYMBOL;
+    case hsps::PDDL_Base::sym_preference:
+      return PDDL_Parser::TK_PREFERENCE_SYMBOL;
+    case hsps::PDDL_Base::sym_set:
+      return PDDL_Parser::TK_SET_SYMBOL;
+    default:
+      return PDDL_Parser::TK_MISC_SYMBOL;
+    }
+  }
+}
+ break;
+case 113:
+val.ival = atoi(yytext); return PDDL_Parser::TK_INT;
+ break;
+case 114:
+val.rval = hsps::rational::ator(yytext); return PDDL_Parser::TK_FLOAT;
+ break;
+case 115:
+yy_echo();
+ break;
+case (116 + 0 + 1):
+    return ( 0 );
+     case 116:
+  {
+  int yy_amount_of_matched_text = yy_cp - yytext - 1;
+  *yy_cp = yy_hold_char;
+  if ( yy_c_buf_p <= &YY_CURRENT_BUFFER->yy_ch_buf[yy_n_chars] )
+      {
+      yy_state_type yy_next_state;
+      yy_c_buf_p = yytext + yy_amount_of_matched_text;
+      yy_current_state = ((yy_state_type)(yy_get_previous_state_()));
+      yy_next_state = ((yy_state_type)(yy_try_NUL_trans_(yy_current_state)));
+      yy_bp = yytext + 0;
+      if ( yy_next_state )
+   {
+   yy_cp = ++yy_c_buf_p;
+   yy_current_state = yy_next_state;
+   goto yy_match;
+   }
+      else
+   {
+       yy_cp = yy_last_accepting_cpos;
+       yy_current_state = yy_last_accepting_state;
+   goto yy_find_action;
+   }
+      }
+  else switch ( yy_get_next_buffer() )
+      {
+      case 1:
+   {
+   yy_did_buffer_switch_on_eof = 0;
+   if ( yy_wrap() )
+       {
+       yy_c_buf_p = yytext + 0;
+       yy_act = (116 + (yy_start - 1) / 2 + 1);
+       goto do_action;
+       }
+   else
+       {
+       if ( ! yy_did_buffer_switch_on_eof )
+    do { yy_init_buffer( YY_CURRENT_BUFFER, yyin ); yy_load_buffer_state(); } while ( 0 );
+       }
+   }
+   break;
+      case 0:
+   yy_c_buf_p = yytext + yy_amount_of_matched_text;
+   yy_current_state = ((yy_state_type)(yy_get_previous_state_()));
+   yy_cp = yy_c_buf_p;
+   yy_bp = yytext + 0;
+   goto yy_match;
+      case 2:
+   yy_c_buf_p =
+       &YY_CURRENT_BUFFER->yy_ch_buf[yy_n_chars];
+   yy_current_state = ((yy_state_type)(yy_get_previous_state_()));
+   yy_cp = yy_c_buf_p;
+   yy_bp = yytext + 0;
+   goto yy_find_action;
+      }
+  break;
+  }
+     default:
+  fprintf(stderr , "action # %d\n", yy_act );
+  yy_fatal_error("fatal flex scanner internal error--no action found");
+     }
+ }
+ return ( 0 );
+    }
+int PDDL_Scanner::yy_get_next_buffer()
+    {
+    register char *dest = YY_CURRENT_BUFFER->yy_ch_buf;
+    register char *source = yytext - 1;
+    register int number_to_move, i;
+    int ret_val;
+    if ( yy_c_buf_p > &YY_CURRENT_BUFFER->yy_ch_buf[yy_n_chars + 1] )
+ yy_fatal_error("fatal flex scanner internal error--end of buffer missed");
+    number_to_move = yy_c_buf_p - yytext;
+    for ( i = 0; i < number_to_move; ++i )
+ *(dest++) = *(source++);
+    if ( YY_CURRENT_BUFFER->yy_eof_status != 0 )
+ yy_n_chars = 0;
+    else
+ {
+ int num_to_read = YY_CURRENT_BUFFER->yy_buf_size - number_to_move - 1;
+ if ( num_to_read > 8192 )
+     num_to_read = 8192;
+ else if ( num_to_read <= 0 )
+     yy_fatal_error("fatal error - scanner input buffer overflow");
+ if ( yy_input((char *)(&YY_CURRENT_BUFFER->yy_ch_buf[number_to_move]), yy_n_chars,num_to_read) < 0 ) yy_fatal_error("YY_INPUT() in flex scanner failed");;
+ }
+    if ( yy_n_chars == 0 )
+ {
+ if ( number_to_move - 0 == 1 )
+     {
+     ret_val = 1;
+     YY_CURRENT_BUFFER->yy_eof_status = 2;
+     }
+ else
+     {
+     ret_val = 2;
+     YY_CURRENT_BUFFER->yy_eof_status = 1;
+     }
+ }
+    else
+ ret_val = 0;
+    yy_n_chars += number_to_move;
+    YY_CURRENT_BUFFER->yy_ch_buf[yy_n_chars] = 0;
+    YY_CURRENT_BUFFER->yy_ch_buf[yy_n_chars + 1] = 0;
+    yytext = &YY_CURRENT_BUFFER->yy_ch_buf[1];
+    return ( ret_val );
+    }
+long PDDL_Scanner::yy_get_previous_state_()
+    {
+    register yy_state_type yy_current_state;
+    register char *yy_cp;
+    yy_current_state = yy_start;
+    for ( yy_cp = yytext + 0; yy_cp < yy_c_buf_p; ++yy_cp )
+ {
+ register char yy_c = (*yy_cp ? yy_ec[*yy_cp] : 1);
+ if ( yy_accept[yy_current_state] )
+     {
+     yy_last_accepting_state = yy_current_state;
+     yy_last_accepting_cpos = yy_cp;
+     }
+ while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
+     {
+     yy_current_state = yy_def[yy_current_state];
+     if ( yy_current_state >= 544 )
+  yy_c = yy_meta[yy_c];
+     }
+ yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+ }
+    return (long)( yy_current_state );
+    }
+long PDDL_Scanner::yy_try_NUL_trans_(long yy_current_state_)
+    {
+    yy_state_type yy_current_state=(yy_state_type)yy_current_state_;
+    register int yy_is_jam;
+    register char *yy_cp = yy_c_buf_p;
+    register char yy_c = 1;
+    if ( yy_accept[yy_current_state] )
+ {
+ yy_last_accepting_state = yy_current_state;
+ yy_last_accepting_cpos = yy_cp;
+ }
+    while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
+ {
+ yy_current_state = yy_def[yy_current_state];
+ if ( yy_current_state >= 544 )
+     yy_c = yy_meta[yy_c];
+ }
+    yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+    yy_is_jam = (yy_current_state == 543);
+    return (long)( yy_is_jam ? 0 : yy_current_state );
+    }
+void PDDL_Scanner::yyunput( char c, char *yy_bp )
+    {
+    register char *yy_cp = yy_c_buf_p;
+    *yy_cp = yy_hold_char;
+    if ( yy_cp < YY_CURRENT_BUFFER->yy_ch_buf + 2 )
+ {
+ register int number_to_move = yy_n_chars + 2;
+ register char *dest =
+     &YY_CURRENT_BUFFER->yy_ch_buf[YY_CURRENT_BUFFER->yy_buf_size + 2];
+ register char *source =
+     &YY_CURRENT_BUFFER->yy_ch_buf[number_to_move];
+ while ( source > YY_CURRENT_BUFFER->yy_ch_buf )
+     *--dest = *--source;
+ yy_cp += dest - source;
+ yy_bp += dest - source;
+ yy_n_chars = YY_CURRENT_BUFFER->yy_buf_size;
+ if ( yy_cp < YY_CURRENT_BUFFER->yy_ch_buf + 2 )
+     yy_fatal_error("flex scanner push-back overflow");
+ }
+    if ( yy_cp > yy_bp && yy_cp[-1] == '\n' )
+ yy_cp[-2] = '\n';
+    *--yy_cp = c;
+    yytext = yy_bp; yyleng = yy_cp - yy_bp; yy_hold_char = *yy_cp; *yy_cp = '\0'; yy_c_buf_p = yy_cp;;
+    }
+int PDDL_Scanner::input()
+    {
+    int c;
+    char *yy_cp = yy_c_buf_p;
+    *yy_cp = yy_hold_char;
+    if ( *yy_c_buf_p == 0 )
+ {
+ if ( yy_c_buf_p < &YY_CURRENT_BUFFER->yy_ch_buf[yy_n_chars] )
+     *yy_c_buf_p = '\0';
+ else
+     {
+     yytext = yy_c_buf_p;
+     ++yy_c_buf_p;
+     switch ( yy_get_next_buffer() )
+  {
+  case 1:
+      {
+      if ( yy_wrap() )
+   {
+   yy_c_buf_p = yytext + 0;
+   return ( EOF );
+   }
+      do { yy_init_buffer( YY_CURRENT_BUFFER, yyin ); yy_load_buffer_state(); } while ( 0 );
+      return ( input() );
+      }
+      break;
+  case 0:
+      yy_c_buf_p = yytext + 0;
+      break;
+  case 2:
+      yy_fatal_error("unexpected last match in YY_PDDL_Scanner_CLASS::input()");
+  }
+     }
+ }
+    c = *yy_c_buf_p;
+    yy_hold_char = *++yy_c_buf_p;
+    return ( c );
+    }
+void PDDL_Scanner::yyrestart ( FILE *input_file )
+    {
+    yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+    yy_load_buffer_state();
+    }
+void PDDL_Scanner::yy_switch_to_buffer( YY_BUFFER_STATE new_buffer )
+    {
+    if ( YY_CURRENT_BUFFER == new_buffer )
+ return;
+    if ( YY_CURRENT_BUFFER )
+ {
+ *yy_c_buf_p = yy_hold_char;
+ YY_CURRENT_BUFFER->yy_buf_pos = yy_c_buf_p;
+ YY_CURRENT_BUFFER->yy_n_chars = yy_n_chars;
+ }
+    YY_CURRENT_BUFFER = new_buffer;
+    yy_load_buffer_state();
+    yy_did_buffer_switch_on_eof = 1;
+    }
+void PDDL_Scanner::yy_load_buffer_state( )
+    {
+    yy_n_chars = YY_CURRENT_BUFFER->yy_n_chars;
+    yytext = yy_c_buf_p = YY_CURRENT_BUFFER->yy_buf_pos;
+    yyin = YY_CURRENT_BUFFER->yy_input_file;
+    yy_hold_char = *yy_c_buf_p;
+    }
+YY_BUFFER_STATE PDDL_Scanner::yy_create_buffer( FILE *file, int size )
+    {
+    YY_BUFFER_STATE b;
+    b = (YY_BUFFER_STATE) malloc( sizeof( struct yy_buffer_state ) );
+    if ( ! b )
+ yy_fatal_error("out of dynamic memory in YY_PDDL_Scanner_CREATE_BUFFER()");
+    b->yy_buf_size = size;
+    b->yy_ch_buf = (char *) malloc( (unsigned) (b->yy_buf_size + 2) );
+    if ( ! b->yy_ch_buf )
+ yy_fatal_error("out of dynamic memory in YY_PDDL_Scanner_CREATE_BUFFER()");
+    yy_init_buffer( b, file );
+    return ( b );
+    }
+void PDDL_Scanner::yy_delete_buffer( YY_BUFFER_STATE b )
+    {
+    if ( b == YY_CURRENT_BUFFER )
+ YY_CURRENT_BUFFER = (YY_BUFFER_STATE) 0;
+    free( (char *) b->yy_ch_buf );
+    free( (char *) b );
+    }
+void PDDL_Scanner::yy_init_buffer( YY_BUFFER_STATE b, FILE *file)
+    {
+    b->yy_input_file = file;
+    b->yy_ch_buf[0] = '\n';
+    b->yy_n_chars = 1;
+    b->yy_ch_buf[1] = 0;
+    b->yy_ch_buf[2] = 0;
+    b->yy_buf_pos = &b->yy_ch_buf[1];
+    b->yy_eof_status = 0;
+    }
+int yy_wrap() {
+  return 1;
+}
+void PDDL_Scanner::open_file(char* name, bool trace) {
+  yy_flex_debug = trace;
+  yyin = fopen(name, "r");
+  if (!yyin) {
+    std::cerr << "error: can't open " << name << std::endl;
+    exit(255);
+  }
+  _filename = name;
+  if (_reset) yy_init_buffer(YY_CURRENT_BUFFER, yyin);
+  _reset = true;
+  _line_no = 1;
+  _trace_line = trace;
+}
+void PDDL_Scanner::close_file() {
+  if (_filename != 0) {
+    fclose(yyin);
+    _filename = 0;
+  }
+}

--- a/pr/seq-opt-hspsf/search.ccx
+++ b/pr/seq-opt-hspsf/search.ccx
@@ -1,0 +1,2653 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+State::~State()
+{
+}
+const State* State::predecessor() const
+{
+  return pre;
+}
+State* State::predecessor()
+{
+  return pre;
+}
+void State::set_predecessor(State* p)
+{
+  pre = p;
+}
+bool State::is_encapsulated()
+{
+  return false;
+}
+hsps::rational State::acc_cost()
+{
+  if (predecessor()) {
+    return delta_cost() + predecessor()->acc_cost();
+  }
+  else {
+    return 0;
+  }
+}
+index_type State::depth() const
+{
+  if (predecessor()) {
+    return 1 + predecessor()->depth();
+  }
+  else {
+    return 0;
+  }
+}
+void State::write_eval(::std::ostream& s, char* p, bool e)
+{
+  if (p) s << p << " ";
+  s << est_cost();
+  if (e) s << ::std::endl;
+}
+State* State::copy_path()
+{
+  State* s = copy();
+  if (predecessor()) {
+    s->set_predecessor(predecessor()->copy_path());
+  }
+  return s;
+}
+void State::delete_path()
+{
+  if (predecessor()) {
+    predecessor()->delete_path();
+  }
+  delete this;
+}
+int State::compare_path(const State* s)
+{
+  if (s == 0) return 1;
+  int c = compare(*s);
+  if (c == 0) {
+    if (predecessor() == 0) return -1;
+    return predecessor()->compare_path(s->predecessor());
+  }
+  return c;
+}
+void State::write_path(::std::ostream& s)
+{
+  State* p = predecessor();
+  if (p) {
+    p->write_path(s);
+  }
+  write(s);
+  s << ::std::endl;
+}
+void State::write_path_as_graph(::std::ostream& s)
+{
+  State* p = predecessor();
+  if (p) {
+    p->write_path_as_graph(s);
+  }
+  s << "S" << depth() << " [label=\"";
+  write(s);
+  if (is_final()) {
+    s << ",style=\"bold\"";
+  }
+  s << "\"];" << ::std::endl;
+  if (p) {
+    s << "S" << depth() << " -> S" << p->depth()
+      << " [label=\"";
+    write_plan(s);
+    s << "\"];" << ::std::endl;
+  }
+}
+void ProgressionState::insert_path(Plan& p)
+{
+  if (predecessor()) {
+    predecessor()->insert_path(p);
+  }
+  insert(p);
+}
+void RegressionState::insert_path(Plan& p)
+{
+  State* sp = this;
+  while (sp != 0) {
+    sp->insert(p);
+    sp = sp->predecessor();
+  }
+}
+PlanTrait::~PlanTrait()
+{
+}
+const PlanTrait* PlanTrait::cast_to(const char* n) const
+{
+  return 0;
+}
+Plan::~Plan()
+{
+}
+void Plan::output(Plan& to)
+{
+}
+void Plan::set_name(const Name* n)
+{
+}
+void Plan::set_optimal(bool o)
+{
+}
+void Plan::add_trait(PlanTrait* t)
+{
+  delete t;
+}
+Search::~Search()
+{
+}
+NoSearch::~NoSearch()
+{
+}
+void NoSearch::reset()
+{
+  _solved = false;
+}
+hsps::rational NoSearch::new_state(State& s, hsps::rational bound)
+{
+  if (s.is_final()) _solved = true;
+  return s.est_cost();
+}
+bool NoSearch::solved() const
+{
+  return _solved;
+}
+bool NoSearch::optimal() const
+{
+  return false;
+}
+bool NoSearch::done() const
+{
+  return false;
+}
+Transitions::Transitions()
+  : state_vec((State*)0, 0), target_state(0)
+{
+}
+Transitions::Transitions(State* from, State* to, hsps::rational d)
+  : state_vec((State*)0, 0), target_state(0)
+{
+  find(from, to, d, true);
+}
+Transitions::~Transitions()
+{
+  clear();
+}
+void Transitions::clear()
+{
+  for (index_type k = 0; k < length(); k++)
+    delete (*this)[k];
+  state_vec::clear();
+}
+bool Transitions::find(State* from, State* to, hsps::rational d, bool x)
+{
+  target_state = to;
+  delta_bound = d;
+  bound_is_exact = x;
+  from->expand(*this, delta_bound + to->est_cost());
+  target_state = 0;
+  return (length() > 0);
+}
+hsps::rational Transitions::new_state(State& s, hsps::rational bound)
+{
+  if (!target_state) {
+    ::std::cerr << "error: Transitions::new_state called with state = ";
+    s.write(::std::cerr);
+    ::std::cerr << " and target_state == nil" << ::std::endl;
+    exit(255);
+  }
+  if (((s.delta_cost() == delta_bound) || !bound_is_exact) &&
+      (target_state->compare(s) == 0)) {
+    append(s.copy());
+  }
+  return s.est_cost();
+}
+bool Transitions::solved() const
+{
+  return (length() > 0);
+}
+bool Transitions::optimal() const
+{
+  return false;
+}
+bool Transitions::done() const
+{
+  return false;
+}
+StateFactory::~StateFactory()
+{
+}
+PlanSet::~PlanSet()
+{
+}
+void PlanSet::output(PlanSet& to)
+{
+}
+void PlanSet::output(PlanSet& to, const bool_vec& s)
+{
+}
+}

--- a/pr/seq-opt-hspsf/search_base.ccx
+++ b/pr/seq-opt-hspsf/search_base.ccx
@@ -1,0 +1,4563 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+SearchResult::~SearchResult()
+{
+}
+count_type Result::solution_count()
+{
+  return n_found;
+}
+bool Result::search_space_exhausted()
+{
+  return (max_ex == POS_INF);
+}
+void Result::reset()
+{
+  n_found = 0;
+  min_cost = POS_INF;
+  max_ex = NEG_INF;
+}
+void Result::set_stop_condition(stop_condition c)
+{
+  sc = c;
+}
+void Result::set_n_to_find(count_type n)
+{
+  find_n = n;
+  sc = stop_at_nth;
+}
+void Result::set_plan_set(PlanSet* s)
+{
+  plans = s;
+}
+void Result::solution(State& s, hsps::rational cost)
+{
+  n_found += 1;
+  min_cost = hsps::rational::min(min_cost,cost);
+  if (plans) {
+    Plan* p = plans->new_plan();
+    if (p) {
+      s.insert_path(*p);
+      p->end();
+    }
+  }
+}
+void Result::no_more_solutions(hsps::rational cost)
+{
+  max_ex = hsps::rational::max(max_ex,cost);
+}
+bool Result::more()
+{
+  switch (sc) {
+  case stop_at_first:
+    return false;
+  case stop_at_nth:
+    return (n_found < find_n);
+  case stop_at_all_optimal:
+    return (max_ex < min_cost);
+  case stop_at_all:
+    return true;
+  default:
+    assert(0);
+  }
+}
+SearchStats::SearchStats(Statistics& s)
+  : stats(s),
+    cost_limit(POS_INF),
+    node_limit(count_type_max),
+    work_limit(count_type_max),
+    zero_eval_count(0)
+{
+}
+SearchStats::SearchStats(Statistics& s, hsps::rational limit)
+  : stats(s),
+    cost_limit(limit),
+    node_limit(count_type_max),
+    work_limit(count_type_max),
+    zero_eval_count(0)
+{
+}
+SearchStats::~SearchStats()
+{
+}
+void SearchStats::set_cost_limit(hsps::rational c_max)
+{
+  cost_limit = c_max;
+}
+hsps::rational SearchStats::get_cost_limit() const
+{
+  return cost_limit;
+}
+bool SearchStats::cost_limit_reached() const
+{
+  return (cost() > cost_limit);
+}
+void SearchStats::set_node_limit(count_type n)
+{
+  node_limit = n;
+}
+count_type SearchStats::get_node_limit() const
+{
+  return node_limit;
+}
+bool SearchStats::node_limit_reached() const
+{
+  return (stats.nodes() + node_count > node_limit);
+}
+void SearchStats::set_work_limit(count_type n)
+{
+  work_limit = n;
+}
+count_type SearchStats::get_work_limit() const
+{
+  return work_limit;
+}
+bool SearchStats::work_limit_reached() const
+{
+  return (work() > work_limit);
+}
+count_type SearchStats::work() const
+{
+  return (Heuristic::eval_count - zero_eval_count) + work_count;
+}
+void SearchStats::reset()
+{
+  zero_eval_count = Heuristic::eval_count;
+  work_count = 0;
+  node_count = 0;
+}
+void SearchStats::start_count()
+{
+  if (stats.run_level() == 0) {
+    zero_eval_count = Heuristic::eval_count;
+  }
+  stats.start();
+}
+void SearchStats::stop_count()
+{
+  stats.stop();
+  if (stats.run_level() == 0) {
+    work_count += (Heuristic::eval_count - zero_eval_count);
+    node_count += stats.nodes();
+  }
+}
+bool SearchStats::break_signal_raised() const
+{
+  return (stats.break_signal_raised() ||
+   node_limit_reached() ||
+   work_limit_reached());
+}
+int SearchAlgorithm::default_trace_level = 0;
+SearchAlgorithm::SearchAlgorithm(Statistics& s, SearchResult& r)
+  : SearchStats(s),
+    result(r),
+    is_solved(false),
+    trace_level(default_trace_level)
+{
+}
+SearchAlgorithm::SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+  : SearchStats(s, limit),
+    result(r),
+    is_solved(false),
+    trace_level(default_trace_level)
+{
+}
+SearchAlgorithm::~SearchAlgorithm()
+{
+}
+void SearchAlgorithm::set_problem_name(const Name* n)
+{
+  problem_name = n;
+}
+void SearchAlgorithm::set_trace_level(int level)
+{
+  trace_level = level;
+}
+void SearchAlgorithm::reset()
+{
+  SearchStats::reset();
+  set_solved(false, false);
+}
+bool SearchAlgorithm::solved() const
+{
+  return is_solved;
+}
+bool SearchAlgorithm::optimal() const
+{
+  return (is_solved && is_optimal);
+}
+bool SearchAlgorithm::done() const
+{
+  return ((solved() && !result.more()) || break_signal_raised());
+}
+void SearchAlgorithm::set_solved(bool s, bool o)
+{
+  is_solved = s;
+  is_optimal = o;
+}
+void SearchAlgorithm::set_solved(bool s)
+{
+  is_solved = s;
+  is_optimal = true;
+}
+hsps::rational MultiSearchAlgorithm::resume(State& s)
+{
+  s.reevaluate();
+  return resume(s, s.est_cost());
+}
+}

--- a/pr/seq-opt-hspsf/seq_reg.ccx
+++ b/pr/seq-opt-hspsf/seq_reg.ccx
@@ -1,0 +1,4899 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+class AtomSet {
+ protected:
+  Instance& instance;
+  bool_vec set;
+  index_type size;
+  index_type count();
+ private:
+  hsps::rational split(index_set g, index_type p, index_type n_out, index_type limit,
+       StateFactory& f, State* sp, Search& s, hsps::rational bound);
+  hsps::rational split_random(index_set g, index_type p, index_type n_out,
+       index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+ public:
+  static index_type max_set_size_encountered;
+  AtomSet(Instance& i);
+  AtomSet(Instance& i, const index_set& g);
+  AtomSet(Instance& i, const bool_vec& g);
+  AtomSet(const AtomSet& s);
+  ~AtomSet();
+  index_type atom_set_size() { return size; };
+  void add(const index_set& s);
+  void add(const bool_vec& s);
+  void del(const index_set& s);
+  void del(const bool_vec& s);
+  bool is_init_all();
+  bool is_init_some();
+  bool is_goal_all();
+  bool is_goal_some();
+  index_vec& copy_to(index_vec& s);
+  bool_vec& copy_to(bool_vec& s);
+  hsps::rational split(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound);
+  hsps::rational split_random(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+  int compare(const AtomSet& s);
+  index_type hash();
+};
+class AtomSetState : public AtomSet, public State {
+ protected:
+  Heuristic& heuristic;
+  hsps::rational est;
+  hsps::rational eval();
+  hsps::rational eval(hsps::rational b_est);
+  hsps::rational eval_with_trace_level(int level);
+  void apply_path_max();
+ public:
+  AtomSetState(Instance& i, Heuristic& h);
+  AtomSetState(Instance& i, Heuristic& h, const index_set& g);
+  AtomSetState(Instance& i, Heuristic& h, const bool_vec& g);
+  AtomSetState(const AtomSetState& s);
+  virtual ~AtomSetState();
+  index_type atom_set_size() { return size; };
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual void write(std::ostream& s);
+  virtual void write_eval(std::ostream& s, char* p = 0, bool e = true);
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class SeqRegState : public AtomSetState, public StateFactory {
+ protected:
+  const ACF& cost;
+  index_type act;
+  RegressionResourceState* res;
+  bool relevant(Instance::Action& a);
+  bool applicable(Instance::Action& a);
+  SeqRegState* apply(Instance::Action& a);
+ public:
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c)
+    : AtomSetState(i, h), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c,
+       RegressionResourceState* r)
+    : AtomSetState(i, h), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+       RegressionResourceState* r)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+       RegressionResourceState* r)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(const SeqRegState& s);
+  virtual ~SeqRegState();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void set_predecessor(State* p);
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write_plan(std::ostream& s);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual void write(std::ostream& s);
+};
+class ApxSeqRegState : public SeqRegState {
+ protected:
+  index_type limit;
+ public:
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, index_type l)
+    : SeqRegState(i, h, c), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+   index_type l)
+    : SeqRegState(i, h, c, g), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+   index_type l)
+    : SeqRegState(i, h, c, g), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, r), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, g, r), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, g, r), limit(l) { };
+  ApxSeqRegState(const ApxSeqRegState& s)
+    : SeqRegState(s), limit(s.limit) { };
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+};
+class SeqCRegState : public SeqRegState {
+ public:
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c)
+    : SeqRegState(i, h, c) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g)
+    : SeqRegState(i, h, c, g) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g)
+    : SeqRegState(i, h, c, g) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, r) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, g, r) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, g, r) { };
+  SeqCRegState(const SeqRegState& s)
+    : SeqRegState(s) { };
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual int compare(const State& s);
+  index_type hash();
+  virtual void write(std::ostream& s);
+};
+class LDSeqRegState : public SeqRegState {
+  const index_vec& plan;
+  static bool copy_as_ld;
+ public:
+  LDSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+  const index_set& g, const index_vec& p)
+    : SeqRegState(i, h, c, g), plan(p) { };
+  LDSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+  const index_vec& p, const bool_vec& g)
+    : SeqRegState(i, h, c, g), plan(p) { };
+  LDSeqRegState(const LDSeqRegState& s);
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* copy();
+  virtual int compare(const State& s);
+  virtual void write(std::ostream& s);
+};
+}
+namespace hsps {
+SeqRegState::SeqRegState(const SeqRegState& s)
+  : AtomSetState(s), cost(s.cost), act(s.act), res(0)
+{
+  if (s.res) res = s.res->copy();
+}
+SeqRegState::~SeqRegState()
+{
+  if (res) delete res;
+}
+bool SeqRegState::relevant(Instance::Action& a)
+{
+  bool rel = false;
+  for (index_type i = 0; (i < a.add.length()) && !rel; i++)
+    if (set[a.add[i]]) rel = true;
+  return rel;
+}
+bool SeqRegState::applicable(Instance::Action& a)
+{
+  bool app = true;
+  for (index_type i = 0; (i < a.del.length()) && app; i++)
+    if (set[a.del[i]]) app = false;
+  if (res) {
+    if (app) {
+      if (!res->applicable(a)) app = false;
+    }
+  }
+  return app;
+}
+SeqRegState* SeqRegState::apply(Instance::Action& a)
+{
+  SeqRegState* s = (SeqRegState*)copy();
+  for (index_type k = 0; k < a.add.length(); k++) {
+    if (s->set[a.add[k]]) s->size -= 1;
+    s->set[a.add[k]] = false;
+  }
+  for (index_type k = 0; k < a.pre.length(); k++) {
+    if (!s->set[a.pre[k]]) s->size += 1;
+    s->set[a.pre[k]] = true;
+  }
+  s->State::set_predecessor(this);
+  s->act = a.index;
+  s->eval();
+  if (s->res) {
+    s->res->apply(a);
+    if (!s->res->sufficient_consumable(s->set)) s->est = POS_INF;
+  }
+  return s;
+}
+hsps::rational SeqRegState::delta_cost()
+{
+  if (act == no_such_index)
+    return 0;
+  else
+    return cost(act);
+}
+hsps::rational SeqRegState::expand(Search& s, hsps::rational bound)
+{
+  hsps::rational c_min = POS_INF;
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    Instance::Action& a = instance.actions[k];
+    if (a.sel) {
+      if (relevant(a)) {
+ if (applicable(a)) {
+   hsps::rational act_est = 0;
+   if (res) {
+     if (!res->sufficient_consumable(a.pre, a)) act_est = POS_INF;
+   }
+   if ((act_est).finite() && (cost(a.index) + act_est <= bound)) {
+     SeqRegState* new_s = apply(a);
+     if ((new_s->est).finite() && (cost(a.index) + new_s->est <= bound)) {
+       hsps::rational c_new =
+  cost(a.index) + s.new_state(*new_s, bound - cost(a.index));
+       if (s.solved()) {
+  if (size > max_set_size_encountered)
+    max_set_size_encountered = size;
+       }
+       if (s.done()) {
+  delete new_s;
+  return c_new;
+       }
+       else {
+  c_min = hsps::rational::min(c_min,c_new);
+       }
+     }
+     else c_min = hsps::rational::min(c_min,cost(a.index) + new_s->est);
+     delete new_s;
+   }
+   else c_min = hsps::rational::min(c_min,cost(a.index) + act_est);
+ }
+      }
+    }
+  }
+  return c_min;
+}
+void SeqRegState::store(hsps::rational cost, bool opt)
+{
+  if (res) {
+    if (!res->is_root()) return;
+  }
+  heuristic.store(set, cost, opt);
+}
+void SeqRegState::set_predecessor(State* p)
+{
+  if (p == 0) {
+    act = no_such_index;
+    pre = 0;
+    return;
+  }
+  SeqRegState* s = (SeqRegState*)p;
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    Instance::Action& a = instance.actions[k];
+    if (a.sel && s->relevant(a) && s->applicable(a)) {
+      SeqRegState* new_s = s->apply(a);
+      int d = compare(*new_s);
+      delete new_s;
+      if (d == 0) {
+ act = k;
+ pre = s;
+ return;
+      }
+    }
+  }
+  std::cerr << "error in SeqRegState::set_predecessor: state " << *this
+     << " can not be a successor of " << *s << std::endl;
+  assert(0);
+}
+void SeqRegState::insert(Plan& p)
+{
+  if (act != no_such_index) {
+    p.insert(act);
+    for (index_type k = 0; k < instance.n_atoms(); k++)
+      if (set[k] && !instance.actions[act].add.contains(k))
+ p.protect(k);
+    p.advance(instance.actions[act].dur);
+  }
+}
+void SeqRegState::write_plan(std::ostream& s)
+{
+  if (act != no_such_index) {
+    s << instance.actions[act].name;
+  }
+}
+void SeqRegState::insert_path(Plan& p)
+{
+  insert(p);
+  if (predecessor()) {
+    predecessor()->insert_path(p);
+  }
+}
+State* SeqRegState::copy()
+{
+  return new SeqRegState(*this);
+}
+State* SeqRegState::new_state(const index_set& s, State* p)
+{
+  SeqRegState* new_s =
+    (res ? new SeqRegState(instance, heuristic, cost, s, res->new_state())
+         : new SeqRegState(instance, heuristic, cost, s));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* SeqRegState::new_state(const bool_vec& s, State* p)
+{
+  SeqRegState* new_s =
+    (res ? new SeqRegState(instance, heuristic, cost, s, res->new_state())
+         : new SeqRegState(instance, heuristic, cost, s));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+void SeqRegState::write(std::ostream& s)
+{
+  instance.write_atom_set(s, set);
+  if (res) {
+    s << " (";
+    res->write(s);
+    s << ")";
+  }
+}
+bool ApxSeqRegState::is_max()
+{
+  return (size > limit);
+}
+hsps::rational ApxSeqRegState::expand(Search& s, hsps::rational bound)
+{
+  if (size > limit) {
+    return split(limit, *this, this, s, bound);
+  }
+  else {
+    hsps::rational c_rec = SeqRegState::expand(s, bound);
+    return c_rec;
+  }
+}
+State* ApxSeqRegState::copy()
+{
+  return new ApxSeqRegState(*this);
+}
+State* ApxSeqRegState::new_state(const index_set& s, State* p)
+{
+  ApxSeqRegState* new_s =
+    (res ? new ApxSeqRegState(instance, heuristic, cost, s, res, limit)
+         : new ApxSeqRegState(instance, heuristic, cost, s, limit));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* ApxSeqRegState::new_state(const bool_vec& s, State* p)
+{
+  ApxSeqRegState* new_s =
+    (res ? new ApxSeqRegState(instance, heuristic, cost, s, res, limit)
+         : new ApxSeqRegState(instance, heuristic, cost, s, limit));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+hsps::rational SeqCRegState::expand(Search& s, hsps::rational bound)
+{
+  hsps::rational c_min = POS_INF;
+  for (index_type k = 0; k < instance.n_actions(); k++) {
+    Instance::Action& a = instance.actions[k];
+    if (a.sel) {
+      if (relevant(a)) {
+ bool app = applicable(a);
+ if (app) {
+   if ((act != no_such_index) && (act < a.index) &&
+       instance.commutative(act, a.index)) app = false;
+ }
+ if (app) {
+   hsps::rational act_est = 0;
+   if (res) {
+     if (!res->sufficient_consumable(a.pre, a)) act_est = POS_INF;
+   }
+   if ((act_est).finite() && (cost(a.index) + act_est <= bound)) {
+     SeqCRegState* new_s = (SeqCRegState*)apply(a);
+     if ((new_s->est).finite() && (cost(a.index) + new_s->est <= bound)) {
+       hsps::rational c_new = (cost(a.index) +
+        s.new_state(*new_s, bound - cost(a.index)));
+       if (s.solved()) {
+  if (size > max_set_size_encountered)
+    max_set_size_encountered = size;
+       }
+       if (s.done()) {
+  delete new_s;
+  return c_new;
+       }
+       else {
+  c_min = hsps::rational::min(c_min,c_new);
+       }
+     }
+     else {
+       c_min = hsps::rational::min(c_min,cost(a.index) + new_s->est);
+     }
+     delete new_s;
+   }
+   else c_min = hsps::rational::min(c_min,cost(a.index) + act_est);
+ }
+      }
+    }
+  }
+  return c_min;
+}
+State* SeqCRegState::copy()
+{
+  return new SeqCRegState(*this);
+}
+State* SeqCRegState::new_state(const index_set& s, State* p)
+{
+  SeqCRegState* new_s =
+    (res ? new SeqCRegState(instance, heuristic, cost, s, res)
+         : new SeqCRegState(instance, heuristic, cost, s));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+State* SeqCRegState::new_state(const bool_vec& s, State* p)
+{
+  SeqCRegState* new_s =
+    (res ? new SeqCRegState(instance, heuristic, cost, s, res)
+         : new SeqCRegState(instance, heuristic, cost, s));
+  new_s->State::set_predecessor(p);
+  return new_s;
+}
+int SeqCRegState::compare(const State& s)
+{
+  if (act < ((SeqCRegState&)s).act) return -1;
+  else if (act > ((SeqCRegState&)s).act) return 1;
+  else return AtomSetState::compare(s);
+}
+index_type SeqCRegState::hash()
+{
+  return (AtomSetState::hash() + act);
+}
+void SeqCRegState::write(std::ostream& s)
+{
+  if (act != no_such_index)
+    s << "(" << instance.actions[act].name << ") ";
+  else
+    s << "() ";
+  instance.write_atom_set(s, set);
+  if (res) {
+    s << " (";
+    res->write(s);
+    s << ")";
+  }
+}
+bool LDSeqRegState::copy_as_ld = true;
+LDSeqRegState::LDSeqRegState(const LDSeqRegState& s)
+  : SeqRegState(s), plan(s.plan)
+{
+}
+hsps::rational LDSeqRegState::expand(Search& s, hsps::rational bound)
+{
+  hsps::rational c_min = POS_INF;
+  index_type ra = no_such_index;
+  index_type d = depth();
+  if (d < plan.length()) {
+    ra = plan[plan.length() - (d + 1)];
+    Instance::Action& a = instance.actions[ra];
+    if (a.sel && applicable(a)) {
+      hsps::rational act_est = heuristic.eval_precondition(a);
+      if (res) {
+ if (!res->sufficient_consumable(a.pre, a)) act_est = POS_INF;
+      }
+      if ((act_est).finite() && (cost(a.index) + act_est <= bound)) {
+ copy_as_ld = true;
+ LDSeqRegState* new_s = (LDSeqRegState*)apply(a);
+ if ((new_s->est).finite() && (cost(a.index) + new_s->est <= bound)) {
+   hsps::rational c_new = (cost(a.index) +
+    s.new_state(*new_s, bound - cost(a.index)));
+   if (s.solved()) {
+     if (size > max_set_size_encountered)
+       max_set_size_encountered = size;
+   }
+   if (s.done()) {
+     delete new_s;
+     return c_new;
+   }
+   else {
+     c_min = hsps::rational::min(c_min,c_new);
+   }
+ }
+ else {
+   c_min = hsps::rational::min(c_min,cost(a.index) + new_s->est);
+ }
+ delete new_s;
+      }
+      else {
+ c_min = hsps::rational::min(c_min,cost(a.index) + act_est);
+      }
+    }
+  }
+  std::cerr << "exploring deviations at depth " << d << "..." << std::endl;
+  for (index_type k = 0; k < instance.n_actions(); k++)
+    if (instance.actions[k].sel && (k != ra)) {
+      Instance::Action& a = instance.actions[k];
+      if (a.sel && relevant(a)) {
+ bool app = applicable(a);
+ if (app) {
+   if ((act != no_such_index) && (act < a.index) &&
+       instance.commutative(act, a.index)) app = false;
+ }
+ if (app) {
+   hsps::rational act_est = heuristic.eval_precondition(a);
+   if (res) {
+     if (!res->sufficient_consumable(a.pre, a)) act_est = POS_INF;
+   }
+   if ((act_est).finite() && (cost(a.index) + act_est <= bound)) {
+     copy_as_ld = false;
+     SeqCRegState* new_s = (SeqCRegState*)apply(a);
+     copy_as_ld = true;
+     if ((new_s->est_cost()).finite() &&
+  (cost(a.index) + new_s->est_cost() <= bound)) {
+       hsps::rational c_new = (cost(a.index) +
+        s.new_state(*new_s, bound - cost(a.index)));
+       if (s.solved()) {
+  if (size > max_set_size_encountered)
+    max_set_size_encountered = size;
+       }
+       if (s.done()) {
+  delete new_s;
+  return c_new;
+       }
+       else {
+  c_min = hsps::rational::min(c_min,c_new);
+       }
+     }
+     else {
+       c_min = hsps::rational::min(c_min,cost(a.index) + new_s->est_cost());
+     }
+     delete new_s;
+   }
+   else c_min = hsps::rational::min(c_min,cost(a.index) + act_est);
+ }
+      }
+    }
+  return c_min;
+}
+State* LDSeqRegState::copy()
+{
+  if (copy_as_ld) {
+    return new LDSeqRegState(*this);
+  }
+  else {
+    return new SeqCRegState(*this);
+  }
+}
+int LDSeqRegState::compare(const State& s)
+{
+  return SeqRegState::compare(s);
+}
+void LDSeqRegState::write(std::ostream& s)
+{
+  s << "(" << depth() << ": ";
+  if (depth() < plan.length()) {
+    s << instance.actions[plan[plan.length() - (depth() + 1)]].name;
+  }
+  else {
+    s << "-";
+  }
+  s << ") ";
+  SeqRegState::write(s);
+}
+}

--- a/pr/seq-opt-hspsf/soft.ccx
+++ b/pr/seq-opt-hspsf/soft.ccx
@@ -1,0 +1,6251 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+class rational {
+  long nm;
+  long dv;
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+  rational(const rational& r);
+  struct XR {
+    long x_nm;
+    long x_dv;
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+  rational operator=(const rational r);
+  rational operator=(long n);
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+  double decimal() const;
+};
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+inline rational::rational()
+  : nm(0), dv(1) { }
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+inline long rational::numerator() const { return nm; }
+inline long rational::divisor() const { return dv; }
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+inline rational rational::round(const rational r, long d_max)
+{
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+    s.reduce();
+  }
+  return s;
+}
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+inline rational rational::operator=(const rational r)
+{
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+inline rational rational::operator=(long n)
+{
+  nm = n;
+  dv = 1;
+  return *this;
+}
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+inline double rational::decimal() const { return nm/(double)dv; };
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+inline rational operator+(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+#include <map>
+#include <iostream>
+namespace hsps {
+class graph {
+ private:
+  index_type _size;
+  bool_matrix adj;
+  index_set_vec in;
+  index_set_vec out;
+  index_set_vec bi;
+  index_vec comp;
+  index_type n_comp;
+ public:
+  graph();
+  graph(index_type s);
+  graph(const graph& g);
+  graph(const graph& g, const index_set& n);
+  graph(const graph& g, const equivalence& eq);
+  ~graph();
+  index_type size() const { return _size; };
+  bool adjacent(index_type i, index_type j) const { return adj[i][j]; };
+  bool adjacent(index_type i, const index_set& n) const;
+  bool adjacent(const index_set& n, index_type i) const;
+  bool adjacent(const index_set& n0, const index_set& n1) const;
+  bool bi_adjacent(index_type i, index_type j) const
+    { return (adj[i][j] && adj[j][i]); };
+  bool bi_adjacent(index_type i, const index_set& n) const;
+  index_type n_edges() const;
+  index_type n_edges(const index_set& from, const index_set& to) const;
+  pair_set& edges(pair_set& s) const;
+  index_type n_induced_undirected_edges() const;
+  index_type n_induced_undirected_edges(const index_set& n0,
+     const index_set& n1) const;
+  index_type n_bidirectional_edges() const;
+  index_type n_bidirectional_edges(const index_set& n0,
+       const index_set& n1) const;
+  const index_set& successors(index_type i) const { return out[i]; };
+  index_type out_degree(index_type i) const { return out[i].length(); };
+  const index_set& predecessors(index_type i) const { return in[i]; };
+  index_type in_degree(index_type i) const { return in[i].length(); };
+  const index_set& bidirectional(index_type i) const { return bi[i]; };
+  index_type bi_degree(index_type i) const { return bi[i].length(); };
+  pair_set& bidirectional_edges(pair_set& s) const;
+  void descendants(index_type n0, bool_vec& s) const;
+  void descendants(const index_set& s0, bool_vec& s) const;
+  void descendants(index_type n0, index_set& s) const;
+  void descendants(const index_set& s0, index_set& s) const;
+  void ancestors(index_type n0, bool_vec& s) const;
+  void ancestors(const index_set& s0, bool_vec& s) const;
+  void ancestors(index_type n0, index_set& s) const;
+  void ancestors(const index_set& s0, index_set& s) const;
+  index_type max_out_degree() const;
+  index_type max_in_degree() const;
+  index_type max_bi_degree() const;
+  index_type min_out_degree() const;
+  index_type min_in_degree() const;
+  index_type min_bi_degree() const;
+  bool empty() const;
+  bool connected() const;
+  bool strongly_connected() const;
+  bool reachable(index_type n0, index_type n1) const;
+  void reachable(bool_vec& v) const;
+  index_type count_reachable(index_type n0) const;
+  bool acyclic() const;
+  bool top_sort(index_vec& s) const;
+  index_type first_root() const;
+  index_type first_leaf() const;
+  void fringe(const index_set& n, index_set& fn) const;
+  void bi_fringe(const index_set& n, index_set& fn) const;
+  void distance(index_type s0, index_vec& d) const;
+  void distance(const index_set& s0, index_vec& d) const;
+  index_type distance(index_type s0, index_type s1) const;
+  void strongly_connected_components();
+  index_type component(index_type i) const { return comp[i]; };
+  index_type n_components() const { return n_comp; };
+  index_type component_node(index_type i) const;
+  index_type component_size(index_type i) const;
+  void component_node_set(index_type i, index_set& set) const;
+  graph& component_tree(graph& cg) const;
+  equivalence& component_partitioning(equivalence& eq) const;
+  index_type maximal_non_unit_component() const;
+  graph& subgraph(graph& g, const index_set& n) const;
+  graph& edge_subgraph(graph& g, const index_set& nodes) const;
+  equivalence& induced_partitioning(equivalence& eq) const;
+  graph& induced_undirected_graph(graph& g) const;
+  graph& minimal_equivalent_digraph(graph& g) const;
+  graph& minimal_distance_graph(graph& g, const index_set& s0) const;
+  graph& quotient(graph& g, const equivalence& eq) const;
+  bool equals(const graph& g) const;
+  bool equals(const graph& g, const index_vec& c) const;
+  void difference(const graph& g,
+    const index_vec& c,
+    pair_set& d0,
+    pair_set& d1) const;
+  void difference(const graph& g,
+    pair_set& d0,
+    pair_set& d1) const;
+  index_type cardinality_of_difference(const graph& g) const;
+  void init(index_type s);
+  void copy(const graph& g);
+  void copy(const graph& g, const index_vec& map);
+  void copy_and_rename(const graph& g, const index_vec& map);
+  index_type add_node();
+  void remove_node(index_type n);
+  void add_graph(const graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge_to_transitive_closure(index_type src,
+          index_type dst,
+          pair_set& e);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_edges(const pair_set& e);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void recalculate();
+  void complement();
+  void complement_with_loops();
+  void remove_loops();
+  void reverse();
+  void transitive_closure();
+  void missing_transitive_edges(pair_set& e) const;
+  void transitive_reduction();
+  void intersect(const graph& g);
+  void randomize(count_type n, RNG& rnd);
+  void randomize_connected(count_type n, RNG& rnd);
+  void randomize_strongly_connected(count_type n, RNG& rnd);
+  void random_digraph(count_type n, RNG& rnd);
+  void random_connected_digraph(count_type n, RNG& rnd);
+  void random_strongly_connected_digraph(count_type n, RNG& rnd);
+  void random_digraph_with_density(rational density, RNG& rnd);
+  void random_tree(RNG& rnd);
+  void random_tree(index_type b, index_type d, RNG& rnd);
+  bool is_clique(const index_set& nodes) const;
+  bool is_independent(const index_set& nodes) const;
+  bool is_independent_range(index_type l, index_type u) const;
+  void maximal_clique(index_set& clique) const;
+  void maximal_clique_including(index_type node, index_set& clique) const;
+  void maximal_clique_cover(index_set_vec& sets) const;
+  void all_maximal_cliques(index_set_vec& cliques) const;
+  void all_maximal_cliques_including(index_type node, index_set_vec& cliques)
+    const;
+  void apx_independent_set(index_set& set) const;
+  void apx_independent_set_including(index_type node, index_set& set) const;
+  void apx_independent_set_cover(index_set_vec& sets) const;
+  void apx_independent_set_disjoint_cover(index_set_vec& sets) const;
+  void all_nondominated_cliques(index_set_vec &cliques) const;
+  void all_cliques_geq(index_type k, index_set_vec& cliques) const;
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_undirected_edge_set(::std::ostream& s) const;
+  void write_adjacency_lists(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       const char* name) const;
+  void write_component_labeled_digraph(::std::ostream& s,
+           const char* name) const;
+  void write_graph_correspondance(::std::ostream& s,
+      const graph& g,
+      const index_vec& c,
+      const char* name) const;
+ public:
+  void max_clique(index_set& sel,
+    index_type next,
+    index_set& clique) const;
+  void all_max_cliques(index_set& sel,
+         index_type next,
+         index_set_vec& cliques) const;
+  void all_nondominated_cliques_aux(index_set_vec &cliques,
+                                    index_set &current_clique,
+                                    const index_set &candidates,
+        index_type min) const;
+  void ramsey(const index_set& nodes, index_set& I, index_set& C) const;
+  void apx_independent_set(const index_set& nodes, index_set& set) const;
+  void undirected_dfs(index_type n, bool_vec& visited) const;
+  void reachable(index_type n, bool_vec& v) const;
+  void reverse_reachable(index_type n, bool_vec& v) const;
+ private:
+  void scc_first_dfs(index_type n, bool_vec& visited, index_vec& num) const;
+  void scc_second_dfs(index_type n, bool_vec& visited, index_type c_id);
+};
+template<class LS>
+void write_labeled_digraph
+(std::ostream& s,
+ const graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << "{" << std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << ::std::endl;
+  }
+  s << "node [width=0,height=0];" << ::std::endl;
+  for (index_type k = 0; k < g.size(); k++) {
+    if (with_node_indices) {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"(" << k << ") " << ls[k] << "\"];"
+ << ::std::endl;
+    }
+    else {
+      s << "\t" << k + (c_id == no_such_index ? 0 : c_id)
+ << " [label=\"" << ls[k] << "\"];"
+ << ::std::endl;
+    }
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j))
+ s << "\t" << i + (c_id == no_such_index ? 0 : c_id)
+   << " -> " << j + (c_id == no_such_index ? 0 : c_id)
+   << ";" << ::std::endl;
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+typedef lvector<graph> graph_vec;
+template<class N, class E> class labeled_graph : public graph {
+ public:
+  typedef std::map<index_type, N> node_label_map;
+  typedef std::map<index_pair, E> edge_label_map;
+  typedef lvector<N> node_label_vec;
+  typedef lvector<E> edge_label_vec;
+ protected:
+  node_label_map _node_label;
+  edge_label_map _edge_label;
+ public:
+  labeled_graph();
+  labeled_graph(index_type size);
+  labeled_graph(const graph& g);
+  labeled_graph(const labeled_graph& g);
+  labeled_graph(const graph& g, const index_set& nodes);
+  labeled_graph(const labeled_graph& g, const index_set& nodes);
+  labeled_graph(const graph& g, const equivalence& eq);
+  ~labeled_graph();
+  N& node_label(index_type n);
+  E& edge_label(index_type i, index_type j);
+  const N& node_label(index_type n) const;
+  const E& edge_label(index_type i, index_type j) const;
+  bool node_has_label(index_type n) const;
+  bool edge_has_label(index_type i, index_type j) const;
+  labeled_graph& subgraph(labeled_graph& g, const index_set& n) const;
+  index_type node_with_label(const N& l) const;
+  index_pair edge_with_label(const E& l) const;
+  void init(index_type size);
+  void init(index_type size, const N& n, const E& e);
+  void copy(const graph& g);
+  void copy(const labeled_graph& g);
+  void add_graph(const graph& g, mapping& m);
+  void add_graph(const labeled_graph& g, mapping& m);
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, const E& lbl);
+  void add_edge(const index_set& srcs, index_type dst);
+  void add_edge(const index_set& srcs, index_type dst, const E& lbl);
+  void add_edge(index_type src, const index_set& dsts);
+  void add_edge(index_type src, const index_set& dsts, const E& lbl);
+  index_type add_node();
+  index_type add_node(const N& l);
+  void remove_node(index_type n);
+  void remove_edge(index_type src, index_type dst);
+  void remove_edges_from(index_type src);
+  void remove_edges_to(index_type dst);
+  void remove_edges_incident_on(index_type n);
+  void remove_undirected_edge(index_type n0, index_type n1);
+  void remove_edges(const pair_set& e);
+  void remove_undirected_edges(const pair_set& e);
+  void clear_edges();
+  void clear_node_labels();
+  void clear_edge_labels();
+  void remove_edges_with_label(const E& l);
+  void write_digraph(::std::ostream& s,
+       bool with_node_indices,
+       bool with_node_labels,
+       bool with_edge_labels,
+       bool compact_edges,
+       const char* name) const;
+  void write_matrix(::std::ostream& s,
+      const char* unlabeled_edge,
+      const char* missing_edge) const;
+};
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph()
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(index_type s)
+  : graph(s)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g)
+  : graph(g)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const labeled_graph& g)
+  : graph(g), _node_label(g._node_label), _edge_label(g._edge_label)
+{
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph(const graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const labeled_graph& g, const index_set& n)
+{
+  g.subgraph(*this, n);
+}
+template<class N, class E>
+labeled_graph<N,E>::labeled_graph
+(const graph& g, const equivalence& eq)
+{
+  g.quotient(*this, eq);
+}
+template<class N, class E>
+labeled_graph<N,E>::~labeled_graph()
+{
+}
+template<class N, class E>
+N& labeled_graph<N,E>::node_label(index_type n)
+{
+  assert(n < size());
+  return _node_label[n];
+}
+template<class N, class E>
+E& labeled_graph<N,E>::edge_label(index_type i, index_type j)
+{
+  assert((i < size()) && (j < size()));
+  return _edge_label[index_pair(i, j)];
+}
+template<class N, class E>
+const N& labeled_graph<N,E>::node_label(index_type n) const
+{
+  assert(node_has_label(n));
+  return (_node_label.find(n)->second);
+}
+template<class N, class E>
+const E& labeled_graph<N,E>::edge_label(index_type i, index_type j) const
+{
+  assert(edge_has_label(i, j));
+  return (_edge_label.find(index_pair(i, j))->second);
+}
+template<class N, class E>
+bool labeled_graph<N,E>::node_has_label(index_type n) const
+{
+  assert(n < size());
+  return (_node_label.find(n) != _node_label.end());
+}
+template<class N, class E>
+bool labeled_graph<N,E>::edge_has_label(index_type i, index_type j) const
+{
+  assert((i < size()) && (j < size()));
+  return (_edge_label.find(index_pair(i, j)) != _edge_label.end());
+}
+template<class N, class E>
+void labeled_graph<N,E>::init(index_type s)
+{
+  graph::init(s);
+  _node_label.clear();
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::copy(const labeled_graph& g)
+{
+  graph::copy(g);
+  _node_label = g._node_label;
+  _edge_label = g._edge_label;
+}
+template<class N, class E>
+labeled_graph<N,E>& labeled_graph<N,E>::subgraph
+(labeled_graph& g, const index_set& n) const
+{
+  g.init(n.length());
+  for (index_type k = 0; k < n.length(); k++) {
+    assert(n[k] < size());
+    if (node_has_label(n[k])) {
+      g.node_label(k) = node_label(n[k]);
+    }
+  }
+  for (index_type i = 0; i < n.length(); i++)
+    for (index_type j = 0; j < n.length(); j++)
+      if (adjacent(n[i], n[j])) {
+ g.add_edge(i, j);
+ if (edge_has_label(n[i], n[j])) {
+   g.edge_label(i, j) = edge_label(n[i], n[j]);
+ }
+      }
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::node_with_label(const N& l) const
+{
+  for (index_type k = 0; k < size(); k++)
+    if (node_has_label(k))
+      if (node_label(k) == l)
+ return k;
+  return no_such_index;
+}
+template<class N, class E>
+index_pair labeled_graph<N,E>::edge_with_label(const E& l) const
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && edge_has_label(i, j))
+ if (edge_label(i, j) == l)
+   return index_pair(i, j);
+  return no_such_index;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_graph
+(const labeled_graph& g, mapping& m)
+{
+  graph::add_graph(g, m);
+  for (index_type i = 0; i < g.size(); i++) {
+    if (g.node_has_label(i))
+      node_label(m[i]) = g.node_label(i);
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j) && g.edge_has_label(i, j))
+ edge_label(m[i], m[j]) = g.edge_label(i, j);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst)
+{
+  graph::add_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, index_type dst, const E& lbl)
+{
+  graph::add_edge(src, dst);
+  edge_label(src, dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst)
+{
+  graph::add_edge(srcs, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(const index_set& srcs, index_type dst, const E& lbl)
+{
+  graph::add_edge(srcs, dst);
+  for (index_type k = 0; k < srcs.length(); k++)
+    edge_label(srcs[k], dst) = lbl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts)
+{
+  graph::add_edge(src, dsts);
+}
+template<class N, class E>
+void labeled_graph<N,E>::add_edge
+(index_type src, const index_set& dsts, const E& lbl)
+{
+  graph::add_edge(src, dsts);
+  for (index_type k = 0; k < dsts.length(); k++)
+    edge_label(src, dsts[k]) = lbl;
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node()
+{
+  return graph::add_node();
+}
+template<class N, class E>
+index_type labeled_graph<N,E>::add_node(const N& l)
+{
+  index_type n = graph::add_node();
+  node_label(n) = l;
+  return n;
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_node(index_type n)
+{
+  assert(n < size());
+  labeled_graph g(*this);
+  index_set ns;
+  ns.fill(size());
+  ns.subtract(n);
+  g.subgraph(*this, ns);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edge(index_type src, index_type dst)
+{
+  _edge_label.erase(index_pair(src, dst));
+  graph::remove_edge(src, dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edge(index_type n0, index_type n1)
+{
+  _edge_label.erase(index_pair(n0, n1));
+  _edge_label.erase(index_pair(n1, n0));
+  graph::remove_undirected_edge(n0, n1);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_from(index_type src)
+{
+  index_set ns(successors(src));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(src, ns[k]);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_to(index_type dst)
+{
+  index_set ns(predecessors(dst));
+  for (index_type k = 0; k < ns.length(); k++)
+    remove_edge(ns[k], dst);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_incident_on(index_type n)
+{
+  remove_edges_from(n);
+  remove_edges_to(n);
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_undirected_edges(const pair_set& e)
+{
+  for (index_type k = 0; k < e.length(); k++) {
+    remove_undirected_edge(e[k].first, e[k].second);
+  }
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edges()
+{
+  _edge_label.clear();
+  graph::clear_edges();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_node_labels()
+{
+  _node_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::clear_edge_labels()
+{
+  _edge_label.clear();
+}
+template<class N, class E>
+void labeled_graph<N,E>::remove_edges_with_label(const E& l)
+{
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j) && (edge_label(i, j) == l))
+ remove_edge(i, j);
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_digraph
+(::std::ostream& s,
+ bool with_node_indices,
+ bool with_node_labels,
+ bool with_edge_labels,
+ bool compact_edges,
+ const char* name) const
+{
+  if (strncmp(name, "cluster", 7) == 0)
+    s << "subgraph";
+  else
+    s << "digraph";
+  s << " \"" << name << "\"" << ::std::endl << "{" << ::std::endl;
+  if (with_node_indices || with_node_labels) {
+    s << "\tnode [shape=ellipse];" << ::std::endl;
+  }
+  else {
+    s << "\tnode [shape=point];" << ::std::endl;
+  }
+  for (index_type i = 0; i < size(); i++) {
+    s << "\t" << i;
+    if (with_node_indices || with_node_labels) {
+      s << " [label=\"";
+      if (with_node_indices) {
+ if (with_node_labels) {
+   s << i << ": ";
+   if (node_has_label(i)) {
+     s << node_label(i);
+   }
+ }
+ else {
+   s << i;
+ }
+      }
+      else {
+ if (node_has_label(i)) {
+   s << node_label(i);
+ }
+      }
+      s << "\"]";
+    }
+    s << ";" << std::endl;
+  }
+  for (index_type i = 0; i < size(); i++)
+    for (index_type j = 0; j < size(); j++)
+      if (adjacent(i, j)) {
+ if (adjacent(j, i) && compact_edges) {
+   if (i < j) {
+     s << "\t" << i << " -> " << j;
+     s << " [dir=both";
+     if (with_edge_labels &&
+  (edge_has_label(i, j) || edge_has_label(j, i))) {
+       if (!edge_has_label(i, j)) {
+  s << ",label=\"" << edge_label(j, i) << "\"";
+       }
+       else if (!edge_has_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else if (edge_label(i, j) == edge_label(j, i)) {
+  s << ",label=\"" << edge_label(i, j) << "\"";
+       }
+       else {
+  s << ",label=\"" << edge_label(i, j) << ", "
+    << edge_label(j, i) << "\"";
+       }
+     }
+     s << "]" << ::std::endl;
+   }
+ }
+ else {
+   s << "\t" << i << " -> " << j;
+   if (with_edge_labels && edge_has_label(i, j)) {
+     s << " [label=\"" << edge_label(i, j) << "\"]";
+   }
+   s << ";" << ::std::endl;
+ }
+      }
+  s << "}" << ::std::endl;
+}
+template<class N, class E>
+void labeled_graph<N,E>::write_matrix
+(::std::ostream& s, const char* unlabeled_edge, const char* missing_edge) const
+{
+  s << '[';
+  for (index_type i = 0; i < size(); i++) {
+    if (i > 0) s << ' ';
+    s << '[';
+    for (index_type j = 0; j < size(); j++) {
+      if (j > 0) s << ',';
+      if (adjacent(i, j)) {
+ if (edge_has_label(i, j)) {
+   s << edge_label(i, j);
+ }
+ else {
+   s << unlabeled_edge;
+ }
+      }
+      else {
+ s << missing_edge;
+      }
+    }
+    s << ']';
+    if (i + 1 < size()) {
+      s << ',' << '\n';
+    }
+    else {
+      s << ']' << '\n';
+    }
+  }
+}
+class index_graph : public labeled_graph<index_type,index_type> {
+  static const index_type NODE_SHAPE = 2 + 4 + 8 + 16;
+  static const index_type NODE_STYLE = 64 + 128 + 256;
+  static const index_type EDGE_STYLE = 64 + 128;
+  static const index_type EDGE_DIR = 512 + 1024;
+ public:
+  static const index_type NS_CIRCLE = 0;
+  static const index_type NS_ELLIPSE = 2;
+  static const index_type NS_BOX = 4;
+  static const index_type NS_POINT = 6;
+  static const index_type NS_DIAMOND = 8;
+  static const index_type NS_HEXAGON = 10;
+  static const index_type NS_OCTAGON = 12;
+  static const index_type NS_PLAINTEXT = 14;
+  static const index_type NS_NORMAL = 0;
+  static const index_type NS_DOUBLE = 32;
+  static const index_type NS_BOLD = 64;
+  static const index_type NS_DASHED = 128;
+  static const index_type NS_DOTTED = 192;
+  static const index_type NS_FILLED = 256;
+  static const index_type ED_NONE = 0;
+  static const index_type ED_FORWARD = 512;
+  static const index_type ED_BACK = 1024;
+  static const index_type ED_BOTH = ED_FORWARD + ED_BACK;
+  static const index_type ES_NORMAL = NS_NORMAL;
+  static const index_type ES_BOLD = NS_BOLD;
+  static const index_type ES_DASHED = NS_DASHED;
+  static const index_type ES_DOTTED = NS_DOTTED;
+  static const index_type STYLE_MAX = 2048;
+  index_graph()
+    : labeled_graph<index_type, index_type>() { };
+  index_graph(index_type size)
+    : labeled_graph<index_type, index_type>(size) { };
+  index_graph(const graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const index_graph& g)
+    : labeled_graph<index_type, index_type>(g) { };
+  index_graph(const graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const index_graph& g, const index_set& nodes)
+    : labeled_graph<index_type, index_type>(g, nodes) { };
+  index_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<index_type, index_type>(g, eq) { };
+  ~index_graph() { };
+  void reverse();
+  void reflect();
+  static void write_node_style(std::ostream& s, index_type l);
+  static void write_edge_style(std::ostream& s, index_type l);
+  void write_styled_digraph(std::ostream& s,
+       bool with_node_indices = false,
+       const char* name = 0,
+       index_type c_id = no_such_index) const;
+  void write_matrix(std::ostream& s) const;
+  void write_MATLAB(std::ostream& s,
+      const char* n,
+      const char* t) const;
+};
+template<class LS>
+void write_styled_digraph
+(std::ostream& s,
+ const index_graph& g,
+ const LS& ls,
+ bool with_node_indices = false,
+ const char* name = 0,
+ index_type c_id = no_such_index)
+{
+  if (c_id != no_such_index) {
+    s << "subgraph cluster" << c_id << " {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  else if (name) {
+    s << "digraph \"" << name << "\" {" << std::endl;
+    s << "node [width=0.5,height=0.5];" << ::std::endl;
+  }
+  for (index_type k = 0; k < g.size(); k++) {
+    s << "\t" << k + (c_id != no_such_index ? c_id : 0) << " [";
+    index_graph::write_node_style(s, g.node_has_label(k) ? g.node_label(k) : 0);
+    if (with_node_indices)
+      s << ",label=\"(" << k << ") " << ls[k] << "\"];" << std::endl;
+    else
+      s << ",label=\"" << ls[k] << "\"];" << std::endl;
+  }
+  for (index_type i = 0; i < g.size(); i++)
+    for (index_type j = 0; j < g.size(); j++)
+      if (g.adjacent(i, j)) {
+ s << "\t" << i + (c_id != no_such_index ? c_id : 0)
+   << " -> " << j + (c_id != no_such_index ? c_id : 0) << " [";
+ index_graph::write_edge_style(s, g.edge_has_label(i, j) ? g.edge_label(i, j) : 0);
+ s << "];" << std::endl;
+      }
+  if ((c_id != no_such_index) || (name != 0)) {
+    s << "}" << ::std::endl;
+  }
+}
+class weighted_graph : public labeled_graph<hsps::rational,hsps::rational> {
+ public:
+  weighted_graph() { };
+  weighted_graph(index_type s)
+    : labeled_graph<hsps::rational,hsps::rational>(s) { };
+  weighted_graph(const graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const weighted_graph& g)
+    : labeled_graph<hsps::rational,hsps::rational>(g) { };
+  weighted_graph(const graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const weighted_graph& g, const index_set& n)
+    : labeled_graph<hsps::rational,hsps::rational>(g, n) { };
+  weighted_graph(const graph& g, const equivalence& eq)
+    : labeled_graph<hsps::rational,hsps::rational>(g, eq) { };
+  weighted_graph(const weighted_graph& g, const equivalence& eq);
+  ~weighted_graph() { };
+  weighted_graph& quotient(weighted_graph& g, const equivalence& eq) const;
+  hsps::rational apx_weighted_independent_set_1(index_set& set) const;
+  hsps::rational apx_weighted_independent_set_2(index_set& set) const;
+  hsps::rational apx_weighted_independent_set(index_set& set) const;
+  void add_edge(index_type src, index_type dst);
+  void add_edge(index_type src, index_type dst, hsps::rational w);
+  void add_undirected_edge(index_type n0, index_type n1);
+  void add_undirected_edge(index_type n0, index_type n1, hsps::rational w);
+  hsps::rational weight(index_type n) const;
+  hsps::rational weight(index_type n0, index_type n1) const;
+  hsps::rational weight(const index_set& ns) const;
+  void set_weight(index_type n, hsps::rational w);
+  void set_weight(index_type n0, index_type n1, hsps::rational w);
+  void increment_edge_weight(index_type src, index_type dst, hsps::rational w);
+  hsps::rational max_node_weight() const;
+  void transitive_closure();
+  hsps::rational critical_path(cost_vec& s);
+  hsps::rational max_flow(index_type s, index_type t);
+  hsps::rational max_flow(index_type s, index_type t, weighted_graph& rg);
+  hsps::rational max_flow(index_type s, index_type t, cost_matrix& f);
+  hsps::rational min_cut(index_type s, index_type t, bool_vec& s_set);
+  hsps::rational min_cut(index_type s, index_type t, pair_set& e_set);
+  index_pair max_weight_edge() const;
+  void min_and_max_edges(const index_set& nodes,
+    pair_set& e_min, hsps::rational& w_min,
+    pair_set& e_max, hsps::rational& w_max) const;
+  hsps::rational maximal_matching(weighted_graph& matching);
+  hsps::rational apx_matching(bool_vec& nodes);
+  void write_node_set(::std::ostream& s) const;
+  void write_edge_set(::std::ostream& s) const;
+  void write_compact(::std::ostream& s) const;
+  void write_matrix(::std::ostream& s) const;
+ private:
+  hsps::rational augmenting_path(index_type s, index_type t, const cost_matrix& f,
+   pair_vec& p);
+};
+class index_set_graph : public labeled_graph<index_set,index_set> {
+ public:
+  index_set_graph() { };
+  index_set_graph(index_type s)
+    : labeled_graph<index_set,index_set>(s) { };
+  index_set_graph(const graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const index_set_graph& g)
+    : labeled_graph<index_set,index_set>(g) { };
+  index_set_graph(const graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const index_set_graph& g, const index_set& n)
+    : labeled_graph<index_set,index_set>(g, n) { };
+  index_set_graph(const graph& g, const equivalence& eq);
+  index_set_graph(const index_set_graph& g, const equivalence& eq);
+  ~index_set_graph() { };
+  void union_reachable();
+  void merge_labels(const index_set& ns);
+  void merge_labels_upwards();
+  void merge_labels_downwards();
+  index_set_graph& quotient(index_set_graph& g, const equivalence& eq) const;
+  index_set_graph& union_reachable(index_set_graph& g) const;
+  index_set_graph& subgraph_set_size_gt(index_set_graph& g, index_type l);
+  void write_edge_set(::std::ostream& s) const;
+  void write_digraph(::std::ostream& s, const char* name) const;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const weighted_graph& g)
+{
+  g.write_compact(s);
+  return s;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const index_set_graph& g)
+{
+  g.write_edge_set(s);
+  return s;
+};
+}
+namespace hsps {
+class Heuristic;
+struct rule {
+  index_set antecedent;
+  index_type consequent;
+  rule() : antecedent(EMPTYSET), consequent(no_such_index) { };
+  rule(index_type c) : antecedent(EMPTYSET), consequent(c) { };
+  rule(const index_set& a, index_type c) : antecedent(a), consequent(c) { };
+  rule(const rule& r) : antecedent(r.antecedent), consequent(r.consequent) { };
+  rule& operator=(const rule& r) {
+    antecedent = r.antecedent;
+    consequent = r.consequent;
+    return *this;
+  };
+  bool operator==(const rule& r) const {
+    return ((antecedent == r.antecedent) && (consequent == r.consequent));
+  };
+  bool operator!=(const rule& r) const {
+    return (!(*this == r));
+  };
+  bool operator<(const rule& r) const {
+    return ((consequent < r.consequent) ||
+     ((consequent == r.consequent) && (antecedent < r.antecedent)));
+  };
+  bool operator>(const rule& r) const {
+    return ((consequent > r.consequent) ||
+     ((consequent == r.consequent) && (antecedent > r.antecedent)));
+  };
+};
+class rule_set : public svector<rule> {
+ public:
+  index_type find_rule(index_type c) const;
+  void compute_dependency_graph(index_type n, index_graph& g) const;
+  void remove(const bool_vec& set, index_vec& map);
+  void remove(const bool_vec& set, index_graph& g);
+  void remove(const bool_vec& set);
+  void make_acyclic(index_graph& g);
+  void make_post_unique(index_graph& g);
+};
+typedef svector<const char*> string_set;
+class Instance {
+  bool xrf;
+ public:
+  static bool write_negation;
+  static bool write_DKEL;
+  static bool write_PDDL2;
+  static bool write_time;
+  static bool write_PDDL3;
+  static bool write_metric;
+  static bool write_extra;
+  static bool write_resource_constraints_at_start;
+  static bool always_write_parameters;
+  static bool always_write_requirements;
+  static bool always_write_precondition;
+  static bool always_write_effect;
+  static bool always_write_conjunction;
+  static bool write_atom_set_with_symbolic_names;
+  static bool write_action_set_with_symbolic_names;
+  static const char* goal_atom_name;
+  static const char* goal_action_name;
+  static hsps::rational goal_action_cost;
+  static const char* pc_name;
+  static index_type pc_count;
+  struct Atom {
+    const Name* name;
+    index_type index;
+    index_type neg;
+    bool init;
+    hsps::rational init_t;
+    bool goal;
+    hsps::rational goal_t;
+    bool irrelevant;
+    void* src;
+    index_vec req_by;
+    index_vec add_by;
+    index_vec del_by;
+    Atom() : name(0), index(no_such_index), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n) : name(n), index(0), neg(no_such_index),
+  init(false), init_t(0), goal(false), goal_t(POS_INF),
+  irrelevant(false), src(0), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom(const Name* n, index_type i) : name(n), index(i),
+  neg(no_such_index), init(false), init_t(0), goal(false),
+  goal_t(POS_INF),
+  irrelevant(false), req_by(no_such_index, 0),
+  add_by(no_such_index, 0), del_by(no_such_index, 0) { };
+    Atom& operator=(const Atom& a) {
+      name = a.name;
+      index = a.index;
+      neg = a.neg;
+      init = a.init;
+      init_t = a.init_t;
+      goal = a.goal;
+      goal_t = a.goal_t;
+      irrelevant = a.irrelevant;
+      src = a.src;
+      req_by = a.req_by;
+      add_by = a.add_by;
+      del_by = a.del_by;
+      return *this;
+    };
+    bool operator==(const Atom& a) {
+      return (index == a.index);
+    };
+  };
+  struct Resource {
+    const Name* name;
+    index_type index;
+    hsps::rational init;
+    void* src;
+    bool consumed;
+    bool used;
+    Resource() : name(0), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n) : name(n), index(no_such_index), init(0), src(0),
+  consumed(false), used(false) { };
+    Resource(const Name* n, index_type i) : name(n), index(i), init(0),
+  src(0), consumed(false), used(false) { };
+    Resource& operator=(const Resource& r) {
+      name = r.name;
+      index = r.index;
+      init = r.init;
+      src = r.src;
+      consumed = r.consumed;
+      used = r.used;
+      return *this;
+    };
+    bool operator==(const Resource& r) {
+      return (index == r.index);
+    };
+    bool reusable() const { return (used && !consumed); };
+    bool consumable() const { return (consumed); };
+  };
+  struct Action {
+    const Name* name;
+    index_type index;
+    bool sel;
+    index_set pre;
+    index_set add;
+    index_set del;
+    index_set lck;
+    amt_vec use;
+    amt_vec cons;
+    hsps::rational dur;
+    hsps::rational dmin;
+    hsps::rational dmax;
+    hsps::rational cost;
+    const char* assoc;
+    void* src;
+    index_set ncw_atms;
+    Action()
+      : name(0), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+  assoc(0), src(0), ncw_atms() { };
+    Action(const Name* n)
+      : name(n), index(no_such_index), sel(true), pre(), add(), del(),
+        lck(), use(ZERO, 0), cons(ZERO, 0), dur(1), dmin(1), dmax(1), cost(1),
+ assoc(0), src(0), ncw_atms() { };
+    Action& operator=(const Action& a) {
+      name = a.name;
+      index = a.index;
+      sel = a.sel;
+      pre = a.pre;
+      add = a.add;
+      del = a.del;
+      lck = a.lck;
+      use = a.use;
+      cons = a.cons;
+      dur = a.dur;
+      dmin = a.dmin;
+      dmax = a.dmax;
+      cost = a.cost;
+      assoc = a.assoc;
+      src = a.src;
+      ncw_atms = a.ncw_atms;
+      return *this;
+    };
+    bool operator==(const Action& a) {
+      return (index == a.index);
+    };
+    hsps::rational req(index_type r) const { return use[r] + cons[r]; };
+    bool e_deletes(index_type p, Heuristic* inc) const;
+    bool e_deletes(const index_set& s, Heuristic* inc) const;
+  };
+  struct Constraint {
+    const Name* name;
+    index_type index;
+    index_set set;
+    index_type lim;
+    bool exact;
+    void* src;
+    bool verified;
+    Constraint() : name(0), index(no_such_index), set(), lim(0),
+  exact(false), src(0), verified(false) { };
+    Constraint(const Name* n) : name(n), index(no_such_index),
+  set(), lim(0), exact(false), src(0), verified(false) { };
+    Constraint(index_set s, index_type n, bool e) : name(0),
+  index(no_such_index), set(s), lim(n), exact(e), src(0),
+  verified(false) { };
+    Constraint& operator=(const Constraint& c) {
+      name = c.name;
+      index = c.index;
+      set = c.set;
+      lim = c.lim;
+      exact = c.exact;
+      src = c.src;
+      verified = c.verified;
+      return *this;
+    };
+    bool operator==(const Constraint& c) {
+      return ((set == c.set) && (lim == c.lim) && (exact == c.exact));
+    };
+  };
+  typedef lvector<Atom> atom_vec;
+  typedef lvector<Resource> resource_vec;
+  typedef lvector<Action> action_vec;
+  typedef lvector<Constraint> constraint_vec;
+  typedef atom_vec::element_reference atom_ref;
+  typedef resource_vec::element_reference resource_ref;
+  typedef action_vec::element_reference action_ref;
+  typedef constraint_vec::element_reference constraint_ref;
+  const Name* name;
+  atom_vec atoms;
+  action_vec actions;
+  resource_vec resources;
+  constraint_vec invariants;
+  index_set init_atoms;
+  index_set goal_atoms;
+  index_type max_pre, max_add, max_del, max_lck,
+               max_add_by, max_del_by, max_req_by;
+  hsps::rational min_dur, max_dur, min_cost, max_cost;
+  set_hash_function atom_set_hash;
+  set_hash_function action_set_hash;
+  static int default_trace_level;
+  int trace_level;
+  Instance();
+  Instance(const Name* n);
+  Instance(const Instance& ins);
+  ~Instance() { };
+  Atom& new_atom(const Name* name);
+  Resource& new_resource(const Name* name);
+  Action& new_action(const Name* name);
+  Action& copy_action(index_type a);
+  Constraint& new_invariant();
+  Constraint& new_invariant(const Name* name);
+  Constraint& new_invariant(const index_set& s, index_type l, bool e);
+  void copy(const Instance& ins);
+  Instance* copy() const;
+  void clear();
+  void restricted_copy(const Instance& ins, const index_set& atms,
+         const index_set& rc, index_set& acts, index_vec& map);
+  void restricted_copy(const Instance& ins, const index_set& acts,
+         index_vec& map);
+  void abstracted_copy(const Instance& ins, const index_set& atms,
+         index_vec& atm_map, index_vec& act_map);
+  void reverse_copy(const Instance& ins);
+  void delete_relax(const index_set& x_atms);
+  void delete_relax_less(const index_set& x_atms);
+  void assign_unique_action_names();
+  void remove_actions(const bool_vec& set, index_vec& map);
+  void remove_atoms(const bool_vec& set, index_vec& map);
+  void remove_invariants(const bool_vec& set, index_vec& map);
+  void remap_set(index_set& set, const index_vec& map);
+  void remap_sets(index_set_vec& sets, const index_vec& map);
+  void set_initial(const index_set& init);
+  void set_goal(const index_set& goal);
+  void set_DNF_goal(const index_set_vec& goal);
+  void replace_atom_by_conjunction(index_type p, const index_set& c);
+  void set_cost_bound(hsps::rational b);
+  void create_composite_resource(const index_set& set);
+  void create_total_resource();
+  void extract_atom_negations_from_invariants();
+  index_type complete_atom_negation(index_type a);
+  void complete_atom_negations(const index_set& s);
+  void complete_atom_negations();
+  index_type create_history_atom(index_type a);
+  void add_all_negation_invariants();
+  void add_missing_negation_invariants();
+  index_type compile_pc_always(const index_set& f, const Name* n);
+  index_type compile_pc_sometime(const index_set& f, const Name* n);
+  index_type compile_pc_at_most_once(const index_set& f, const Name* n);
+  index_type compile_pc_sometime_before(const index_set& f_t,
+     const index_set& f_c,
+     const Name* n);
+  void enforce_pc_always(const index_set& f, const Name* n);
+  void enforce_pc_sometime(const index_set& f, const Name* n);
+  void enforce_pc_at_most_once(const index_set& f, const Name* n);
+  void enforce_pc_sometime_before(const index_set& f_t,
+      const index_set& f_c,
+      const Name* n);
+  void compute_iff_axioms(rule_set& ax);
+  void cross_reference();
+  void clear_cross_reference();
+  bool cross_referenced() const;
+  bool verify_invariant(Constraint& inv);
+  void verify_invariants();
+  void save_durations(cost_vec& out) const;
+  void set_durations(const cost_vec& in);
+  void set_durations(const cost_vec& in, cost_vec& out);
+  void assign_unit_durations(hsps::rational unit = hsps::rational(1));
+  void discretize_durations(hsps::rational interval_width);
+  void quantize_durations(index_type n_intervals);
+  void round_durations_up();
+  void round_durations_down();
+  void round_durations();
+  void assign_unit_costs(cost_vec& save);
+  void restore_costs(const cost_vec& saved);
+  void assign_unlimited_resources(cost_vec& save);
+  void restore_resources(const cost_vec& saved);
+  index_type n_atoms() const { return atoms.length(); };
+  index_type n_resources() const { return resources.length(); };
+  index_type n_reusable_resources() const;
+  index_type n_consumable_resources() const;
+  index_type n_actions() const { return actions.length(); };
+  index_type n_invariants() const { return invariants.length(); };
+  index_type n_verified_invariants() const;
+  void atom_names(name_vec& names) const;
+  void action_names(name_vec& names) const;
+  void coadd_graph(graph& g) const;
+  void cochange_graph(graph& g) const;
+  void causal_graph(graph& g) const;
+  void partitioning_graph(const index_set& goal,
+     index_set_graph& g,
+     index_set& n_goal) const;
+  void make_graph_representation(index_graph& g, name_vec& nn);
+  bool non_interfering(index_type a0, index_type a1) const;
+  bool lock_compatible(index_type a0, index_type a1) const;
+  bool resource_compatible(index_type a0, index_type a1) const;
+  bool commutative(const Action& a0, const Action& a1) const;
+  bool commutative(index_type a0, index_type a1) const;
+  bool additive(index_type p0, index_type p1) const;
+  bool cochanged(index_type p0, index_type p1) const;
+  bool eval_invariant_in_partial_state(const index_set& s,
+           const Constraint& inv);
+  bool eval_invariant_in_partial_state(const bool_vec& s,
+           const Constraint& inv);
+  bool eval_invariant_in_complete_state(const index_set& s,
+     const Constraint& inv);
+  bool eval_invariant_in_complete_state(const bool_vec& s,
+     const Constraint& inv);
+  void negation_atom_set(const index_set& pset, index_set& nset) const;
+  void write_atom_set(::std::ostream& s,
+        const index_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_set(::std::ostream& s,
+        const bool_vec& set,
+        unsigned int c = Name::NC_DEFAULT) const;
+  void write_atom_sets(::std::ostream& s,
+         const index_set_vec& sets,
+         unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const index_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_action_set(::std::ostream& s,
+   const bool_vec& set,
+   unsigned int c = Name::NC_DEFAULT) const;
+  void write_iff_axiom(::std::ostream& s, const rule& r) const;
+  void write_iff_axiom_set(::std::ostream& s, const rule_set& rset) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_digraph(::std::ostream& s,
+     const graph& g,
+     const char* label) const;
+  void write_atom_action_digraph(::std::ostream& s,
+     const graph& g,
+     const index_set& atomset,
+     const index_set& actionset,
+     const bool_vec& mark_shaded,
+     const bool_vec& mark_bold,
+     const bool_vec& mark_dashed,
+     const char* label) const;
+  void write_atom_set_digraph(::std::ostream& s,
+         const index_set_graph& g,
+         const char* label) const;
+  void write_atom_set_graph(::std::ostream& s,
+       const index_set_graph& g,
+       const char* label) const;
+  void write_axiom_dependency_graph(::std::ostream& s,
+        const index_graph& g,
+        const char* label) const;
+  virtual void write_PDDL_action
+    (::std::ostream& s, const Action& act) const;
+  virtual void write_DKEL_invariant_item
+    (::std::ostream& s, const Constraint& inv, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_atom_item
+    (::std::ostream& s, const Atom& atm, string_set& tags) const;
+  virtual void write_DKEL_irrelevant_action_item
+    (::std::ostream& s, const Action& act, string_set& tags) const;
+  virtual void write_domain_atom_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set) const;
+  virtual void write_domain_action_set
+    (::std::ostream& s, const index_set& set, const Name* name) const;
+  virtual void write_domain(::std::ostream& s) const;
+  virtual void write_domain_init(::std::ostream& s) const;
+  virtual void write_domain_declarations(::std::ostream& s) const;
+  virtual void write_domain_actions(::std::ostream& s) const;
+  virtual void write_domain_DKEL_items(::std::ostream& s) const;
+  virtual void write_problem(::std::ostream& s) const;
+  virtual void write_problem_init(::std::ostream& s) const;
+  virtual void write_problem_goal(::std::ostream& s) const;
+  virtual void write_problem_metric(::std::ostream& s) const;
+  void print_atom(::std::ostream& s, const Atom& a) const;
+  void print_resource(::std::ostream& s, const Resource& r) const;
+  void print_action(::std::ostream& s, const Action& a) const;
+  void print_invariant(::std::ostream& s, const Constraint& c) const;
+  virtual void print(::std::ostream& s) const;
+ private:
+  void create_atom_negation(index_type a);
+};
+typedef lvector<Instance*> instance_vec;
+class PreconditionEvaluator {
+  enum eval_node_type { positive_leaf,
+   undecided_leaf,
+   no_test,
+   test_invariant,
+   test_atom };
+  Instance& instance;
+  eval_node_type node_type;
+  index_type i_test;
+  lvector<PreconditionEvaluator*> next;
+  PreconditionEvaluator* prev;
+  index_type n_positive;
+  index_set acts;
+  static void construct(Instance& ins,
+   PreconditionEvaluator* p,
+   bool_vec& s,
+   bool_vec& ua,
+   index_type n_ua,
+   index_type n_pos,
+   bool_vec& rem_invs,
+   bool_vec& rem_atoms,
+   hsps::rational T);
+ public:
+  PreconditionEvaluator(Instance& ins);
+  ~PreconditionEvaluator();
+  static PreconditionEvaluator* construct(Instance& ins, hsps::rational T);
+  PreconditionEvaluator* node(const bool_vec& s);
+  index_type eval(const bool_vec& s,
+    const bool_vec& a,
+    index_type* app,
+    index_type c);
+  void write_graph(std::ostream& s, bool root = true);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule& r)
+{
+  return s << r.antecedent << "->" << r.consequent;
+};
+inline ::std::ostream& operator<<(::std::ostream& s, const rule_set& r)
+{
+  s << '{';
+  for (index_type k = 0; k < r.length(); k++) {
+    if (k > 0) s << ',';
+    s << r[k];
+  }
+  s << '}';
+  return s;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+namespace hsps {
+class SearchResult {
+ public:
+  SearchResult() { };
+  virtual ~SearchResult();
+  virtual void solution(State& s, hsps::rational cost) = 0;
+  virtual void no_more_solutions(hsps::rational cost) = 0;
+  virtual bool more() = 0;
+};
+class Result : public SearchResult {
+ public:
+  enum stop_condition { stop_at_first,
+   stop_at_nth,
+   stop_at_all_optimal,
+   stop_at_all };
+ private:
+  stop_condition sc;
+  count_type find_n;
+  PlanSet* plans;
+  count_type n_found;
+  hsps::rational min_cost;
+  hsps::rational max_ex;
+ public:
+  Result() : sc(stop_at_first), find_n(1), plans(0), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  Result(PlanSet* s) : sc(stop_at_first), find_n(1), plans(s), n_found(0),
+    min_cost(POS_INF), max_ex(NEG_INF) { };
+  virtual ~Result() { };
+  void set_stop_condition(stop_condition c);
+  void set_n_to_find(count_type n);
+  void set_plan_set(PlanSet* s);
+  count_type solution_count();
+  bool search_space_exhausted();
+  void reset();
+  virtual void solution(State& s, hsps::rational cost);
+  virtual void no_more_solutions(hsps::rational cost);
+  virtual bool more();
+};
+class SearchStats : public Search {
+ protected:
+  Statistics& stats;
+  hsps::rational cost_limit;
+  count_type node_limit;
+  count_type node_count;
+  count_type work_limit;
+  count_type work_count;
+  count_type zero_eval_count;
+  void start_count();
+  void stop_count();
+  void reset();
+ public:
+  SearchStats(Statistics& s);
+  SearchStats(Statistics& s, hsps::rational limit);
+  virtual ~SearchStats();
+  void set_cost_limit(hsps::rational c_max);
+  hsps::rational get_cost_limit() const;
+  bool cost_limit_reached() const;
+  void set_node_limit(count_type n);
+  count_type get_node_limit() const;
+  bool node_limit_reached() const;
+  void set_work_limit(count_type n);
+  count_type get_work_limit() const;
+  bool work_limit_reached() const;
+  bool break_signal_raised() const;
+  virtual hsps::rational cost() const = 0;
+  count_type work() const;
+};
+class SearchAlgorithm : public SearchStats {
+  bool is_solved;
+  bool is_optimal;
+ protected:
+  SearchResult& result;
+  const Name* problem_name;
+  int trace_level;
+  void set_solved(bool s, bool o);
+  void set_solved(bool s);
+  void reset();
+ public:
+  static int default_trace_level;
+  void set_problem_name(const Name* n);
+  void set_trace_level(int level);
+  SearchAlgorithm(Statistics& s, SearchResult& r);
+  SearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit);
+  virtual ~SearchAlgorithm();
+  virtual hsps::rational start(State& s, hsps::rational b) = 0;
+  virtual hsps::rational start(State& s) = 0;
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class SingleSearchAlgorithm : public SearchAlgorithm {
+ public:
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  SingleSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~SingleSearchAlgorithm() { };
+  virtual hsps::rational resume() = 0;
+};
+class MultiSearchAlgorithm : public SearchAlgorithm {
+ public:
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r)
+    : SearchAlgorithm(s, r) { };
+  MultiSearchAlgorithm(Statistics& s, SearchResult& r, hsps::rational limit)
+    : SearchAlgorithm(s, r, limit) { };
+  virtual ~MultiSearchAlgorithm() { };
+  virtual hsps::rational resume(State& s, hsps::rational b) = 0;
+  virtual hsps::rational resume(State& s);
+};
+}
+namespace hsps {
+class ACF {
+ public:
+  virtual ~ACF() { };
+  virtual hsps::rational operator()(index_type a) const = 0;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+  virtual hsps::rational cost_gcd(index_type n) const;
+};
+class Heuristic {
+ protected:
+  Instance& instance;
+  int trace_level;
+ public:
+  static count_type eval_count;
+  static int default_trace_level;
+  Heuristic(Instance& ins)
+    : instance(ins), trace_level(default_trace_level) { };
+  virtual ~Heuristic();
+  virtual void set_trace_level(int level);
+  virtual hsps::rational eval(const index_set& s) = 0;
+  virtual hsps::rational eval(const bool_vec& s) = 0;
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+  virtual void store(const index_set& s, hsps::rational v, bool opt);
+  virtual void store(const bool_vec& s, hsps::rational v, bool opt);
+  hsps::rational eval(index_type atom);
+  void compute_heuristic_graph(const ACF& cost, graph& g);
+};
+class ZeroHeuristic : public Heuristic {
+ public:
+  ZeroHeuristic(Instance& ins) : Heuristic(ins) { };
+  virtual ~ZeroHeuristic() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class EvalActionCache : public Heuristic {
+  Heuristic& base_h;
+  cost_vec cache;
+ public:
+  EvalActionCache(Instance& ins, Heuristic& h);
+  virtual ~EvalActionCache() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational eval_precondition(const Instance::Action& a);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RegressionInvariantCheck : public Heuristic {
+  Heuristic& base_h;
+  bool verified_invariants_only;
+ public:
+  RegressionInvariantCheck(Instance& ins, Heuristic& h, bool v)
+    : Heuristic(ins), base_h(h), verified_invariants_only(v) { };
+  virtual ~RegressionInvariantCheck() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class ForwardReachabilityCheck : public Heuristic {
+  index_set goals;
+  bool_vec r;
+  bool_vec f;
+  bool_vec d;
+  hsps::rational compute();
+ public:
+  ForwardReachabilityCheck(Instance& i, const index_set& g);
+  virtual ~ForwardReachabilityCheck();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class Combine2ByMax : public Heuristic {
+  Heuristic& h0;
+  Heuristic& h1;
+ public:
+  Combine2ByMax(Instance& ins, Heuristic& _h0, Heuristic& _h1)
+    : Heuristic(ins), h0(_h0), h1(_h1) { };
+  virtual ~Combine2ByMax() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNByMax : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNByMax(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNByMax() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class CombineNBySum : public Heuristic {
+  lvector<Heuristic*> h_vec;
+ public:
+  CombineNBySum(Instance& ins)
+    : Heuristic(ins), h_vec((Heuristic*)0, 0) { };
+  virtual ~CombineNBySum() { };
+  void add(Heuristic* h) { h_vec.append(h); };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class RoundUp : public Heuristic {
+  Heuristic& h;
+  long d;
+ public:
+  RoundUp(Instance& ins, Heuristic& h0)
+    : Heuristic(ins), h(h0), d(1) { };
+  RoundUp(Instance& ins, Heuristic& h0, long d0)
+    : Heuristic(ins), h(h0), d(d0) { };
+  virtual ~RoundUp() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual hsps::rational eval_to_bound(const index_set& s, hsps::rational bound);
+  virtual hsps::rational eval_to_bound(const bool_vec& s, hsps::rational bound);
+};
+class HX : public Heuristic {
+  Heuristic& h0;
+  index_set X;
+ public:
+  HX(Instance& ins, Heuristic& h, const index_set& x)
+    : Heuristic(ins), h0(h), X(x) { };
+  HX(Instance& ins, Heuristic& h)
+    : Heuristic(ins), h0(h) { };
+  virtual ~HX() { };
+  void setX(const index_set& x) { X = x; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+  virtual void write_eval(const index_set& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+  virtual void write_eval(const bool_vec& s,
+     ::std::ostream& st,
+     char* p = 0,
+     bool e = true);
+};
+class AtomMapAdapter : public Heuristic {
+  index_vec map;
+  Heuristic& base_h;
+ public:
+  AtomMapAdapter(Instance& i, const index_vec& m, Heuristic& h)
+    : Heuristic(i), map(m), base_h(h)
+  { assert(map.length() == instance.n_atoms()); };
+  virtual ~AtomMapAdapter() { };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+  virtual hsps::rational incremental_eval(const index_set& s, index_type i_new);
+  virtual hsps::rational incremental_eval(const bool_vec& s, index_type i_new);
+};
+class CompleteNegationAdapter : public Heuristic {
+  Heuristic& h_base;
+  pair_vec pn_map;
+  bool_vec sc;
+ public:
+  CompleteNegationAdapter(Instance& ins, const pair_vec& p, Heuristic& h);
+  virtual ~CompleteNegationAdapter();
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class CompareEval : public Heuristic {
+  Heuristic& base_h;
+  Heuristic& alt_h;
+  bool max_h_val;
+ public:
+  static count_type lower;
+  static count_type equal;
+  static count_type higher;
+  CompareEval(Instance& i, Heuristic& h0, Heuristic& h1)
+    : Heuristic(i), base_h(h0), alt_h(h1) { }
+  virtual ~CompareEval() { };
+  void set_maximal_heuristic_value(bool on) { max_h_val = on; };
+  virtual hsps::rational eval(const index_set& s);
+  virtual hsps::rational eval(const bool_vec& s);
+};
+class UnitACF : public ACF {
+ public:
+  UnitACF() { };
+  virtual ~UnitACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class ZeroACF : public ACF {
+ public:
+  ZeroACF() { };
+  virtual ~ZeroACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+  virtual hsps::rational min_cost(index_type n) const;
+  virtual hsps::rational max_cost(index_type n) const;
+  virtual hsps::rational avg_cost(index_type n) const;
+};
+class CostACF : public ACF {
+  Instance& instance;
+ public:
+  CostACF(Instance& i) : instance(i) { };
+  virtual ~CostACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class FracACF : public ACF {
+  const ACF& baseACF;
+  cost_vec df;
+ public:
+  FracACF(const ACF& b, index_type l);
+  FracACF(const ACF& b, index_type l, hsps::rational f);
+  virtual ~FracACF();
+  void set(index_type a, hsps::rational f);
+  void set(const index_set& d, hsps::rational f);
+  virtual hsps::rational operator()(index_type a) const;
+};
+class DiscountACF : public ACF {
+  const ACF& baseACF;
+  bool_vec discounted;
+ public:
+  DiscountACF(const ACF& b, index_type l)
+    : baseACF(b), discounted(false, l) { };
+  DiscountACF(const ACF& b, const index_set& d, index_type l)
+    : baseACF(b), discounted(d, l) { };
+  DiscountACF(const ACF& b, const bool_vec& d)
+    : baseACF(b), discounted(d) { };
+  virtual ~DiscountACF() { };
+  void discount(index_type a) { discounted[a] = true; };
+  void discount(const index_set& d) { discounted.insert(d); };
+  void discount(const bool_vec& d) { discounted.insert(d); };
+  void count(index_type a) { discounted[a] = false; };
+  void count(const index_set& d) { discounted.subtract(d); };
+  void count(const bool_vec& d) { discounted.subtract(d); };
+  void count_only(const bool_vec& d);
+  const bool_vec& discounted_actions() { return discounted; };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class MakespanACF : public ACF {
+  Instance& instance;
+ public:
+  MakespanACF(Instance& i) : instance(i) { };
+  virtual ~MakespanACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceConsACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceConsACF(Instance& i, index_type r);
+  virtual ~ResourceConsACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+class ResourceReqACF : public ACF {
+  Instance& instance;
+  index_type resource_id;
+ public:
+  ResourceReqACF(Instance& i, index_type r);
+  virtual ~ResourceReqACF() { };
+  virtual hsps::rational operator()(index_type a) const;
+};
+}
+namespace hsps {
+typedef lvector<Heuristic*> estimator_vec;
+class BasicResourceState {
+ protected:
+  Instance& instance;
+  estimator_vec& estimators;
+  amt_vec amt_consumed;
+ public:
+  BasicResourceState(Instance& i, estimator_vec& est);
+  BasicResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  BasicResourceState(const BasicResourceState& s);
+  virtual ~BasicResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  void apply(Instance::Action& a);
+  bool is_root();
+  int compare(const BasicResourceState& s);
+  index_type hash();
+  BasicResourceState* new_state();
+  BasicResourceState* copy();
+  void write(std::ostream& s);
+};
+class RegressionResourceState : public BasicResourceState {
+ protected:
+  amt_vec max_required;
+ public:
+  RegressionResourceState(Instance& i, estimator_vec& est);
+  RegressionResourceState(Instance& i, estimator_vec& est, const amt_vec& ac);
+  RegressionResourceState(const RegressionResourceState& s);
+  ~RegressionResourceState();
+  hsps::rational available(index_type r) const;
+  hsps::rational available_for_consumption(index_type r) const;
+  bool applicable(Instance::Action& a);
+  bool applicable(Instance::Action& a, const index_vec& c);
+  bool applicable(Instance::Action& a, const index_cost_vec& c);
+  bool applicable(Instance::Action& a,
+    const index_cost_vec& c1,
+    const index_vec& c2);
+  bool sufficient_consumable(const index_set& s);
+  bool sufficient_consumable(const bool_vec& s);
+  bool sufficient_consumable(const index_set& s, const Instance::Action& cact);
+  bool sufficient_consumable(const bool_vec& s, const Instance::Action& cact);
+  bool sufficient_consumable(const index_set& s, const index_cost_vec& cacts);
+  bool sufficient_consumable(const bool_vec& s, const index_cost_vec& cacts);
+  void apply(Instance::Action& a);
+  void reserve_as_required(const amt_vec& req);
+  bool is_root();
+  int compare(const RegressionResourceState& s);
+  index_type hash();
+  RegressionResourceState* new_state();
+  RegressionResourceState* copy();
+  void write(std::ostream& s);
+};
+}
+namespace hsps {
+class IterativeEnumerator {
+ public:
+  IterativeEnumerator() { };
+  virtual ~IterativeEnumerator();
+  virtual bool first() = 0;
+  virtual bool next() = 0;
+};
+class RecursiveEnumerator {
+ protected:
+  virtual bool done() = 0;
+ public:
+  RecursiveEnumerator() { };
+  virtual ~RecursiveEnumerator();
+};
+class SubsetEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  bool_vec in;
+ public:
+  SubsetEnumerator(index_type _n);
+  virtual ~SubsetEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const bool_vec& current_set() const;
+  void current_set(const index_set& elements, index_set& set);
+  void current_set(index_set& set);
+  index_type current_set_size();
+  void all_sets(index_set_vec& sets);
+};
+class mSubsetEnumerator : public SubsetEnumerator {
+ protected:
+  index_type m;
+ public:
+  mSubsetEnumerator(index_type _n, index_type _m);
+  virtual ~mSubsetEnumerator() { };
+  count_type m_of_n();
+  virtual bool first();
+  virtual bool next();
+};
+class kAssignmentEnumerator : public IterativeEnumerator {
+ protected:
+  index_type n;
+  index_type k;
+  index_vec a;
+ public:
+  kAssignmentEnumerator(index_type _n, index_type _k);
+  virtual ~kAssignmentEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  void current_assignment(index_set_vec& sets);
+};
+class CorrespondanceEnumerator : public IterativeEnumerator {
+ protected:
+  const index_vec& a;
+  const index_vec& b;
+  mapping c;
+  bool_vec f;
+  index_type first_free(index_type x,
+   const index_vec& vec,
+   const bool_vec& f_vec);
+  index_type next_free(index_type x,
+         const index_vec& vec,
+         const bool_vec& f_vec,
+         index_type starting_from);
+  bool find(index_type p);
+ public:
+  CorrespondanceEnumerator(const index_vec& v0, const index_vec& v1);
+  virtual ~CorrespondanceEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return c; };
+};
+void write_correspondance(::std::ostream& s, const index_vec& c);
+class PermutationEnumerator : public IterativeEnumerator {
+ protected:
+  CorrespondanceEnumerator e;
+ public:
+  PermutationEnumerator(index_type n);
+  virtual ~PermutationEnumerator() { };
+  virtual bool first();
+  virtual bool next();
+  const mapping& current() const { return e.current(); };
+};
+class RecursivekPartitionEnumerator {
+  index_vec ass;
+ protected:
+  index_type n;
+  index_type k;
+  index_set_vec sets;
+  bool done;
+  void partition(index_type n, index_type k);
+  void construct();
+  void construct(const index_set& set);
+  virtual void solution();
+ public:
+  RecursivekPartitionEnumerator(index_type _n, index_type _k);
+  virtual ~RecursivekPartitionEnumerator();
+  void partition();
+};
+class RecursivePartitionEnumerator : public RecursivekPartitionEnumerator {
+ public:
+  RecursivePartitionEnumerator(index_type _n);
+  virtual ~RecursivePartitionEnumerator() { };
+  void partition();
+  void partition_bounded(index_type min, index_type max);
+};
+class CountPartitions : public RecursivePartitionEnumerator {
+  index_type c;
+ protected:
+  virtual void solution();
+ public:
+  CountPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~CountPartitions() { };
+  index_type count();
+};
+class PrintPartitions : public RecursivePartitionEnumerator {
+ protected:
+  virtual void solution();
+ public:
+  PrintPartitions(index_type _n) : RecursivePartitionEnumerator(_n) { };
+  virtual ~PrintPartitions() { };
+};
+}
+namespace hsps {
+class ExecError {
+ public:
+  enum ErrorType { error_unknown,
+     error_unsatisfied_precondition,
+     error_incompatible_actions,
+     error_resource_conflict,
+     error_resource_shortage,
+     error_unachieved_goal,
+     warning_redundant_action
+  };
+  enum ErrorSeverity { severity_none = 0,
+         severity_warning = 1,
+         severity_plan_failure = 2,
+         severity_execution_failure = 3
+  };
+ protected:
+  ErrorType toe;
+  hsps::rational at;
+  index_type step;
+ public:
+  static const char* error_type_string(ErrorType t);
+  static const char* error_severity_string(ErrorSeverity s);
+  ExecError() : toe(error_unknown), at(0), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t) : toe(e), at(t), step(no_such_index) { };
+  ExecError(ErrorType e, hsps::rational t, index_type s) : toe(e), at(t), step(s) { };
+  virtual ~ExecError();
+  void remap_step(const index_vec& map);
+  ErrorType type_of_error() const { return toe; };
+  ErrorSeverity severity_of_error() const;
+  hsps::rational time_of_error() const { return at; };
+  index_type step_of_error() const { return step; };
+  virtual ExecError* copy() const;
+  virtual void write(::std::ostream& s) const;
+};
+typedef lvector<ExecError*> exec_error_vec;
+typedef svector<ExecError::ErrorType> error_type_set;
+typedef svector<ExecError::ErrorSeverity> error_severity_set;
+class ExecErrorSet : public exec_error_vec {
+  index_type current_step;
+  error_type_set ignored_error_types;
+ public:
+  ExecErrorSet()
+    : exec_error_vec((ExecError*)0, 0),
+    current_step(no_such_index),
+    ignored_error_types() { };
+  ~ExecErrorSet();
+  void ignore_error_type(ExecError::ErrorType t);
+  void ignore_error_severity(ExecError::ErrorSeverity s);
+  void clear_ignored_error_types();
+  void new_error(ExecError* e);
+  bool ignore(ExecError::ErrorType t);
+  void remap_steps(const index_vec& map);
+  hsps::rational earliest_time_of_error();
+  ExecError::ErrorSeverity greatest_error_severity();
+  bool executable();
+  bool valid();
+  index_type count_of_type(ExecError::ErrorType t);
+  ExecErrorSet* earliest();
+  ExecErrorSet* all_of_type(ExecError::ErrorType t);
+  ExecErrorSet* all_of_severity(ExecError::ErrorSeverity s);
+  ExecErrorSet* earliest_of_type(ExecError::ErrorType t);
+  virtual void write(::std::ostream& s) const;
+};
+class UnsatisfiedPreconditionError : public ExecError {
+  Instance& ins;
+  index_type act;
+  index_type pre;
+  index_set holds;
+ public:
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at)
+    : ExecError(ExecError::error_unsatisfied_precondition, at),
+    ins(i), act(a), pre(p), holds(h) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p) { };
+  UnsatisfiedPreconditionError(Instance& i,
+          index_type a,
+          index_type p,
+          const index_set& h,
+          hsps::rational at,
+          index_type s)
+    : ExecError(ExecError::error_unsatisfied_precondition, at, s),
+    ins(i), act(a), pre(p), holds(h) { };
+  virtual ~UnsatisfiedPreconditionError() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  const Instance::Atom& precondition() { return ins.atoms[pre]; };
+  const index_set& true_atoms() { return holds; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class IncompatibleActionError : public ExecError {
+  Instance& ins;
+  index_type act0;
+  index_type act1;
+ public:
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1, hsps::rational at)
+    : ExecError(ExecError::error_incompatible_actions, at),
+    ins(i), act0(a0), act1(a1) { };
+  IncompatibleActionError(Instance& i, index_type a0, index_type a1,
+     hsps::rational at, index_type s)
+    : ExecError(ExecError::error_incompatible_actions, at, s),
+    ins(i), act0(a0), act1(a1) { };
+  virtual ~IncompatibleActionError() { };
+  const Instance::Action& action() { return ins.actions[act0]; };
+  const Instance::Action& incompatible_action() { return ins.actions[act1]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceConflictError : public ExecError {
+  Instance& ins;
+  index_type res;
+  index_set c_acts;
+  index_set c_steps;
+ public:
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_conflict, at), ins(i), res(r) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   const index_set& as,
+   const index_set& ss,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r),
+    c_acts(as), c_steps(ss) { };
+  ResourceConflictError(Instance& i,
+   index_type r,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_conflict, at, s), ins(i), res(r) { };
+  void add_action(index_type a)
+    { c_acts.insert(a); };
+  void add_action(index_type a, index_type s)
+    { c_acts.insert(a); c_steps.insert(s); };
+  virtual ~ResourceConflictError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  const index_set& conflict_actions() { return c_acts; };
+  const index_set& conflict_steps() { return c_steps; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ResourceShortageError : public ExecError {
+  Instance& ins;
+  index_type res;
+  hsps::rational avail;
+  index_type act;
+ public:
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at) :
+    ExecError(ExecError::error_resource_shortage, at), ins(i), res(r),
+    avail(v), act(a) { };
+  ResourceShortageError(Instance& i,
+   index_type r,
+   hsps::rational v,
+   index_type a,
+   hsps::rational at,
+   index_type s) :
+    ExecError(ExecError::error_resource_shortage, at, s), ins(i), res(r),
+    avail(v), act(a) { };
+  virtual ~ResourceShortageError() { };
+  const Instance::Resource& resource() { return ins.resources[res]; };
+  hsps::rational available() { return avail; };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class UnachievedGoalError : public ExecError {
+  Instance& ins;
+  index_type atom;
+ public:
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at)
+    : ExecError(ExecError::error_unachieved_goal, at), ins(i), atom(g) { };
+  UnachievedGoalError(Instance& i, index_type g, hsps::rational at, index_type s)
+    : ExecError(ExecError::error_unachieved_goal, at, s), ins(i), atom(g) { };
+  virtual ~UnachievedGoalError() { };
+  const Instance::Atom& goal() { return ins.atoms[atom]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class RedundantActionWarning : public ExecError {
+  Instance& ins;
+  index_type act;
+ public:
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at) :
+    ExecError(ExecError::warning_redundant_action, at), ins(i), act(a) { };
+  RedundantActionWarning(Instance& i, index_type a, hsps::rational at, index_type s) :
+    ExecError(ExecError::warning_redundant_action, at, s), ins(i), act(a) { };
+  virtual ~RedundantActionWarning() { };
+  const Instance::Action& action() { return ins.actions[act]; };
+  virtual ExecError* copy();
+  virtual void write(::std::ostream& s) const;
+};
+class ExecState : public ProgressionState {
+ protected:
+  Instance& instance;
+  bool_vec atoms;
+  amt_vec res;
+  struct exec_act {
+    index_type act;
+    hsps::rational rem;
+    index_type step;
+    ExecState* start_state;
+    exec_act() :
+      act(no_such_index), rem(ZERO), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r) :
+      act(a), rem(r), step(no_such_index), start_state(0) { };
+    exec_act(index_type a, hsps::rational r, index_type s) :
+      act(a), rem(r), step(s), start_state(0) { };
+    exec_act(const exec_act& e) :
+      act(e.act), rem(e.rem), step(e.step), start_state(e.start_state) { };
+    exec_act& operator=(const exec_act& e) {
+      act = e.act;
+      rem = e.rem;
+      step = e.step;
+      start_state = e.start_state;
+    };
+  };
+  typedef lvector<exec_act> exec_act_vec;
+  exec_act_vec actions;
+  hsps::rational abs_t;
+  hsps::rational delta_t;
+  hsps::rational dur;
+  int trace_level;
+  void apply_conditional_delete_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& to);
+  void active_conditional_add_effects
+    (Instance::Action& a, const ExecState* start_state, bool_vec& eff);
+ public:
+  ExecState(Instance& i);
+  ExecState(Instance& i, index_set g);
+  ExecState(Instance& i, const bool_vec& g);
+  ExecState(const ExecState& s);
+  virtual ~ExecState();
+  static bool extended_action_definition;
+  void set_trace_level(int level);
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual State* new_state(index_set& s);
+  virtual State* copy();
+  virtual void insert(Plan& p);
+  virtual void write_plan(::std::ostream& s);
+  virtual void write(::std::ostream& s);
+  hsps::rational current_time() const;
+  hsps::rational end_time() const;
+  void current_atoms(index_set& atms) const;
+  const bool_vec& current_atoms() const;
+  void current_actions(index_set& acts) const;
+  index_type n_current_actions() const;
+  void starting_actions(index_set& acts) const;
+  void finishing_actions(index_set& acts) const;
+  hsps::rational min_delta() const;
+  hsps::rational max_delta() const;
+  void current_resource_levels
+    (amt_vec& avail, amt_vec& in_use) const;
+  void current_resource_levels
+    (index_type r, hsps::rational& avail, hsps::rational& in_use) const;
+  void current_resource_use(amt_vec& res) const;
+  bool check_atoms(const index_set& set) const;
+  bool check_atoms(const index_set& set, index_set& holds) const;
+  bool is_final(ExecErrorSet* errors);
+  bool applicable(Instance::Action& act,
+    ExecErrorSet* errors,
+    index_type step);
+  void apply(Instance::Action& act,
+      ExecErrorSet* errors,
+      index_type step);
+  void advance(hsps::rational dt,
+        ExecErrorSet* errors);
+  void finish(ExecErrorSet* errors);
+  void clip(hsps::rational at_t);
+  void intersect(const bool_vec& atms);
+};
+class Timeline {
+ public:
+  virtual ~Timeline();
+  virtual index_type n_intervals() = 0;
+  virtual index_type n_points() = 0;
+  virtual index_type interval_start_point(index_type i) = 0;
+  virtual index_type interval_end_point(index_type i) = 0;
+  virtual hsps::rational point_time(index_type i) = 0;
+  virtual hsps::rational interval_start_time(index_type i) = 0;
+  virtual hsps::rational interval_end_time(index_type i) = 0;
+  hsps::rational total_time();
+};
+class ExecTrace : public Timeline, public lvector<ExecState*> {
+  Instance& instance;
+ public:
+  ExecTrace(Instance& ins);
+  ~ExecTrace();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  ExecState* final_state();
+  ExecTrace* copy();
+  ExecTrace* necessary_trace();
+  void peak_resource_use(amt_vec& res);
+  bool test_always(index_type p);
+  bool test_sometime(index_type p);
+  bool test_sometime_after(index_type p, index_type q);
+  bool test_sometime_before(index_type p, index_type q);
+  bool test_at_most_once(index_type p);
+  void extract_always_within(bool_matrix& c, cost_matrix& t);
+  void clip_last_state(hsps::rational at_t);
+  void write(::std::ostream& s);
+};
+class BasicTimeline : public Timeline {
+ protected:
+  cost_vec points;
+  bool open_start;
+  bool open_end;
+  void set_point(hsps::rational t);
+  void clip_start(hsps::rational t);
+  void clip_end(hsps::rational t);
+ public:
+  BasicTimeline();
+  virtual ~BasicTimeline();
+  virtual index_type n_intervals();
+  virtual index_type n_points();
+  virtual index_type interval_start_point(index_type i);
+  virtual index_type interval_end_point(index_type i);
+  virtual hsps::rational point_time(index_type i);
+  virtual hsps::rational interval_start_time(index_type i);
+  virtual hsps::rational interval_end_time(index_type i);
+  void write(::std::ostream& s);
+};
+class ResourceProfile : public BasicTimeline {
+ protected:
+  Instance& instance;
+  index_type res;
+  amt_vec avail;
+  amt_vec in_use;
+  index_set_vec a_start;
+  index_set_vec a_finish;
+  hsps::rational max_req;
+ public:
+  ResourceProfile(Instance& ins, index_type r, ExecTrace& trace);
+  virtual ~ResourceProfile();
+  void set_makespan(hsps::rational t);
+  const Name* resource_name() const { return instance.resources[res].name; };
+  hsps::rational amount_available(index_type i);
+  hsps::rational amount_in_use(index_type i);
+  hsps::rational amount_free(index_type i);
+  index_type first_use_interval(index_type i);
+  index_type first_min_free_interval(index_type i);
+  hsps::rational possible_unexpected_loss_to(index_type i);
+  hsps::rational min_free_from(index_type i);
+  hsps::rational min_free();
+  hsps::rational peak_use();
+  hsps::rational min_peak_use();
+  hsps::rational tolerable_unexpected_loss();
+  hsps::rational total_consumption();
+  void writeGantt(::std::ostream& s);
+  static double GANTT_EXTRA_WIDTH;
+  static double GANTT_EXTRA_HEIGHT;
+  void write(::std::ostream& s);
+};
+class Schedule : public Plan {
+ public:
+  struct step {
+    index_type act;
+    hsps::rational at;
+    index_type track;
+    step() : act(no_such_index), at(0), track(no_such_index) { };
+    step(index_type a, hsps::rational t) : act(a), at(t), track(no_such_index) { };
+    step& operator=(const step& s) {
+      act = s.act;
+      at = s.at;
+      return *this;
+    };
+    bool operator==(const step& s) {
+      return ((act == s.act) && (at == s.at));
+    };
+  };
+  typedef lvector<step> step_vec;
+ private:
+  Instance& instance;
+  step_vec steps;
+  hsps::rational end_t;
+  index_set action_set;
+  index_vec action_vec;
+  index_type n_tracks;
+  const Name* ann_name;
+  bool ann_optimal;
+  int trace_level;
+  hsps::rational current_t;
+  bool finished;
+  void insert_step(hsps::rational at, index_type act);
+  hsps::rational next_start_time(hsps::rational t) const;
+  hsps::rational next_finish_time(hsps::rational t) const;
+  hsps::rational last_finish_time() const;
+  void compute_action_set_and_vec();
+  void assign_tracks();
+  enum s_status { s_pending, s_ready, s_executing, s_finished };
+  bool construct_minimal_makespan(const index_vec& acts,
+      graph& prec,
+      const index_set& c,
+      hsps::rational& best,
+      index_vec& sindex);
+ public:
+  static bool write_traits;
+  Schedule(Instance& i);
+  Schedule(const Schedule& s);
+  virtual ~Schedule();
+  void set_trace_level(int level) { trace_level = level; };
+  index_type length() const;
+  hsps::rational makespan() const;
+  hsps::rational cost() const;
+  index_type n_steps() const { return steps.length(); };
+  const step_vec& plan_steps() const { return steps; };
+  const index_set& plan_actions() const { return action_set; };
+  const index_vec& step_actions() const { return action_vec; };
+  void step_action_names(name_vec& nv);
+  bool step_in_interval(index_type s, hsps::rational i_start, hsps::rational i_end) const;
+  index_type step_action(index_type s) const;
+  const Name* plan_name() const;
+  bool plan_is_optimal() const;
+  plan_trait_vec traits;
+  const PlanTrait* find_trait(const char* cn);
+  virtual void protect(index_type atom);
+  virtual void insert(index_type act);
+  virtual void advance(hsps::rational delta);
+  virtual void end();
+  void set_start_time(hsps::rational at);
+  void reduce(ExecErrorSet* warnings);
+  void clear();
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+  virtual void output(Plan& plan) const;
+  virtual void output(Plan& plan, const index_vec& act_map) const;
+  void write(::std::ostream& s, unsigned int c = Name::NC_DEFAULT) const;
+  void write_step_set(::std::ostream& s, const index_set& set) const;
+  void write_steps(::std::ostream& s) const;
+  void writeXML(::std::ostream& s,
+  ExecErrorSet* errors = 0,
+  ExecTrace* trace = 0,
+  graph* prec = 0,
+  index_type id = 0) const;
+  void writeGantt(::std::ostream& s) const;
+  static double GANTT_UNIT_WIDTH;
+  static double GANTT_UNIT_HEIGHT;
+  static double GANTT_TEXT_XOFF;
+  static double GANTT_TEXT_YOFF;
+  static hsps::rational GANTT_TIME_MARK_INTERVAL;
+  static bool GANTT_ACTION_NAMES_ON_CHART;
+  bool simulate(ExecTrace* trace = 0,
+  ExecErrorSet* errors = 0,
+  bool finish = false) const;
+  bool simulate_low_resolution(ExecTrace* trace = 0,
+          ExecErrorSet* errors = 0,
+          bool finish = false) const;
+  bool simulate(index_set& achieved,
+  ExecErrorSet* errors = 0) const;
+  bool simulate(amt_vec& rtl) const;
+  void deorder(graph& prec) const;
+  void deorder(weighted_graph& prec) const;
+  void base_precedence_graph(graph& prec) const;
+  bool equivalent(const Schedule& s, index_vec* c = 0) const;
+  bool schedule(const index_vec& acts,
+  const graph& prec,
+  index_vec* map = 0);
+  bool construct_conflict_free(const index_vec& acts,
+          const graph& prec,
+          index_set& cs,
+          index_vec& map);
+  bool construct_minimal_makespan(const index_vec& acts,
+      const graph& prec,
+      index_vec& map);
+  bool random_sequence(index_type ln_max,
+         index_type ln_avg,
+         bool continue_from_goal,
+         ExecTrace* trace,
+         RNG& rnd);
+};
+typedef lvector<Schedule*> plan_vec;
+class ScheduleSet : public plan_vec, public PlanSet {
+ protected:
+  struct ScheduleProperties {
+    bool valid;
+    ExecTrace* trace;
+    index_type n_resources;
+    amt_vec total_consumption;
+    amt_vec peak_use;
+    amt_vec tolerable_loss;
+    hsps::rational makespan;
+    ScheduleProperties()
+      : valid(true), trace(0), n_resources(0), total_consumption(0, 0),
+ peak_use(0, 0), tolerable_loss(POS_INF, 0), makespan(0) { };
+    ScheduleProperties(index_type n)
+      : valid(true), trace(0), n_resources(n), total_consumption(0, n),
+ peak_use(0, n), tolerable_loss(POS_INF, n), makespan(0) { };
+    bool dominates(const ScheduleProperties& p);
+  };
+  typedef lvector<ScheduleProperties*> prop_vec;
+  Instance& instance;
+  prop_vec props;
+  int trace_level;
+  ScheduleProperties* compute_properties(Schedule* s);
+  void cache_properties(index_type i, ScheduleProperties* p);
+  bool dominated(const ScheduleProperties& p, prop_vec& pv);
+  void dominated(prop_vec& pv, bool_vec& dom);
+  bool dominated(const ScheduleProperties& p);
+  void replace_schedule_with_properties
+    (index_type i, Schedule* s, ScheduleProperties* p);
+  void add_schedule_with_properties
+    (Schedule* s, ScheduleProperties* p);
+ public:
+  ScheduleSet(Instance& i);
+  ScheduleSet(ScheduleSet& s, const bool_vec& sel);
+  ~ScheduleSet();
+  void set_trace_level(int level);
+  void add_schedule(Schedule* s);
+  void add_schedule_if_different(Schedule* s);
+  void reduce_plans();
+  void filter_invalid_plans();
+  void filter_unschedulable_plans();
+  void filter_equivalent_plans();
+  void add_distinguishing_traits_1();
+  void add_distinguishing_traits_2();
+  bool common_precedence_constraints(graph& prec);
+  bool separating_precedence_constraints
+    (ScheduleSet& s, pair_set& d0, pair_set& d1);
+  void write_deordered_graphs(::std::ostream& s, bool w_names = true);
+  void writeXML(::std::ostream& s);
+  virtual Plan* new_plan();
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+  void remove(bool_vec& set);
+  void clear();
+};
+class ScheduleTrait : public PlanTrait {
+ protected:
+  Schedule* plan;
+  ScheduleSet* plan_set;
+  bool is_min;
+  bool is_max;
+  bool is_unique;
+  void write_meta_short(::std::ostream& s) const;
+  void write_meta_attributes(::std::ostream& s) const;
+ public:
+  ScheduleTrait(Schedule* p)
+    : plan(p), plan_set(0), is_min(false), is_max(false), is_unique(false) { };
+  ScheduleTrait(Schedule* p, ScheduleSet* s)
+    : plan(p), plan_set(s), is_min(false), is_max(false), is_unique(false) { };
+  virtual ~ScheduleTrait();
+  void set_min() { is_min = true; };
+  void set_max() { is_max = true; };
+  void set_unique() { is_unique = true; };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const = 0;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const = 0;
+};
+class EquivalentTo : public ScheduleTrait {
+  Schedule* s_eq;
+  index_vec cor;
+ public:
+  EquivalentTo(Schedule* p, ScheduleSet* ss, Schedule* s, const index_vec& c)
+    : ScheduleTrait(p, ss), s_eq(s), cor(c) { };
+  virtual ~EquivalentTo() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class DerivedFrom : public ScheduleTrait {
+  Schedule* s_src;
+  pair_set e_prec;
+ public:
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const pair_set& e)
+    : ScheduleTrait(p, ss), s_src(s), e_prec(e) { };
+  DerivedFrom(Schedule* p, ScheduleSet* ss, Schedule* s, const index_pair& e)
+    : ScheduleTrait(p, ss), s_src(s) { e_prec.assign_singleton(e); };
+  DerivedFrom(Schedule* p, ScheduleSet* ss,
+       DerivedFrom* a, const index_vec& m,
+       const index_pair& e);
+  virtual ~DerivedFrom() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void write_detail(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanPrecedenceRelation : public ScheduleTrait {
+  graph prec;
+ public:
+  PlanPrecedenceRelation(Schedule* s, const graph& p)
+    : ScheduleTrait(s), prec(p) { };
+  PlanPrecedenceRelation(Schedule* s, const graph& p, const index_vec& m)
+    : ScheduleTrait(s) { prec.copy_and_rename(p, m); };
+  virtual ~PlanPrecedenceRelation() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const graph& precedence_relation() const { return prec; };
+};
+class PlanActionOccurs : public ScheduleTrait {
+  Instance& instance;
+  index_type act;
+  index_type n_of_times;
+ public:
+  PlanActionOccurs(Schedule* p, Instance& i, index_type a, index_type n)
+    : ScheduleTrait(p), instance(i), act(a), n_of_times(n) { };
+  virtual ~PlanActionOccurs() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+class PlanStepOrder : public ScheduleTrait {
+  Instance& instance;
+  index_pair order;
+ public:
+  PlanStepOrder(Schedule* p, Instance& i, const index_pair& o)
+    : ScheduleTrait(p), instance(i), order(o) { };
+  virtual ~PlanStepOrder() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+  const index_pair& precedence() const { return order; };
+};
+class PlanFeatureValue : public ScheduleTrait {
+ public:
+  enum plan_feature_type { makespan,
+      cost,
+      resource_peak_use,
+      resource_total_consumption,
+      resource_tolerable_loss };
+ private:
+  plan_feature_type ftype;
+  Instance& instance;
+  index_type index;
+  hsps::rational value;
+ public:
+  PlanFeatureValue(Schedule* p,
+     plan_feature_type t,
+     Instance& i,
+     index_type x,
+     hsps::rational v) :
+    ScheduleTrait(p), ftype(t), instance(i), index(x), value(v) { };
+  virtual ~PlanFeatureValue() { };
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+  virtual void write_short(::std::ostream& s) const;
+  virtual void writeXML(::std::ostream& s) const;
+};
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       const graph& prec,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+bool feasible(Instance& ins,
+       const index_vec& acts,
+       index_type r,
+       const index_set& a,
+       index_type i_a,
+       const index_set& b,
+       index_type i_b,
+       hsps::rational c_max,
+       graph& uc,
+       graph_vec* rfps = 0,
+       index_type* rff = 0);
+class PlanName : public Name {
+  const Name* src;
+  const char* desc;
+  index_type index;
+ public:
+  PlanName(const char* s, index_type i)
+    : src(0), desc(s), index(i) { };
+  PlanName(const Name* n, const char* s, index_type i)
+    : src(n), desc(s), index(i) { };
+  virtual ~PlanName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorType t);
+::std::ostream& operator<<(::std::ostream& s, ExecError::ErrorSeverity s);
+}
+#include <list>
+namespace hsps {
+class SoftInstance : public Instance {
+ public:
+  struct SoftGoal {
+    Name* name;
+    index_set atoms;
+    hsps::rational weight;
+    void* src;
+    SoftGoal() : name(0), atoms(EMPTYSET), weight(0), src(0) { };
+    SoftGoal& operator=(const SoftGoal& g) {
+      name = g.name;
+      atoms = g.atoms;
+      weight = g.weight;
+      src = g.src;
+      return *this;
+    };
+    bool operator==(const SoftGoal& g) const {
+      return ((atoms == g.atoms) &&
+       (weight == g.weight));
+    };
+    bool is_sat(const bool* s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s[atoms[k]]) return false;
+      return true;
+    };
+    bool is_sat_init(const Instance& ins) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!ins.atoms[k].init) return false;
+      return true;
+    };
+    bool is_sat(const index_set& s) const {
+      for (index_type k = 0; k < atoms.length(); k++)
+ if (!s.contains(atoms[k])) return false;
+      return true;
+    };
+  };
+  typedef lvector<SoftGoal> soft_goal_vec;
+  soft_goal_vec soft;
+  index_set hard;
+  hsps::rational null_value;
+  SoftInstance();
+  SoftInstance(Name* n);
+  ~SoftInstance() { };
+  SoftGoal& new_soft_goal();
+  index_type n_soft() const { return soft.length(); };
+  index_type n_hard() const { return hard.length(); };
+  bool empty_plan_valid();
+  hsps::rational empty_plan_value();
+  void remap_hard_goals(const index_vec& atom_map);
+  void remap_soft_goals(const index_vec& atom_map);
+  void compile(Instance& ins);
+  void create_decision_problem(const bool_vec& sel, Instance& ins);
+  void create_decision_problem(const bool_vec& sel, hsps::rational b, Instance& ins);
+  hsps::rational compute_epsilon();
+  hsps::rational eval_goal_state(const index_set& s);
+  hsps::rational eval_goal_state(const index_set& s, index_set& g);
+  hsps::rational eval_plan(Schedule& s);
+  void eval_plan_set(ScheduleSet& s, cost_vec& v);
+  virtual void write_problem_goal(std::ostream& s) const;
+  virtual void write_problem_metric(std::ostream& s) const;
+  void write_goal_value_expression(std::ostream& s) const;
+  void write_soft_goal_set(std::ostream& s, const index_set& set) const;
+  void write_soft_goal_set(std::ostream& s, const bool_vec& set) const;
+  virtual void print(std::ostream& s) const;
+};
+class DecisionProblemEnumerator : public IterativeEnumerator {
+  SoftInstance& instance;
+  SubsetEnumerator selected;
+  Heuristic& h_cost;
+  hsps::rational nb_min;
+  index_set g_sel;
+  index_set a_sel;
+  hsps::rational v_sel;
+  hsps::rational c_sel;
+  hsps::rational nb_sel;
+  bool find_next(bool more);
+ public:
+  DecisionProblemEnumerator(SoftInstance& ins, Heuristic& h, hsps::rational b);
+  virtual ~DecisionProblemEnumerator();
+  virtual bool first();
+  virtual bool next();
+  hsps::rational current_value() const;
+  hsps::rational current_min_cost() const;
+  hsps::rational current_max_cost() const;
+  hsps::rational current_min_nb() const;
+  hsps::rational current_max_nb() const;
+  const index_set& current_soft_goals() const;
+  const index_set& current_goal_atoms() const;
+  void create_decision_problem(Instance& ins);
+};
+class MaxValueSearch {
+ protected:
+  struct option {
+    hsps::rational goal_value;
+    hsps::rational est_cost;
+    index_set goals;
+    State* root;
+    option() : goal_value(0), est_cost(0), goals(EMPTYSET), root(0) { };
+    index_type n_goals() const { goals.length(); };
+    hsps::rational est_value() const { return (goal_value - est_cost); };
+  };
+  typedef std::list<option> option_list;
+  typedef option_list::iterator option_p;
+  SoftInstance& instance;
+  ACF& cost;
+  Statistics& stats;
+  Result& res;
+  MultiSearchAlgorithm* search;
+  option_list options;
+  hsps::rational lb;
+  bool solved_flag;
+  int trace_level;
+  void insert_option_in_list(const option& o);
+  void init_option_list();
+  void make_empty_plan();
+  virtual void init_option(const index_set& selected, option& o) = 0;
+  virtual hsps::rational explore_next_option() = 0;
+ public:
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r);
+  MaxValueSearch(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+   index_type tt_size, bool use_cc);
+  ~MaxValueSearch();
+  static index_type print_options_max;
+  void print_option_list(std::ostream& s);
+  index_type n_options() const { return options.size(); };
+  hsps::rational best_option_estimated_value();
+  index_type best_option_size();
+  void init();
+  hsps::rational main();
+  bool solved() { return solved_flag; }
+};
+class MaxNetBenefit : public MaxValueSearch {
+  Heuristic& heuristic;
+  RegressionResourceState* root_rs;
+ protected:
+  virtual void init_option(const index_set& selected, option& o);
+  virtual hsps::rational explore_next_option();
+ public:
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(0)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs)
+    : MaxValueSearch(i, c, s, r), heuristic(h), root_rs(rs)
+    { };
+  MaxNetBenefit(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+  Heuristic& h, RegressionResourceState* rs,
+  index_type tt_size, bool use_cc)
+    : MaxValueSearch(i, c, s, r, tt_size, use_cc), heuristic(h), root_rs(rs)
+    { };
+  ~MaxNetBenefit() { };
+};
+}
+namespace hsps {
+class AtomSet {
+ protected:
+  Instance& instance;
+  bool_vec set;
+  index_type size;
+  index_type count();
+ private:
+  hsps::rational split(index_set g, index_type p, index_type n_out, index_type limit,
+       StateFactory& f, State* sp, Search& s, hsps::rational bound);
+  hsps::rational split_random(index_set g, index_type p, index_type n_out,
+       index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+ public:
+  static index_type max_set_size_encountered;
+  AtomSet(Instance& i);
+  AtomSet(Instance& i, const index_set& g);
+  AtomSet(Instance& i, const bool_vec& g);
+  AtomSet(const AtomSet& s);
+  ~AtomSet();
+  index_type atom_set_size() { return size; };
+  void add(const index_set& s);
+  void add(const bool_vec& s);
+  void del(const index_set& s);
+  void del(const bool_vec& s);
+  bool is_init_all();
+  bool is_init_some();
+  bool is_goal_all();
+  bool is_goal_some();
+  index_vec& copy_to(index_vec& s);
+  bool_vec& copy_to(bool_vec& s);
+  hsps::rational split(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound);
+  hsps::rational split_random(index_type limit, StateFactory& f, State* sp,
+       Search& s, hsps::rational bound, RNG& r);
+  int compare(const AtomSet& s);
+  index_type hash();
+};
+class AtomSetState : public AtomSet, public State {
+ protected:
+  Heuristic& heuristic;
+  hsps::rational est;
+  hsps::rational eval();
+  hsps::rational eval(hsps::rational b_est);
+  hsps::rational eval_with_trace_level(int level);
+  void apply_path_max();
+ public:
+  AtomSetState(Instance& i, Heuristic& h);
+  AtomSetState(Instance& i, Heuristic& h, const index_set& g);
+  AtomSetState(Instance& i, Heuristic& h, const bool_vec& g);
+  AtomSetState(const AtomSetState& s);
+  virtual ~AtomSetState();
+  index_type atom_set_size() { return size; };
+  virtual hsps::rational est_cost();
+  virtual bool is_final();
+  virtual bool is_max();
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void reevaluate();
+  virtual int compare(const State& s);
+  virtual index_type hash();
+  virtual void write(std::ostream& s);
+  virtual void write_eval(std::ostream& s, char* p = 0, bool e = true);
+};
+}
+namespace hsps {
+class SeqRegState : public AtomSetState, public StateFactory {
+ protected:
+  const ACF& cost;
+  index_type act;
+  RegressionResourceState* res;
+  bool relevant(Instance::Action& a);
+  bool applicable(Instance::Action& a);
+  SeqRegState* apply(Instance::Action& a);
+ public:
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c)
+    : AtomSetState(i, h), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(0) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c,
+       RegressionResourceState* r)
+    : AtomSetState(i, h), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+       RegressionResourceState* r)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+       RegressionResourceState* r)
+    : AtomSetState(i, h, g), cost(c), act(no_such_index), res(r) { };
+  SeqRegState(const SeqRegState& s);
+  virtual ~SeqRegState();
+  virtual hsps::rational delta_cost();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual void store(hsps::rational cost, bool opt);
+  virtual void set_predecessor(State* p);
+  virtual void insert(Plan& p);
+  virtual void insert_path(Plan& p);
+  virtual void write_plan(std::ostream& s);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual void write(std::ostream& s);
+};
+class ApxSeqRegState : public SeqRegState {
+ protected:
+  index_type limit;
+ public:
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, index_type l)
+    : SeqRegState(i, h, c), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+   index_type l)
+    : SeqRegState(i, h, c, g), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+   index_type l)
+    : SeqRegState(i, h, c, g), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, r), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, g, r), limit(l) { };
+  ApxSeqRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+   RegressionResourceState* r, index_type l)
+    : SeqRegState(i, h, c, g, r), limit(l) { };
+  ApxSeqRegState(const ApxSeqRegState& s)
+    : SeqRegState(s), limit(s.limit) { };
+  virtual bool is_max();
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+};
+class SeqCRegState : public SeqRegState {
+ public:
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c)
+    : SeqRegState(i, h, c) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g)
+    : SeqRegState(i, h, c, g) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g)
+    : SeqRegState(i, h, c, g) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, r) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const index_set& g,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, g, r) { };
+  SeqCRegState(Instance& i, Heuristic& h, const ACF& c, const bool_vec& g,
+        RegressionResourceState* r)
+    : SeqRegState(i, h, c, g, r) { };
+  SeqCRegState(const SeqRegState& s)
+    : SeqRegState(s) { };
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* new_state(const index_set& s, State* p);
+  virtual State* new_state(const bool_vec& s, State* p);
+  virtual State* copy();
+  virtual int compare(const State& s);
+  index_type hash();
+  virtual void write(std::ostream& s);
+};
+class LDSeqRegState : public SeqRegState {
+  const index_vec& plan;
+  static bool copy_as_ld;
+ public:
+  LDSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+  const index_set& g, const index_vec& p)
+    : SeqRegState(i, h, c, g), plan(p) { };
+  LDSeqRegState(Instance& i, Heuristic& h, const ACF& c,
+  const index_vec& p, const bool_vec& g)
+    : SeqRegState(i, h, c, g), plan(p) { };
+  LDSeqRegState(const LDSeqRegState& s);
+  virtual hsps::rational expand(Search& s, hsps::rational bound);
+  virtual State* copy();
+  virtual int compare(const State& s);
+  virtual void write(std::ostream& s);
+};
+}
+namespace hsps {
+class HashTable {
+ public:
+  struct Entry {
+    State* state;
+    index_type depth;
+    hsps::rational cost;
+  };
+ private:
+  index_type size;
+  index_type nocc;
+  Entry* tab;
+  count_type hits;
+  count_type cols;
+  count_type miss;
+ public:
+  HashTable(index_type s);
+  ~HashTable();
+  void inc_occ_count() { nocc += 1; };
+  Entry& operator[](index_type i);
+  index_type index(State& s);
+  Entry* find(State& s);
+  void insert(State& s, hsps::rational v, index_type d);
+  void insert(State& s, hsps::rational v);
+  void clear();
+  double hit_ratio();
+  double HCF();
+  double TUF();
+};
+}
+namespace hsps {
+class IDA : public MultiSearchAlgorithm {
+  HashTable* ttab;
+  bool cycle_check;
+  hsps::rational current_bound;
+  count_type iteration_limit;
+  count_type iteration_count;
+  static const count_type TRACE_LEVEL_2_NOTIFY = 100000;
+ public:
+  IDA(Statistics& s, SearchResult& r);
+  IDA(Statistics& s, SearchResult& r, HashTable* t);
+  virtual ~IDA();
+  void set_iteration_limit(count_type i_max) { iteration_limit = i_max; };
+  void increase_iteration_limit(count_type i) { iteration_limit += i; };
+  count_type get_iteration_limit() { return iteration_limit; };
+  void set_cycle_check(bool cc) { cycle_check = cc; };
+  hsps::rational main(State& s, hsps::rational bound);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual hsps::rational start(State& s, hsps::rational b);
+  virtual hsps::rational start(State& s);
+  virtual hsps::rational cost() const;
+  virtual hsps::rational resume(State& s, hsps::rational b);
+};
+}
+namespace hsps {
+SoftInstance::SoftInstance()
+  : soft(SoftGoal(), 0), null_value(0)
+{
+}
+SoftInstance::SoftInstance(Name* n)
+  : Instance(n), soft(SoftGoal(), 0), null_value(0)
+{
+}
+SoftInstance::SoftGoal& SoftInstance::new_soft_goal()
+{
+  soft.inc_length();
+  return soft[soft.length() - 1];
+}
+bool SoftInstance::empty_plan_valid()
+{
+  for (index_type k = 0; k < hard.length(); k++)
+    if (!atoms[hard[k]].init) return false;
+  return true;
+}
+hsps::rational SoftInstance::empty_plan_value()
+{
+  if (!empty_plan_valid()) return NEG_INF;
+  hsps::rational v = null_value;
+  for (index_type k = 0; k < soft.length(); k++)
+    if (soft[k].is_sat_init(*this))
+      v += soft[k].weight;
+  return v;
+}
+void SoftInstance::remap_hard_goals(const index_vec& atom_map)
+{
+  remap_set(hard, atom_map);
+}
+void SoftInstance::remap_soft_goals(const index_vec& atom_map)
+{
+  for (index_type k = 0; k < n_soft(); k++) {
+    remap_set(soft[k].atoms, atom_map);
+  }
+}
+void SoftInstance::compile(Instance& ins)
+{
+  ins.copy(*this);
+  Atom& a_mod = ins.new_atom(new StringName("_modifiable"));
+  a_mod.init = true;
+  a_mod.goal = false;
+  for (index_type k = 0; k < ins.n_actions(); k++)
+    ins.actions[k].pre.insert(a_mod.index);
+  hsps::rational residual_value = 0;
+  index_set g(hard);
+  for (index_type k = 0; k < n_soft(); k++) {
+    Name* n = (soft[k].name ? soft[k].name : new EnumName("preference", k));
+    Atom& a = ins.new_atom(n);
+    a.init = false;
+    a.goal = true;
+    g.insert(a.index);
+    Action& a_sat = ins.new_action(new ModName(n, "sat"));
+    a_sat.pre.insert(soft[k].atoms);
+    a_sat.add.insert(a.index);
+    a_sat.del.insert(a_mod.index);
+    a_sat.cost = 0;
+    Action& a_unsat = ins.new_action(new ModName(n, "unsat"));
+    a_unsat.add.insert(a.index);
+    a_unsat.del.insert(a_mod.index);
+    a_unsat.cost = soft[k].weight;
+    residual_value += (-1 * soft[k].weight);
+  }
+  residual_value -= null_value;
+  if (residual_value != 0) {
+    std::cerr << "warning: compiled problem metric differs by "
+       << residual_value
+       << std::endl;
+  }
+  ins.set_goal(g);
+}
+void SoftInstance::create_decision_problem
+(const bool_vec& sel, hsps::rational nb_min, Instance& ins)
+{
+  index_set s(hard);
+  hsps::rational v = null_value;
+  for (index_type k = 0; k < n_soft(); k++) if (sel[k]) {
+    s.insert(soft[k].atoms);
+    v += soft[k].weight;
+  }
+  ins.copy(*this);
+  ins.set_goal(s);
+  ins.set_cost_bound(v - nb_min);
+}
+void SoftInstance::create_decision_problem
+(const bool_vec& sel, Instance& ins)
+{
+  index_set s(hard);
+  for (index_type k = 0; k < n_soft(); k++) if (sel[k]) {
+    s.insert(soft[k].atoms);
+  }
+  ins.copy(*this);
+  ins.set_goal(s);
+}
+hsps::rational SoftInstance::compute_epsilon()
+{
+  bool first = true;
+  hsps::rational e;
+  for (index_type k = 0; k < n_actions(); k++) if (actions[k].cost != 0) {
+    if (first) {
+      e = actions[k].cost;
+      first = false;
+    }
+    else {
+      e = rational::rgcd(e, actions[k].cost);
+    }
+  }
+  for (index_type k = 0; k < n_soft(); k++) if (soft[k].weight != 0) {
+    if (first) {
+      e = soft[k].weight;
+      first = false;
+    }
+    else {
+      e = rational::rgcd(e, soft[k].weight);
+    }
+  }
+  return e;
+}
+hsps::rational SoftInstance::eval_goal_state(const index_set& s)
+{
+  hsps::rational v = null_value;
+  for (index_type k = 0; k < n_soft(); k++)
+    if (s.contains(soft[k].atoms)) v += soft[k].weight;
+  return v;
+}
+hsps::rational SoftInstance::eval_goal_state(const index_set& s, index_set& g)
+{
+  hsps::rational v = null_value;
+  g.clear();
+  for (index_type k = 0; k < n_soft(); k++)
+    if (s.contains(soft[k].atoms)) {
+      v += soft[k].weight;
+      g.insert(k);
+    }
+  return v;
+}
+hsps::rational SoftInstance::eval_plan(Schedule& s)
+{
+  if (trace_level > 1) {
+    std::cerr << "evaluating plan";
+    if (s.plan_name()) std::cerr << " " << s.plan_name();
+    std::cerr << "..." << std::endl;
+  }
+  index_set f;
+  bool ok = s.simulate(f, 0);
+  if (!ok) {
+    if (trace_level > 1) {
+      std::cerr << " - plan is not executable" << std::endl;
+    }
+    return NEG_INF;
+  }
+  if (trace_level > 1) {
+    std::cerr << " - achieved atoms: ";
+    write_atom_set(std::cerr, f);
+    std::cerr << std::endl;
+  }
+  if (!f.contains(hard)) {
+    if (trace_level > 1) {
+      std::cerr << " - hard goals not satisfied" << std::endl;
+    }
+    return NEG_INF;
+  }
+  hsps::rational v = eval_goal_state(f);
+  if (trace_level > 1) {
+    std::cerr << " - value is " << v << std::endl;
+  }
+  return v;
+}
+void SoftInstance::eval_plan_set(ScheduleSet& s, cost_vec& v)
+{
+  v.assign_value(0, s.length());
+  for (index_type k = 0; k < s.length(); k++) {
+    assert(s[k]);
+    v[k] = eval_plan(*s[k]);
+  }
+}
+void SoftInstance::write_problem_goal(std::ostream& s) const
+{
+  if (write_PDDL3) {
+    if ((n_hard() + n_soft()) > 0) {
+      s << " (:goal";
+      if ((n_hard() + n_soft()) > 1) s << " (and";
+      for (index_type k = 0; k < n_hard(); k++) {
+ s << " (";
+ atoms[hard[k]].name->write(s, Name::NC_INSTANCE);
+ s << ")";
+      }
+      for (index_type k = 0; k < n_soft(); k++) {
+ s << " (preference";
+ if (soft[k].name) {
+   s << " ";
+   soft[k].name->write(s, Name::NC_INSTANCE);
+ }
+ if (soft[k].atoms.length() > 1) s << " (and";
+ for (index_type i = 0; i < soft[k].atoms.length(); i++) {
+   s << " (";
+   atoms[soft[k].atoms[i]].name->write(s, Name::NC_INSTANCE);
+   s << ")";
+ }
+ if (soft[k].atoms.length() > 1) s << ")";
+ s << ")";
+      }
+      if ((n_hard() + n_soft()) > 1) s << ")";
+      s << ")" << std::endl;
+    }
+  }
+  else {
+    Instance::write_problem_goal(s);
+  }
+}
+void SoftInstance::write_goal_value_expression(std::ostream& s) const
+{
+  if (n_soft() > 0) {
+    if (null_value != 0) {
+      s << "(+ " << std::resetiosflags(std::ios::scientific) << ((null_value).decimal()) << " ";
+    }
+    for (index_type k = 0; k < n_soft() - 1; k++) {
+      s << "(+ (* " << std::resetiosflags(std::ios::scientific) << ((soft[k].weight).decimal())
+ << " (- 1 (is-violated " << soft[k].name << "))) ";
+    }
+    s << "(* " << std::resetiosflags(std::ios::scientific) << ((soft[n_soft() - 1].weight).decimal())
+      << " (- 1 (is-violated " << soft[n_soft() - 1].name << ")))";
+    for (index_type k = 0; k < n_soft() - 1; k++) {
+      s << ")";
+    }
+    if (null_value != 0) {
+      s << ")";
+    }
+  }
+  else if (null_value != 0) {
+    s << std::resetiosflags(std::ios::scientific) << ((null_value).decimal());
+  }
+  else {
+    s << "0";
+  }
+}
+void SoftInstance::write_problem_metric(std::ostream& s) const
+{
+  if (!write_metric) return;
+  if ((max_cost > 0) && (n_soft() > 0)) {
+    if (!write_PDDL2 || !write_PDDL3) {
+      std::cerr << "warning: can't write correct :metric without PDDL2/PDDL3"
+  << std::endl;
+      return;
+    }
+    s << " (:metric maximize (- ";
+    write_goal_value_expression(s);
+    s << " (_cost)))" << std::endl;
+  }
+  else if ((max_cost == 0) && (n_soft() > 0)) {
+    if (!write_PDDL3) {
+      std::cerr << "warning: can't write correct :metric without PDDL3"
+  << std::endl;
+      return;
+    }
+    s << " (:metric maximize ";
+    write_goal_value_expression(s);
+    s << ")" << std::endl;
+  }
+  else if ((max_cost > 0) && (n_soft() == 0)) {
+    if (!write_PDDL2) {
+      std::cerr << "warning: can't write correct :metric without PDDL2"
+  << std::endl;
+      return;
+    }
+    s << " (:metric minimize (_cost))" << std::endl;
+  }
+}
+void SoftInstance::write_soft_goal_set
+(std::ostream& s, const index_set& set) const
+{
+  s << "{";
+  for (index_type k = 0; k < set.length(); k++) {
+    assert(set[k] < n_soft());
+    if (k > 0) s << ",";
+    if (soft[set[k]].name) s << soft[set[k]].name;
+    else s << "#" << set[k];
+  }
+  s << "}";
+}
+void SoftInstance::write_soft_goal_set
+(std::ostream& s, const bool_vec& set) const
+{
+  s << "{";
+  bool first = true;
+  for (index_type k = 0; k < n_soft(); k++) if (set[k]) {
+    if (!first) s << ",";
+    first = false;
+    if (soft[k].name) s << soft[k].name;
+    else s << "#" << k;
+  }
+  s << "}";
+}
+void SoftInstance::print(std::ostream& s) const
+{
+  Instance::print(s);
+  s << "hard goals: " << hard << " = ";
+  write_atom_set(s, hard);
+  s << std::endl << "soft goals:" << std::endl;
+  for (index_type k = 0; k < n_soft(); k++) {
+    s << " " << soft[k].name << ": " << soft[k].atoms << " = ";
+    write_atom_set(s, soft[k].atoms);
+    s << " (weight = " << std::resetiosflags(std::ios::scientific) << ((soft[k].weight).decimal()) << ")" << std::endl;
+  }
+  s << "metric null value: " << std::resetiosflags(std::ios::scientific) << ((null_value).decimal()) << std::endl;
+}
+DecisionProblemEnumerator::DecisionProblemEnumerator
+(SoftInstance& ins, Heuristic& h, hsps::rational b)
+  : instance(ins), selected(ins.n_soft()), h_cost(h), nb_min(b)
+{
+}
+DecisionProblemEnumerator::~DecisionProblemEnumerator()
+{
+}
+bool DecisionProblemEnumerator::find_next(bool more)
+{
+  while (more) {
+    selected.current_set(g_sel);
+    a_sel.clear();
+    v_sel = instance.null_value;
+    for (index_type k = 0; k < g_sel.length(); k++) {
+      a_sel.insert(instance.soft[g_sel[k]].atoms);
+      v_sel += instance.soft[g_sel[k]].weight;
+    }
+    c_sel = h_cost.eval(a_sel);
+    nb_sel = v_sel - c_sel;
+    if (nb_sel >= nb_min) return true;
+    more = selected.next();
+  }
+  return false;
+}
+bool DecisionProblemEnumerator::first()
+{
+  bool more = selected.first();
+  return find_next(more);
+}
+bool DecisionProblemEnumerator::next()
+{
+  bool more = selected.next();
+  return find_next(more);
+}
+hsps::rational DecisionProblemEnumerator::current_value() const
+{
+  return v_sel;
+}
+hsps::rational DecisionProblemEnumerator::current_min_cost() const
+{
+  return c_sel;
+}
+hsps::rational DecisionProblemEnumerator::current_max_cost() const
+{
+  return v_sel - nb_min;
+}
+hsps::rational DecisionProblemEnumerator::current_max_nb() const
+{
+  return nb_sel;
+}
+hsps::rational DecisionProblemEnumerator::current_min_nb() const
+{
+  return nb_min;
+}
+const index_set& DecisionProblemEnumerator::current_soft_goals() const
+{
+  return g_sel;
+}
+const index_set& DecisionProblemEnumerator::current_goal_atoms() const
+{
+  return a_sel;
+}
+void DecisionProblemEnumerator::create_decision_problem(Instance& ins)
+{
+  instance.create_decision_problem(selected.current_set(), nb_min, ins);
+}
+index_type MaxValueSearch::print_options_max = 3;
+MaxValueSearch::MaxValueSearch
+(SoftInstance& i, ACF& c, Statistics& s, Result& r)
+  : instance(i), cost(c), stats(s), res(r), search(0), lb(NEG_INF),
+    solved_flag(false), trace_level(SearchAlgorithm::default_trace_level)
+{
+  lb = instance.empty_plan_value();
+  HashTable* tt = new HashTable(100007);
+  search = new IDA(stats, res, tt);
+}
+MaxValueSearch::MaxValueSearch
+(SoftInstance& i, ACF& c, Statistics& s, Result& r,
+ index_type tt_size, bool use_cc)
+  : instance(i), cost(c), stats(s), res(r), search(0), lb(NEG_INF),
+    solved_flag(false), trace_level(SearchAlgorithm::default_trace_level)
+{
+  lb = instance.empty_plan_value();
+  HashTable* tt = new HashTable(tt_size);
+  IDA* i_search = new IDA(stats, res, tt);
+  i_search->set_cycle_check(use_cc);
+  search = i_search;
+}
+MaxValueSearch::~MaxValueSearch()
+{
+}
+void MaxValueSearch::insert_option_in_list(const option& o)
+{
+  option_p p = options.begin();
+  while (p != options.end()) {
+    if (p->est_value() < o.est_value()) {
+      options.insert(p, o);
+      while (p != options.end()) {
+ if (p->goals == o.goals) {
+   option_p q = p++;
+   options.erase(q);
+ }
+ else {
+   p++;
+ }
+      }
+      return;
+    }
+    else if (p->goals == o.goals) {
+      return;
+    }
+    p++;
+  }
+  options.insert(p, o);
+}
+void MaxValueSearch::print_option_list(std::ostream& s)
+{
+  option_p p = options.begin();
+  count_type n = 0;
+  while ((p != options.end()) && (n < print_options_max)) {
+    s << *(p->root) << ": " << std::resetiosflags(std::ios::scientific) << ((p->est_value()).decimal())
+      << " (" << std::resetiosflags(std::ios::scientific) << ((p->goal_value).decimal()) << " - "
+      << std::resetiosflags(std::ios::scientific) << ((p->est_cost).decimal()) << ", "
+      << p->n_goals() << " goals)"
+      << std::endl;
+    p++;
+    n++;
+  }
+}
+void MaxValueSearch::init_option_list()
+{
+  SubsetEnumerator se(instance.n_soft());
+  bool more = se.first();
+  index_set s;
+  count_type n = 0;
+  while (more && !stats.break_signal_raised()) {
+    se.current_set(s);
+    option o;
+    init_option(s, o);
+    if (o.est_value() > lb) {
+      insert_option_in_list(o);
+    }
+    if ((trace_level > 1) && (options.size() >= (n + 1000))) {
+      std::cerr << options.size() << " options created (" << stats << ")"
+  << std::endl;
+      n = options.size();
+    }
+    more = se.next();
+  }
+}
+void MaxValueSearch::make_empty_plan()
+{
+  ZeroHeuristic hz(instance);
+  SeqCRegState s(instance, hz, cost, EMPTYSET);
+  res.solution(s, 0);
+}
+hsps::rational MaxNetBenefit::explore_next_option()
+{
+  option_p p = options.begin();
+  if (p == options.end()) {
+    std::cerr << "error: explore_next_option called with empty list"
+       << std::endl;
+    exit(255);
+  }
+  option o = *p;
+  p++;
+  options.pop_front();
+  hsps::rational next_best_value = lb;
+  if (p != options.end()) {
+    next_best_value = p->est_value();
+  }
+  if (o.root == 0) {
+    std::cerr << "error: NIL root in option" << std::endl;
+    exit(255);
+  }
+  search->set_cost_limit(o.goal_value - next_best_value);
+  if (trace_level > 0) {
+    std::cerr << "searching " << *(o.root) << " with cost limit "
+       << std::resetiosflags(std::ios::scientific) << ((search->get_cost_limit()).decimal()) << "..."
+       << std::endl;
+  }
+  hsps::rational new_est_cost = search->resume(*o.root, o.est_cost);
+  if ((new_est_cost <= o.est_cost) && !search->solved()) {
+    std::cerr << "error: search returned less or equal cost ("
+       << std::resetiosflags(std::ios::scientific) << ((new_est_cost).decimal()) << ") with no solution"
+       << std::endl;
+    stats.error();
+  }
+  o.est_cost = new_est_cost;
+  if (search->solved()) {
+    std::cerr << "solution found (value "
+       << std::resetiosflags(std::ios::scientific) << ((o.est_value()).decimal())
+       << ", " << stats << ")" << std::endl;
+    solved_flag = true;
+    return o.est_value();
+  }
+  else {
+    if (trace_level > 0) {
+      std::cerr << "no solution (estimated value "
+  << std::resetiosflags(std::ios::scientific) << ((o.est_value()).decimal())
+  << ", " << stats << ")" << std::endl;
+    }
+    if (o.est_value() > lb) {
+      insert_option_in_list(o);
+    }
+    if (options.empty()) {
+      return 0;
+    }
+    else {
+      return options.front().est_value();
+    }
+  }
+}
+void MaxNetBenefit::init_option(const index_set& selected, option& o)
+{
+  index_set g(instance.hard);
+  o.goal_value = instance.null_value;
+  for (index_type k = 0; k < selected.length(); k++) {
+    g.insert(instance.soft[selected[k]].atoms);
+    o.goal_value += instance.soft[selected[k]].weight;
+  }
+  o.goals = g;
+  if (root_rs)
+    o.root = new SeqCRegState(instance, heuristic, cost, g, root_rs);
+  else
+    o.root = new SeqCRegState(instance, heuristic, cost, g);
+  o.est_cost = o.root->est_cost();
+}
+hsps::rational MaxValueSearch::best_option_estimated_value()
+{
+  if (options.empty()) {
+    return 0;
+  }
+  else {
+    return options.front().est_value();
+  }
+}
+index_type MaxValueSearch::best_option_size()
+{
+  if (options.empty()) {
+    return 0;
+  }
+  else {
+    return options.front().n_goals();
+  }
+}
+void MaxValueSearch::init()
+{
+  stats.start();
+  std::cerr << "initializing option list ("
+     << instance.n_soft() << " soft goals)..."
+     << std::endl;
+  init_option_list();
+  solved_flag = false;
+  stats.stop();
+}
+hsps::rational MaxValueSearch::main()
+{
+  hsps::rational best_value = best_option_estimated_value();
+  stats.start();
+  while (!solved_flag && !stats.break_signal_raised() && !options.empty()) {
+    if (print_options_max > 0) {
+      std::cerr << "top " << print_options_max
+  << " of " << n_options()
+  << " current options:" << std::endl;
+      print_option_list(std::cerr);
+    }
+    best_value = explore_next_option();
+    std::cerr << "current best value = " << std::resetiosflags(std::ios::scientific) << ((best_value).decimal());
+    if (print_options_max == 0)
+      std::cerr << ", " << n_options() << " options";
+    std::cerr << " (solved = " << solved_flag << ", " << stats << ")"
+       << std::endl;
+  }
+  if (options.empty()) {
+    if (instance.empty_plan_valid()) {
+      std::cerr << "no more options - empty plan is best" << std::endl;
+      make_empty_plan();
+      solved_flag = true;
+      return 0;
+    }
+    else {
+      std::cerr << "no more options - problem unsolvable" << std::endl;
+      return NEG_INF;
+    }
+  }
+  stats.stop();
+  return best_value;
+}
+}

--- a/pr/seq-opt-hspsf/stats.ccx
+++ b/pr/seq-opt-hspsf/stats.ccx
@@ -1,0 +1,3244 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <iostream>
+#include <limits.h>
+namespace hsps {
+long euclid(long n, long k, long& a, long& b);
+long gcd(long n, long k);
+long lcm(long n, long k);
+unsigned long ilog(unsigned long n);
+long imag(long n);
+
+class rational {
+  long nm;
+  long dv;
+
+ public:
+  rational();
+  rational(long n);
+  rational(long n, long d);
+
+  rational(const rational& r);
+
+  struct XR {
+    long x_nm;
+    long x_dv;
+
+    XR& operator=(const rational r);
+  };
+  rational(const XR& x);
+
+  long numerator() const;
+  long divisor() const;
+  long sign() const;
+  bool zero() const;
+  bool finite() const;
+  bool infinite() const;
+  bool integral() const;
+
+  static rational reduce(rational r);
+  static rational invert(const rational r);
+  static rational infinity(const rational r);
+  static rational infinity(const long s);
+  static rational floor(const rational r);
+  static rational floor_to(const rational r, long div);
+  static rational ceil(const rational r);
+  static rational ceil_to(const rational r, long div);
+  static rational frac(const rational r);
+  static rational round(const rational r, long div_max);
+  static rational min(const rational r0, const rational r1);
+  static rational max(const rational r0, const rational r1);
+  static rational rgcd(const rational r0, const rational r1);
+  static rational dtor(double v);
+  static rational ator(const char* s);
+
+  rational reduce() const;
+  rational invert() const;
+  rational floor() const;
+  rational floor_to(long d) const;
+  rational ceil() const;
+  rational frac() const;
+  rational round(long div_max) const;
+  rational round() const;
+
+  rational operator=(const rational r);
+  rational operator=(long n);
+
+  rational operator+=(const rational r);
+  rational operator-=(const rational r);
+  rational operator*=(const rational r);
+  rational operator/=(const rational r);
+  rational operator+=(long n);
+  rational operator-=(long n);
+  rational operator*=(long n);
+  rational operator/=(long n);
+
+  double decimal() const;
+};
+
+bool operator==(const rational r0, const rational r1);
+bool operator==(const rational r0, long n1);
+bool operator==(long n0, const rational r1);
+
+bool operator!=(const rational r0, const rational r1);
+bool operator!=(const rational r0, long n1);
+bool operator!=(long n0, const rational r1);
+
+bool operator<(const rational r0, const rational r1);
+bool operator<=(const rational r0, const rational r1);
+bool operator>(const rational r0, const rational r1);
+bool operator>=(const rational r0, const rational r1);
+rational operator+(const rational r0, const rational r1);
+rational operator-(const rational r0, const rational r1);
+rational operator*(const rational r0, const rational r1);
+rational operator/(const rational r0, const rational r1);
+rational operator+(const rational r0, long n1);
+rational operator-(const rational r0, long n1);
+rational operator*(const rational r0, long n1);
+rational operator/(const rational r0, long n1);
+rational operator+(long n0, const rational r1);
+rational operator-(long n0, const rational r1);
+rational operator*(long n0, const rational r1);
+rational operator/(long n0, const rational r1);
+
+rational safeadd(const rational r0, const rational r1);
+rational safemul(const rational r0, const rational r1);
+
+::std::ostream& operator<<(::std::ostream& s, const rational r);
+
+
+
+
+
+inline rational::XR& rational::XR::operator=(const rational r)
+{
+  x_nm = r.numerator();
+  x_dv = r.divisor();
+  return *this;
+}
+
+inline rational::rational()
+  : nm(0), dv(1) { }
+
+inline rational::rational(long n)
+  : nm(n), dv(1) { }
+
+inline rational::rational(long n, long d)
+  : nm(d < 0 ? -1*n : n), dv(d < 0 ? -1*d : d) { }
+
+
+
+
+
+
+
+inline rational::rational(const rational& r)
+  : nm(r.nm), dv(r.dv) { }
+
+inline rational::rational(const rational::XR& x)
+  : nm(x.x_nm), dv(x.x_dv) { };
+
+inline long rational::numerator() const { return nm; }
+
+inline long rational::divisor() const { return dv; }
+
+inline long rational::sign() const
+{
+  return (nm < 0 ? -1 : (nm > 0 ? 1 : 0));
+}
+
+inline bool rational::zero() const
+{
+  return nm == 0;
+}
+
+inline bool rational::finite() const
+{
+  return dv != 0;
+}
+
+inline bool rational::infinite() const
+{
+  return dv == 0;
+}
+
+inline bool rational::integral() const
+{
+  return dv == 1;
+}
+
+inline rational rational::reduce(rational r)
+{
+  if (r.infinite()) return infinity(r.sign());
+  if (r.sign() == 0) return rational(0,1);
+  long c = gcd(r.nm, r.dv);
+  return rational(r.nm / c, r.dv / c);
+}
+
+inline rational rational::invert(const rational r)
+{
+  return rational(r.dv, r.nm);
+}
+
+inline rational rational::infinity(const long s)
+{
+  return rational((s < 0 ? -1 : (s > 0 ? 1 : 0)), 0);
+}
+
+inline rational rational::infinity(const rational r)
+{
+  return rational(r.sign(),0);
+}
+
+inline rational rational::floor(const rational r)
+{
+  if (r.infinite()) return r;
+  return rational(r.nm / r.dv);
+}
+
+inline rational rational::floor_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  return rational((r.nm * d) / r.dv, d);
+}
+
+inline rational rational::ceil(const rational r)
+{
+  if (r.infinite()) return r;
+  if (r.dv == 1) return r;
+  return rational((r.nm / r.dv) + 1, 1);
+}
+
+inline rational rational::ceil_to(const rational r, long d)
+{
+  if (r.infinite()) return r;
+  long x = (r.nm * d);
+  long y = x / r.dv;
+  if ((y * r.dv) == x)
+    return rational(y, d);
+  else
+    return rational(y + 1, d);
+}
+
+inline rational rational::frac(const rational r) {
+  if (r.infinite()) return r;
+  return reduce(rational(r.nm % r.dv, r.dv));
+}
+
+inline rational rational::round(const rational r, long d_max)
+{
+
+
+
+  if (r.infinite()) return r;
+  rational s(r);
+  while (s.dv > d_max) {
+    s.dv = (s.dv / 2);
+    s.nm = (s.nm / 2);
+
+
+
+    s.reduce();
+
+
+
+  }
+  return s;
+}
+
+inline rational rational::rgcd(const rational r0, const rational r1)
+{
+  long c = gcd(r0.divisor(), r1.divisor());
+  long a0 = r0.numerator() * (r1.divisor() / c);
+  long a1 = r1.numerator() * (r0.divisor() / c);
+  long d = gcd(a0, a1);
+  return rational(d, (r0.divisor() / c) * (r1.divisor() / c) * c).reduce();
+}
+
+inline rational rational::min(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() < 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() < 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r0;
+  else return r1;
+}
+
+inline rational rational::max(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    if (r0.sign() > 0) return r0;
+    else return r1;
+  }
+  else if (r1.infinite()) {
+    if (r1.sign() > 0) return r1;
+    else return r0;
+  }
+  else if (r0 < r1) return r1;
+  else return r0;
+}
+
+inline rational rational::reduce() const
+{
+  return reduce(*this);
+}
+
+inline rational rational::invert() const
+{
+  return invert(*this);
+}
+
+inline rational rational::floor() const
+{
+  return floor(*this);
+}
+
+inline rational rational::floor_to(long d) const
+{
+  return floor_to(*this, d);
+}
+
+inline rational rational::ceil() const
+{
+  return ceil(*this);
+}
+
+inline rational rational::frac() const
+{
+  return frac(*this);
+}
+
+inline rational rational::round(long d_max) const
+{
+  return round(*this, d_max);
+}
+
+inline rational rational::round() const
+{
+  return round(*this, (LONG_MAX/16));
+}
+
+inline rational rational::operator=(const rational r)
+{
+
+
+
+  nm = r.nm;
+  dv = r.dv;
+  return *this;
+}
+
+inline rational rational::operator=(long n)
+{
+
+
+
+  nm = n;
+  dv = 1;
+  return *this;
+}
+
+inline rational rational::operator+=(const rational r)
+{
+  return *this = (*this + r);
+}
+
+inline rational rational::operator-=(const rational r)
+{
+  return *this = (*this - r);
+}
+
+inline rational rational::operator*=(const rational r)
+{
+  return *this = (*this * r);
+}
+
+inline rational rational::operator/=(const rational r)
+{
+  return *this = (*this / r);
+}
+
+inline rational rational::operator+=(long n)
+{
+  return *this = (*this + n);
+}
+
+inline rational rational::operator-=(long n)
+{
+  return *this = (*this - n);
+}
+
+inline rational rational::operator*=(long n)
+{
+  return *this = (*this * n);
+}
+
+inline rational rational::operator/=(long n)
+{
+  return *this = (*this / n);
+}
+
+inline double rational::decimal() const { return nm/(double)dv; };
+
+inline bool operator==(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite()) return r0.sign() == r1.sign();
+  else return ((r0.numerator() == r1.numerator()) &&
+        (r0.divisor() == r1.divisor()));
+}
+
+inline bool operator==(const rational r0, long n1)
+{
+  return ((r0.numerator() == n1) && (r0.divisor() == 1));
+}
+
+inline bool operator==(long n0, const rational r1)
+{
+  return ((r1.numerator() == n0) && (r1.divisor() == 1));
+}
+
+inline bool operator!=(const rational r0, const rational r1)
+{
+  return !(r0 == r1);
+}
+
+inline bool operator!=(const rational r0, long n1)
+{
+  return !(r0 == n1);
+}
+
+inline bool operator!=(long n0, const rational r1)
+{
+  return !(n0 == r1);
+}
+
+inline bool operator<(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() < 0;
+}
+
+inline bool operator<=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() <= 0;
+}
+
+inline bool operator>(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return false;
+  else return (r0 - r1).sign() > 0;
+}
+
+inline bool operator>=(const rational r0, const rational r1)
+{
+  if (r0.infinite() && r1.infinite() && (r0.sign() == r1.sign())) return true;
+  else return (r0 - r1).sign() >= 0;
+}
+
+inline rational operator+(const rational r0, const rational r1)
+{
+
+
+
+
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+           << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() + r1.numerator(), 1);
+  }
+
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) +
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator-(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() != r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " - " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1.sign() * -1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() - r1.numerator(), 1);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n = (r0.numerator() * (r1.divisor() / c) -
+       r1.numerator() * (r0.divisor() / c));
+    long d = ((r0.divisor() / c) * r1.divisor());
+    return rational(n, d).reduce();
+  }
+}
+inline rational operator*(const rational r0, const rational r1)
+{
+  if (r0.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if (r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else if ((r0.divisor() == 1) && (r1.divisor() == 1)) {
+    return rational(r0.numerator() * r1.numerator(), 1);
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    return rational((r0.numerator() / c0) * (r1.numerator() / c1),
+      (r0.divisor() / c1) * (r1.divisor() / c0)).reduce();
+  }
+}
+inline rational operator/(const rational r0, const rational r1)
+{
+  return (r0 * r1.invert());
+}
+inline rational operator+(const rational r0, long n1)
+{
+  return rational(r0.numerator() + (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator-(const rational r0, long n1)
+{
+  return rational(r0.numerator() - (n1 * r0.divisor()), r0.divisor()).reduce();
+}
+inline rational operator*(const rational r0, long n1)
+{
+  return rational(r0.numerator() * n1, r0.divisor()).reduce();
+}
+inline rational operator/(const rational r0, long n1)
+{
+  return rational((n1 < 0 ? r0.numerator() * -1 : r0.numerator()),
+    r0.divisor() * (n1 < 0 ? n1 * -1 : n1)).reduce();
+}
+inline rational operator+(long n0, const rational r1)
+{
+  return rational(r1.numerator() + (n0 * r1.divisor()), r1.divisor()).reduce();
+}
+inline rational operator-(long n0, const rational r1)
+{
+  return rational((n0 * r1.divisor()) - r1.numerator(), r1.divisor()).reduce();
+}
+inline rational operator*(long n0, const rational r1)
+{
+  return rational(r1.numerator() * n0, r1.divisor()).reduce();
+}
+inline rational operator/(long n0, const rational r1)
+{
+  return (n0 * r1.invert());
+}
+inline rational safeadd(const rational r0, const rational r1)
+{
+  if (r1.infinite()) {
+    if (r0.infinite()) {
+      if (r1.sign() == r0.sign()) return rational::infinity(r0);
+      else {
+ ::std::cerr << "error: " << r0 << " + " << r1 << " not defined"
+      << ::std::endl;
+ abort();
+      }
+    }
+    else {
+      return rational::infinity(r1);
+    }
+  }
+  else if (r0.infinite()) {
+    return rational::infinity(r0);
+  }
+  else {
+    long c = gcd(r0.divisor(), r1.divisor());
+    long n0 = r0.numerator();
+    long d0 = r0.divisor() / c;
+    long n1 = r1.numerator();
+    long d1 = r1.divisor() / c;
+    assert(d0 > 0);
+    assert(d1 > 0);
+    while (((LONG_MAX / (2*d1)) < (imag(n0) + 1)) ||
+    ((LONG_MAX / (2*d0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / (d0 * c)) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    long f0 = n0 * d1;
+    long f1 = n1 * d0;
+    long n = f0 + f1;
+    long d = d0 * d1 * c;
+    return rational(n, d).reduce();
+  }
+}
+inline rational safemul(const rational r0, const rational r1)
+{
+  if (r0.infinite() || r1.infinite()) {
+    return rational::infinity(r0.sign() * r1.sign());
+  }
+  else {
+    long c0 = gcd(r0.numerator(), r1.divisor());
+    long c1 = gcd(r1.numerator(), r0.divisor());
+    long n0 = r0.numerator() / c0;
+    long n1 = r1.numerator() / c1;
+    long d0 = r0.divisor() / c1;
+    long d1 = r1.divisor() / c0;
+    while (((LONG_MAX / imag(n0)) < (imag(n1) + 1)) ||
+    ((LONG_MAX / d0) < (d1 + 1))) {
+      if ((d1 < 2) && (d0 < 2)) {
+ std::cerr << "error: overflow in safeadd(" << r0 << ", " << r1 << ")"
+    << std::endl;
+ abort();
+      }
+      if (d0 < 2) {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+      else if (d1 < 2) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else if ((imag(n0) - d0) > (imag(n1) - d1)) {
+ n0 = (n0 / 2);
+ d0 = (d0 / 2);
+      }
+      else {
+ n1 = (n1 / 2);
+ d1 = (d1 / 2);
+      }
+    }
+    return rational(n0 * n1, d0 * d1).reduce();
+  }
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const rational r)
+{
+  if (r.infinite()) {
+    if (r.sign() < 0) return s << "-INF";
+    else return s << "INF";
+  }
+  else if (r.integral()) {
+    return s << r.numerator();
+  }
+  else {
+    return s << r.numerator() << '/' << r.divisor();
+  }
+}
+}
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+  void swap();
+};
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+  void sort_ascending();
+  void sort_descending();
+};
+typedef comparable_pair<index_type> index_pair;
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+class index_set;
+class bool_vec;
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+class RNG {
+ public:
+  virtual ~RNG() { };
+  virtual void seed(unsigned long s) = 0;
+  virtual unsigned long seed_value() = 0;
+  virtual unsigned long random() = 0;
+  void seed_with_pid();
+  void seed_with_time();
+  unsigned long random_in_range(unsigned long range);
+  unsigned long random_in_range(unsigned long range, unsigned long except);
+  double random_double(unsigned long div);
+  double normal_sample(double mean, double var);
+  unsigned long binomial_sample(unsigned long n, double p);
+  index_type select_one_of(const bool_vec& sel);
+  index_type select_one_of(const index_vec& sel);
+  void select_fixed_set(index_set& s, index_type m, index_type n);
+  void select_variable_set(index_set& s, index_type m, index_type n);
+  void select_non_empty_variable_set(index_set& s, index_type m, index_type n);
+  virtual unsigned long max() = 0;
+};
+class LC_RNG : public RNG {
+  unsigned long a;
+  unsigned long b;
+  unsigned long mod;
+  unsigned long x;
+ public:
+  LC_RNG()
+    : a(23), b(0), mod(100000001), x(100000001 - 1) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m)
+    : a(_a), b(_b), mod(m), x(m - 1) { };
+  LC_RNG(unsigned long s)
+    : a(23), b(0), mod(100000001), x(s) { };
+  LC_RNG(unsigned long _a, unsigned long _b, unsigned long m, unsigned long s)
+    : a(_a), b(_b), mod(m), x(s) { };
+  virtual ~LC_RNG() { };
+  virtual void seed(unsigned long s);
+  virtual unsigned long seed_value();
+  virtual unsigned long random();
+  virtual unsigned long max();
+};
+}
+#include <iostream>
+#include <iomanip>
+const hsps::rational POS_INF(1,0);
+const hsps::rational NEG_INF(-1,0);
+const hsps::rational ZERO(0,1);
+namespace hsps {
+inline hsps::rational random_numeric
+(hsps::rational min, hsps::rational max, unsigned long prec, RNG& rng)
+{
+  hsps::rational d = (max - min);
+  hsps::rational s = (d / prec);
+  unsigned long r = rng.random_in_range(prec + 1);
+  return ((r*s) + min);
+}
+class amt_vec : public auto_expanding_vector<hsps::rational> {
+ public:
+  amt_vec()
+    : auto_expanding_vector<hsps::rational>() { };
+  amt_vec(const hsps::rational& v, index_type l)
+    : auto_expanding_vector<hsps::rational>(v, l) { };
+  amt_vec(const amt_vec& vec)
+    : auto_expanding_vector<hsps::rational>(vec) { };
+  int compare(const amt_vec& vec, index_type n);
+  int dcompare(const amt_vec& vec, index_type n);
+  index_type hash(index_type n);
+  void write(std::ostream& s, index_type n);
+};
+inline int amt_vec::compare(const amt_vec& vec, index_type n)
+{
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) return -1;
+    else if ((*this)[k] > vec[k]) return 1;
+  }
+  return 0;
+}
+inline int amt_vec::dcompare(const amt_vec& vec, index_type n)
+{
+  bool this_less_than_vec = false;
+  bool vec_less_than_this = false;
+  for (index_type k = 0; k < n; k++) {
+    if ((*this)[k] < vec[k]) this_less_than_vec = true;
+    else if ((*this)[k] > vec[k]) vec_less_than_this = true;
+  }
+  if (this_less_than_vec && !vec_less_than_this) return -1;
+  else if (!this_less_than_vec && vec_less_than_this) return 1;
+  else return 0;
+}
+inline index_type amt_vec::hash(index_type n)
+{
+  if (n == 0) return 0;
+  if (n == 1) return ((index_type)(((*this)[0]).numerator() - ((*this)[0]).divisor()));
+  index_type h = 0;
+  for (index_type k = 0; k < n - 1; k++) {
+    h += ((index_type)(((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).numerator() - ((((*this)[k]) + 1) * (((*this)[k + 1]) + 1)).divisor()));
+  }
+  return h;
+}
+inline void amt_vec::write(std::ostream& s, index_type n)
+{
+  s << '[';
+  for (index_type k = 0; k < n; k++) {
+    if (k > 0) s << ',';
+    s << std::resetiosflags(std::ios::scientific) << (((*this)[k]).decimal());
+  }
+  s << ']';
+}
+typedef lvector<hsps::rational> cost_vec;
+typedef svector<hsps::rational> cost_set;
+typedef matrix<hsps::rational> cost_matrix;
+class cost_vec_util : public cost_vec
+{
+ public:
+  class decreasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_cost_order : public cost_vec::order {
+  public:
+    virtual bool operator()
+      (const hsps::rational& v0, const hsps::rational& v1) const
+      { return (v0 < v1); };
+  };
+  static class decreasing_cost_order decreasing;
+  static class increasing_cost_order increasing;
+  static hsps::rational max(const cost_vec& v);
+  static hsps::rational min(const cost_vec& v);
+  hsps::rational max() const { return max(*this); };
+  hsps::rational min() const { return min(*this); };
+};
+struct interval : public comparable_pair<hsps::rational> {
+  interval(const hsps::rational& v1, const hsps::rational& v2) :
+    comparable_pair<hsps::rational>(v1, v2) { };
+  interval(const hsps::rational& v) :
+    comparable_pair<hsps::rational>(v) { };
+  interval(const interval& p) :
+    comparable_pair<hsps::rational>(p) { };
+  interval() :
+    comparable_pair<hsps::rational>(NEG_INF, POS_INF) { };
+};
+typedef std::pair<index_type, hsps::rational> index_cost_pair;
+typedef lvector<index_cost_pair> index_cost_vec;
+inline std::ostream& operator<<(std::ostream& s, const index_cost_pair& p)
+{
+  s << '(' << p.first << ',' << p.second << ')';
+}
+inline std::ostream& operator<<(std::ostream& s, const interval& i)
+{
+  s << '[' << i.first << ',' << i.second << ']';
+}
+}
+#include <string>
+#include <iostream>
+namespace hsps {
+class Name {
+ public:
+  static const unsigned int NC_DEFAULT = 0;
+  static const unsigned int NC_INSTANCE = 1;
+  static const unsigned int NC_DOMAIN = 2;
+  static const unsigned int NC_PROBLEM = 4;
+  static const unsigned int NC_PLAN = 8;
+  static const unsigned int NC_ESCAPE = 16 + 32;
+  static const unsigned int NC_PDDL = 16;
+  static const unsigned int NC_XML = 32;
+  static const unsigned int NC_LATEX = 16 + 32;
+  static const unsigned int NC_IPC = 64;
+  static bool context_is_instance(unsigned int c)
+    { return ((c & NC_INSTANCE) == NC_INSTANCE); };
+  static bool context_is_domain(unsigned int c)
+    { return ((c & NC_DOMAIN) == NC_DOMAIN); };
+  static bool context_is_problem(unsigned int c)
+    { return ((c & NC_PROBLEM) == NC_PROBLEM); };
+  static bool context_is_plan(unsigned int c)
+    { return ((c & NC_PLAN) == NC_PLAN); };
+  static bool escape_for_pddl(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_PDDL); };
+  static bool escape_for_xml(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_XML); };
+  static bool escape_for_latex(unsigned int c)
+    { return ((c & NC_ESCAPE) == NC_LATEX); };
+  static bool conform_to_IPC(unsigned int c)
+    { return ((c & NC_IPC) == NC_IPC); };
+  virtual ~Name();
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const = 0;
+  virtual const Name* cast_to(const char* cname) const;
+  ::std::string to_string(unsigned int c = NC_DEFAULT) const;
+  char* to_cstring(unsigned int c = NC_DEFAULT) const;
+  bool equals(const Name* name) const;
+  void write_char_escaped(::std::ostream& s,
+     char ch,
+     unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       ::std::string& str,
+       unsigned int c) const;
+  void write_string_escaped(::std::ostream& s,
+       const char* str,
+       unsigned int c) const;
+};
+typedef lvector<const Name*> name_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const Name& n) {
+  n.write(s, false);
+  return s;
+}
+inline ::std::ostream& operator<<(::std::ostream& s, const Name* n) {
+  n->write(s, false);
+  return s;
+}
+inline void Name::write_char_escaped
+(::std::ostream& s, char ch, unsigned int c) const
+{
+  if (escape_for_latex(c)) {
+    if (ch == '_') s << '\\' << '_';
+    else if (ch == '%') s << '\\' << '%';
+    else if (ch == '#') s << '\\' << '#';
+    else s << ch;
+  }
+  else if (escape_for_xml(c)) {
+    if (ch == '<') s << "&lt;";
+    else if (ch == '>') s << "&gt;";
+    else if (ch == '&') s << "&amp;";
+    else if (ch == '"') s << "&quot;";
+    else s << ch;
+  }
+  else if (escape_for_pddl(c)) {
+    if (ch == ' ') s << '_';
+    else s << ch;
+  }
+  else {
+    s << ch;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, const char* str, unsigned int c) const
+{
+  while (*str) {
+    write_char_escaped(s, *str, c);
+    str++;
+  }
+}
+inline void Name::write_string_escaped
+(::std::ostream& s, ::std::string& str, unsigned int c) const
+{
+  for (index_type i = 0; i < str.length(); i++)
+    write_char_escaped(s, str[i], c);
+}
+class NameWithContext : public Name {
+  const Name* name;
+  unsigned int c_on;
+  unsigned int c_off;
+ public:
+  NameWithContext(const Name* n, unsigned int on, unsigned int off)
+    : name(n), c_on(on), c_off(off) { };
+  virtual ~NameWithContext() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class StringName : public Name {
+  const char* _string;
+  bool _own;
+ public:
+  StringName(const char* s, bool c = false)
+    : _string(c ? strdup(s) : s), _own(c) { };
+  virtual ~StringName() { if (_own) delete (char*)_string; };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class ConcatenatedName : public Name {
+  name_vec elements;
+  char catc;
+ public:
+  ConcatenatedName() : elements((Name*)0, 0), catc('+') { };
+  ConcatenatedName(const Name* n) : elements(n, 1), catc('+') { };
+  ConcatenatedName(char c) : elements((Name*)0, 0), catc(c) { };
+  ConcatenatedName(const Name* n1, const Name* n2, char c)
+    : elements((Name*)0, 0), catc(c)
+  {
+    elements.append(n1);
+    elements.append(n2);
+  };
+  virtual ~ConcatenatedName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+  void append(const Name* n) { elements.append(n); };
+};
+class ModName : public Name {
+  const char* _mod;
+  const Name* _name;
+ public:
+  ModName(const Name* n, const char* m) : _mod(m), _name(n) { };
+  virtual ~ModName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class CopyName : public Name {
+  const Name* _name;
+  index_type _num;
+ public:
+  CopyName(const Name* n) : _name(n), _num(no_such_index) { };
+  CopyName(const Name* n, index_type m) : _name(n), _num(m) { };
+  virtual ~CopyName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class NameAtIndex : public Name {
+  const Name* _name;
+  index_type _index;
+ public:
+  NameAtIndex(const Name* n, index_type i) : _name(n), _index(i) { };
+  virtual ~NameAtIndex() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+class EnumName : public Name {
+  const char* prefix;
+  index_type index;
+ public:
+  EnumName(const char* p, index_type i) : prefix(p), index(i) { };
+  virtual ~EnumName() { };
+  virtual void write(::std::ostream& s, unsigned int c = NC_DEFAULT) const;
+};
+}
+namespace hsps {
+class Search;
+class Plan;
+class State {
+ protected:
+  State* pre;
+ public:
+  State() : pre(0) { };
+  State(const State& s) : pre(s.pre) { };
+  virtual ~State();
+  virtual const State* predecessor() const;
+  virtual State* predecessor();
+  virtual void set_predecessor(State* p);
+  virtual bool is_encapsulated();
+  virtual hsps::rational delta_cost() = 0;
+  virtual hsps::rational acc_cost();
+  virtual index_type depth() const;
+  virtual hsps::rational est_cost() = 0;
+  virtual bool is_final() = 0;
+  virtual bool is_max() = 0;
+  virtual hsps::rational expand(Search& s, hsps::rational bound) = 0;
+  virtual void store(hsps::rational cost, bool opt) = 0;
+  virtual void reevaluate() = 0;
+  virtual int compare(const State& s) = 0;
+  virtual index_type hash() = 0;
+  virtual State* copy() = 0;
+  virtual void insert(Plan& p) = 0;
+  virtual void insert_path(Plan& p) = 0;
+  virtual void write(::std::ostream& s) = 0;
+  virtual void write_plan(::std::ostream& s) = 0;
+  virtual void write_eval(::std::ostream& s, char* p = 0, bool e = true);
+  State* copy_path();
+  void delete_path();
+  int compare_path(const State* s);
+  void write_path(::std::ostream& s);
+  virtual void write_path_as_graph(::std::ostream& s);
+};
+inline bool operator==(State& s0, State& s1) {
+  return (s0.compare(s1) == 0);
+}
+inline bool operator<(State& s0, State& s1) {
+  return (s0.compare(s1) < 0);
+}
+inline bool operator<=(State& s0, State& s1) {
+  return (s0.compare(s1) <= 0);
+}
+inline bool operator>(State& s0, State& s1) {
+  return (s0.compare(s1) > 0);
+}
+inline bool operator>=(State& s0, State& s1) {
+  return (s0.compare(s1) >= 0);
+}
+inline ::std::ostream& operator<<(::std::ostream& s, State& state) {
+  state.write(s);
+  return s;
+}
+class ProgressionState : public State {
+ public:
+  ProgressionState() { };
+  ProgressionState(const ProgressionState& s) : State(s) { };
+  virtual ~ProgressionState() { };
+  virtual void insert_path(Plan& p);
+};
+class RegressionState : public State {
+ public:
+  RegressionState() { };
+  RegressionState(const RegressionState& s) : State(s) { };
+  virtual ~RegressionState() { };
+  virtual void insert_path(Plan& p);
+};
+typedef lvector<State*> state_vec;
+class PlanTrait {
+ public:
+  PlanTrait() { };
+  virtual ~PlanTrait();
+  virtual const PlanTrait* cast_to(const char* class_name) const;
+};
+typedef lvector<PlanTrait*> plan_trait_vec;
+class Plan {
+ public:
+  virtual ~Plan();
+  virtual void protect(index_type atom) = 0;
+  virtual void insert(index_type act) = 0;
+  virtual void advance(hsps::rational delta) = 0;
+  virtual void end() = 0;
+  virtual void output(Plan& to);
+  virtual void set_name(const Name* n);
+  virtual void set_optimal(bool o);
+  virtual void add_trait(PlanTrait* t);
+};
+class Search {
+ public:
+  virtual ~Search();
+  virtual hsps::rational new_state(State& s, hsps::rational bound) = 0;
+  virtual bool solved() const = 0;
+  virtual bool optimal() const = 0;
+  virtual bool done() const = 0;
+};
+class NoSearch : public Search {
+  bool _solved;
+ public:
+  NoSearch() : _solved(false) { };
+  virtual ~NoSearch();
+  void reset();
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class Transitions : public state_vec, public Search {
+  State* target_state;
+  hsps::rational delta_bound;
+  bool bound_is_exact;
+ public:
+  Transitions();
+  Transitions(State* from, State* to, hsps::rational db);
+  virtual ~Transitions();
+  void clear();
+  bool find(State* from, State* to, hsps::rational d, bool x);
+  virtual hsps::rational new_state(State& s, hsps::rational bound);
+  virtual bool solved() const;
+  virtual bool optimal() const;
+  virtual bool done() const;
+};
+class StateFactory {
+ public:
+  virtual ~StateFactory();
+  virtual State* new_state(const index_set& s, State* pre) = 0;
+  virtual State* new_state(const bool_vec& s, State* pre) = 0;
+};
+class PlanSet {
+ public:
+  virtual ~PlanSet();
+  virtual Plan* new_plan() = 0;
+  virtual void output(PlanSet& to);
+  virtual void output(PlanSet& to, const bool_vec& s);
+};
+}
+namespace hsps {
+extern const double D_INF;
+class Stopwatch {
+  double start_t;
+  double current_t;
+  double total_t;
+  static const double TIME_OUT_TOLERANCE = 1.1;
+  static bool interrupt_signal_trapped;
+  static volatile bool interrupt_signal_raised;
+  static bool alarm_signal_trapped;
+  static volatile bool alarm_signal_raised;
+  bool interrupt_enabled;
+  bool time_out_enabled;
+  double time_out_t;
+  bool memory_limit_enabled;
+  unsigned long memory_limit;
+  bool stack_limit_enabled;
+  unsigned long stack_limit;
+  static void alarm_handler(int sig);
+  static void interrupt_handler(int sig);
+  static void check_stack();
+  void set_interrupt();
+  void clear_interrupt();
+  void set_alarm(double t);
+  void clear_alarm();
+  void check_signals();
+  static unsigned long peak_mem;
+  static unsigned long peak_size;
+  static unsigned long peak_stack;
+  static unsigned long init_stack;
+ protected:
+  bool interrupt_flag;
+  bool time_out_flag;
+  bool out_of_memory_flag;
+  bool out_of_stack_flag;
+  bool error_flag;
+  count_type running;
+  bool terminate_on_interrupt;
+  bool terminate_on_time_out;
+  bool terminate_on_out_of_memory;
+  bool terminate_on_out_of_stack;
+  bool terminate_on_error;
+ public:
+  static const long FLAG_INTERRUPTED = 1;
+  static const long FLAG_TIME_OUT = 2;
+  static const long FLAG_OUT_OF_MEMORY = 4;
+  static const long FLAG_OUT_OF_STACK = 8;
+  static const long FLAG_ERROR = 16;
+  Stopwatch();
+  ~Stopwatch();
+  static double seconds();
+  void enable_interrupt(bool terminate);
+  void disable_interrupt();
+  void enable_time_out(double t, bool terminate);
+  void disable_time_out();
+  void enable_memory_limit(unsigned long l, bool terminate);
+  void disable_memory_limit();
+  void enable_stack_limit(unsigned long l, bool terminate);
+  void disable_stack_limit();
+  void set_terminate_flags(bool on_interrupt,
+      bool on_time_out,
+      bool on_out_of_memory,
+      bool on_out_of_stack,
+      bool on_error);
+  bool interrupt_raised();
+  bool time_out_raised();
+  bool out_of_memory_raised();
+  bool out_of_stack_raised();
+  bool error_raised();
+  double remaining();
+  bool break_signal_raised();
+  virtual void interrupt();
+  virtual void time_out();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  virtual void error();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  count_type run_level() { return running; };
+  void add(Stopwatch& s);
+  void add_total(Stopwatch& s);
+  double time();
+  double total_time();
+  unsigned long peak_memory() const;
+  unsigned long peak_total_size() const;
+  unsigned long peak_stack_size() const;
+  unsigned long flags();
+  void print(::std::ostream& s);
+};
+class Statistics : public Stopwatch {
+  count_type min_nodes_created;
+  count_type max_nodes_created;
+  count_type min_nodes_expanded;
+  count_type max_nodes_expanded;
+  count_type iterations_started;
+  count_type iterations_finished;
+  count_type total_min_nodes_created;
+  count_type total_max_nodes_created;
+  count_type total_min_nodes_expanded;
+  count_type total_max_nodes_expanded;
+  count_type total_iterations_started;
+  count_type total_iterations_finished;
+  index_type max_depth;
+  hsps::rational max_lb;
+  count_type nodes_to_prove_lb;
+ public:
+  static bool long_print_format;
+  static bool running_print_max;
+  Statistics()
+    : min_nodes_created(0), max_nodes_created(0),
+    min_nodes_expanded(0), max_nodes_expanded(0),
+    iterations_started(0), iterations_finished(0),
+    total_min_nodes_created(0), total_max_nodes_created(0),
+    total_min_nodes_expanded(0), total_max_nodes_expanded(0),
+    total_iterations_started(0), total_iterations_finished(0),
+    max_depth(0), max_lb(0), nodes_to_prove_lb(0)
+    { };
+  void create_node(State& s);
+  void expand_node(State& s);
+  void current_lower_bound(hsps::rational b);
+  void begin_iteration();
+  void end_iteration();
+  virtual void start();
+  virtual void stop();
+  virtual void reset();
+  virtual void time_out();
+  virtual void interrupt();
+  virtual void out_of_memory();
+  virtual void out_of_stack();
+  void add(Statistics& s);
+  void add_nodes(Statistics& s);
+  void add_total(Statistics& s);
+  void add_nodes_total(Statistics& s);
+  double branching_factor() const {
+    return ((min_nodes_created + max_nodes_created)/
+     ((double)(min_nodes_expanded + max_nodes_expanded)));
+  };
+  count_type nodes() const {
+    return (min_nodes_expanded + max_nodes_expanded);
+  };
+  count_type total_nodes() const {
+    if (running)
+      return (total_min_nodes_expanded + total_max_nodes_expanded +
+       min_nodes_expanded + max_nodes_expanded);
+    else
+      return (total_min_nodes_expanded + total_max_nodes_expanded);
+  };
+  count_type total_min_nodes() const {
+    if (running) return (total_min_nodes_expanded + min_nodes_expanded);
+    else return total_min_nodes_expanded;
+  };
+  count_type total_max_nodes() const {
+    if (running) return (total_max_nodes_expanded + max_nodes_expanded);
+    else return total_max_nodes_expanded;
+  };
+  hsps::rational max_lower_bound() const {
+    return max_lb;
+  };
+  count_type nodes_at_max_lower_bound() const {
+    return nodes_to_prove_lb;
+  };
+  count_type iterations() {
+    return iterations_started;
+  };
+  count_type complete_iterations() {
+    return iterations_finished;
+  };
+  count_type total_iterations() {
+    if (running) return iterations_started + total_iterations_started;
+    else return total_iterations_started;
+  };
+  count_type total_complete_iterations() {
+    if (running) return iterations_finished + total_iterations_finished;
+    else return total_iterations_finished;
+  };
+  void print_brief(::std::ostream& s, const char* p = 0);
+  void print(::std::ostream& s, const char* p = 0);
+  void print_total(::std::ostream& s, const char* p = 0);
+};
+inline ::std::ostream& operator<<(::std::ostream& s, Stopwatch& t) {
+  return s << t.total_time();
+}
+inline ::std::ostream& operator<<(::std::ostream& s, Statistics& t) {
+  if (Statistics::long_print_format) {
+    t.print_total(s);
+    return s;
+  }
+  else {
+    return s << t.total_nodes() << " nodes, "
+      << t.total_time() << " seconds, "
+      << t.peak_memory() << "k heap, "
+      << t.peak_stack_size() << "k stack";
+  }
+}
+}
+#include <sys/resource.h>
+#include <unistd.h>
+#include <signal.h>
+#include <alloca.h>
+#include <sstream>
+#include <fstream>
+#include <math.h>
+namespace hsps {
+const double D_INF = ((double)(1.0/0.0));
+unsigned long Stopwatch::peak_mem = 0;
+unsigned long Stopwatch::peak_size = 0;
+unsigned long Stopwatch::peak_stack = 0;
+unsigned long Stopwatch::init_stack = 0;
+bool Statistics::long_print_format = false;
+bool Statistics::running_print_max = false;
+bool Stopwatch::interrupt_signal_trapped = false;
+volatile bool Stopwatch::interrupt_signal_raised = false;
+bool Stopwatch::alarm_signal_trapped = false;
+volatile bool Stopwatch::alarm_signal_raised = false;
+double Stopwatch::seconds()
+{
+  rusage u;
+  getrusage(RUSAGE_SELF, &u);
+  ::std::ostringstream fn;
+  fn << "/proc/" << getpid() << "/stat";
+  std::ifstream ps_in(fn.str().c_str());
+  std::string item;
+  for (index_type n = 0; n < 23; n++) {
+    ps_in >> item;
+  }
+  ps_in.close();
+  long vm = atoi(item.c_str()) / 1024;
+  if (vm > Stopwatch::peak_mem) {
+    Stopwatch::peak_mem = vm;
+  }
+  if (vm > Stopwatch::peak_size) {
+    Stopwatch::peak_size = vm;
+  }
+  check_stack();
+  return (u.ru_utime.tv_sec + (u.ru_utime.tv_usec / 1000000.0));
+}
+Stopwatch::Stopwatch()
+  : start_t(0.0),
+    current_t(0.0),
+    total_t(0.0),
+    interrupt_enabled(false),
+    time_out_enabled(false),
+    time_out_t(0.0),
+    memory_limit_enabled(false),
+    memory_limit(0),
+    stack_limit_enabled(false),
+    stack_limit(0),
+    interrupt_flag(false),
+    time_out_flag(false),
+    out_of_memory_flag(false),
+    out_of_stack_flag(false),
+    error_flag(false),
+    running(0),
+    terminate_on_interrupt(false),
+    terminate_on_time_out(false),
+    terminate_on_out_of_memory(false),
+    terminate_on_out_of_stack(false),
+    terminate_on_error(false)
+{
+}
+Stopwatch::~Stopwatch()
+{
+}
+void Stopwatch::alarm_handler(int sig)
+{
+  alarm_signal_raised = true;
+}
+void Stopwatch::interrupt_handler(int sig)
+{
+  if (interrupt_signal_raised) exit(255);
+  interrupt_signal_raised = true;
+  signal(SIGINT, Stopwatch::interrupt_handler);
+}
+void Stopwatch::set_alarm(double t)
+{
+  if ((memory_limit_enabled || stack_limit_enabled) &&
+      (t > 2.0))
+    t = 2.0;
+  unsigned int sec = (unsigned int)floor(t);
+  if (sec > 0) {
+    alarm_signal_trapped = true;
+    alarm_signal_raised = false;
+    signal(SIGALRM, Stopwatch::alarm_handler);
+    alarm(sec);
+  }
+  else if (time_out_enabled) {
+    alarm_signal_trapped = false;
+    alarm_signal_raised = false;
+    time_out();
+  }
+}
+void Stopwatch::clear_alarm()
+{
+  alarm_signal_trapped = false;
+  alarm_signal_raised = false;
+}
+void Stopwatch::set_interrupt()
+{
+  signal(SIGINT, Stopwatch::interrupt_handler);
+  interrupt_signal_trapped = true;
+  interrupt_signal_raised = false;
+}
+void Stopwatch::clear_interrupt()
+{
+  signal(SIGINT, SIG_DFL);
+  interrupt_signal_trapped = false;
+  interrupt_signal_raised = false;
+}
+void Stopwatch::check_signals()
+{
+  if (interrupt_signal_trapped && interrupt_signal_raised) {
+    signal(SIGINT, SIG_DFL);
+    interrupt();
+  }
+  if (alarm_signal_trapped && alarm_signal_raised) {
+    double r = remaining();
+    if (time_out_enabled && (r < TIME_OUT_TOLERANCE)) {
+      time_out();
+    }
+    else if (memory_limit_enabled && (peak_memory() > memory_limit)) {
+      out_of_memory();
+    }
+    else if (stack_limit_enabled && (peak_stack_size() > stack_limit)) {
+      out_of_stack();
+    }
+    else {
+      set_alarm(r);
+    }
+  }
+}
+void Stopwatch::check_stack()
+{
+  unsigned long current_stack = (unsigned long)alloca(4);
+  if (init_stack == 0) {
+    init_stack = current_stack;
+  }
+  else {
+    if (current_stack < init_stack) {
+      unsigned long used_stack = ((init_stack - current_stack) / 1024);
+      if (used_stack > peak_stack) {
+ peak_stack = used_stack;
+      }
+    }
+    else {
+      unsigned long used_stack = ((current_stack - init_stack) / 1024);
+      if (used_stack > peak_stack) {
+ peak_stack = used_stack;
+      }
+    }
+  }
+}
+void Stopwatch::enable_interrupt(bool terminate)
+{
+  interrupt_enabled = true;
+  terminate_on_interrupt = terminate;
+}
+void Stopwatch::disable_interrupt()
+{
+  interrupt_enabled = false;
+}
+void Stopwatch::enable_time_out(double t, bool terminate)
+{
+  time_out_enabled = true;
+  time_out_t = total_time() + t;
+  time_out_flag = false;
+  terminate_on_time_out = terminate;
+}
+void Stopwatch::disable_time_out()
+{
+  time_out_enabled = false;
+}
+void Stopwatch::enable_memory_limit(unsigned long l, bool terminate)
+{
+  memory_limit_enabled = true;
+  memory_limit = l;
+  out_of_memory_flag = false;
+  terminate_on_out_of_memory = terminate;
+}
+void Stopwatch::disable_memory_limit()
+{
+  memory_limit_enabled = false;
+}
+void Stopwatch::enable_stack_limit(unsigned long l, bool terminate)
+{
+  stack_limit_enabled = true;
+  stack_limit = l;
+  out_of_stack_flag = false;
+  terminate_on_out_of_stack = terminate;
+}
+void Stopwatch::disable_stack_limit()
+{
+  stack_limit_enabled = false;
+}
+void Stopwatch::set_terminate_flags
+(bool on_int, bool on_to, bool on_mo, bool on_so, bool on_err)
+{
+  terminate_on_interrupt = on_int;
+  terminate_on_time_out = on_to;
+  terminate_on_out_of_memory = on_mo;
+  terminate_on_out_of_stack = on_so;
+  terminate_on_error = on_err;
+}
+bool Stopwatch::interrupt_raised()
+{
+  if (interrupt_signal_trapped) check_signals();
+  return interrupt_flag;
+}
+bool Stopwatch::time_out_raised()
+{
+  if (alarm_signal_trapped) check_signals();
+  return time_out_flag;
+}
+bool Stopwatch::out_of_memory_raised()
+{
+  if (alarm_signal_trapped) check_signals();
+  return (memory_limit_enabled && (peak_memory() > memory_limit));
+}
+bool Stopwatch::out_of_stack_raised()
+{
+  if (alarm_signal_trapped) check_signals();
+  return (stack_limit_enabled && (peak_stack_size() > stack_limit));
+}
+bool Stopwatch::error_raised()
+{
+  return error_flag;
+}
+bool Stopwatch::break_signal_raised()
+{
+  if (interrupt_signal_trapped || alarm_signal_trapped) check_signals();
+  return (interrupt_flag ||
+   time_out_flag ||
+   (memory_limit_enabled && (peak_memory() > memory_limit)) ||
+   (stack_limit_enabled && (peak_stack_size() > stack_limit)) ||
+   error_flag);
+}
+double Stopwatch::remaining()
+{
+  if (time_out_enabled) {
+    return time_out_t - total_time();
+  }
+  else {
+    seconds();
+    return D_INF;
+  }
+}
+void Stopwatch::start()
+{
+  if (running == 0) {
+    start_t = seconds();
+    if (interrupt_enabled) set_interrupt();
+    if (time_out_enabled || memory_limit_enabled || stack_limit_enabled)
+      set_alarm(remaining());
+  }
+  running += 1;
+}
+void Stopwatch::stop()
+{
+  if (running == 0) return;
+  running -= 1;
+  if (running == 0) {
+    current_t = seconds() - start_t;
+    if (current_t < 0.0) current_t = 0.0;
+    total_t += current_t;
+    if (alarm_signal_trapped) clear_alarm();
+    if (interrupt_enabled) clear_interrupt();
+  }
+}
+void Stopwatch::reset()
+{
+  running = 0;
+  start_t = 0.0;
+  current_t = 0.0;
+  total_t = 0.0;
+}
+void Stopwatch::time_out()
+{
+  if (!time_out_flag) {
+    ::std::cerr << "time-out: " << total_time() << ::std::endl;
+    time_out_flag = true;
+  }
+  if (terminate_on_time_out) exit(0);
+}
+void Stopwatch::out_of_memory()
+{
+  if (!out_of_memory_flag) {
+    ::std::cerr << "memory limit exceeded: " << peak_memory() << ::std::endl;
+    out_of_memory_flag = true;
+  }
+  if (terminate_on_out_of_memory) exit(0);
+}
+void Stopwatch::out_of_stack()
+{
+  if (!out_of_stack_flag) {
+    ::std::cerr << "stack limit exceeded: " << peak_stack_size() << ::std::endl;
+    out_of_stack_flag = true;
+  }
+  if (terminate_on_out_of_stack) exit(0);
+}
+void Stopwatch::interrupt()
+{
+  if (!interrupt_flag) {
+    ::std::cerr << "interrupt: " << total_time() << ::std::endl;
+    interrupt_flag = true;
+  }
+  if (terminate_on_interrupt) exit(0);
+}
+void Stopwatch::error()
+{
+  if (!error_flag) {
+    error_flag = true;
+  }
+  if (terminate_on_error) exit(0);
+}
+void Stopwatch::add(Stopwatch& s)
+{
+  total_t += s.time();
+}
+void Stopwatch::add_total(Stopwatch& s)
+{
+  total_t += s.total_time();
+}
+double Stopwatch::time()
+{
+  if (running > 0) {
+    current_t = seconds() - start_t;
+    if (current_t < 0.0) current_t = 0.0;
+  }
+  return current_t;
+}
+double Stopwatch::total_time()
+{
+  if (running > 0) return total_t + time();
+  else return total_t;
+}
+unsigned long Stopwatch::peak_memory() const
+{
+  return peak_mem;
+}
+unsigned long Stopwatch::peak_total_size() const
+{
+  return peak_size;
+}
+unsigned long Stopwatch::peak_stack_size() const
+{
+  return peak_stack;
+}
+unsigned long Stopwatch::flags()
+{
+  return ((interrupt_raised() ? FLAG_INTERRUPTED : 0) +
+   (time_out_raised() ? FLAG_TIME_OUT : 0) +
+   (out_of_memory_raised() ? FLAG_OUT_OF_MEMORY : 0) +
+   (out_of_stack_raised() ? FLAG_OUT_OF_STACK : 0) +
+   (error_raised() ? FLAG_ERROR : 0));
+}
+void Statistics::create_node(State& s)
+{
+  if (s.is_max()) max_nodes_created += 1;
+  else min_nodes_created += 1;
+  index_type d = s.depth();
+  if (d > max_depth) {
+    max_depth = d;
+    if (running_print_max) {
+      ::std::cerr << "max depth: " << d << " (" << *this << ")" << ::std::endl;
+    }
+  }
+}
+void Statistics::expand_node(State& s)
+{
+  if (s.is_max()) max_nodes_expanded += 1;
+  else min_nodes_expanded += 1;
+}
+void Statistics::current_lower_bound(hsps::rational b)
+{
+  if (b > max_lb) {
+    max_lb = b;
+    nodes_to_prove_lb = nodes();
+  }
+}
+void Statistics::begin_iteration()
+{
+  iterations_started += 1;
+}
+void Statistics::end_iteration()
+{
+  iterations_finished += 1;
+}
+void Statistics::start()
+{
+  if (running == 0) {
+    min_nodes_created = 0;
+    max_nodes_created = 0;
+    min_nodes_expanded = 0;
+    max_nodes_expanded = 0;
+    iterations_started = 0;
+    iterations_finished = 0;
+  }
+  Stopwatch::start();
+}
+void Statistics::stop()
+{
+  Stopwatch::stop();
+  if (running == 0) {
+    total_min_nodes_created += min_nodes_created;
+    total_max_nodes_created += max_nodes_created;
+    total_min_nodes_expanded += min_nodes_expanded;
+    total_max_nodes_expanded += max_nodes_expanded;
+    total_iterations_started += iterations_started;
+    total_iterations_finished += iterations_finished;
+  }
+}
+void Statistics::reset()
+{
+  Stopwatch::reset();
+  min_nodes_created = 0;
+  max_nodes_created = 0;
+  min_nodes_expanded = 0;
+  max_nodes_expanded = 0;
+  iterations_started = 0;
+  iterations_finished = 0;
+  total_min_nodes_created = 0;
+  total_max_nodes_created = 0;
+  total_min_nodes_expanded = 0;
+  total_max_nodes_expanded = 0;
+  total_iterations_started = 0;
+  total_iterations_finished = 0;
+  max_depth = 0;
+  max_lb = 0;
+  nodes_to_prove_lb = 0;
+}
+void Statistics::time_out()
+{
+  if (!time_out_flag) {
+    ::std::cerr << "time-out: " << *this << ::std::endl;
+    time_out_flag = true;
+  }
+  if (terminate_on_time_out) exit(0);
+}
+void Statistics::interrupt()
+{
+  if (!interrupt_flag) {
+    ::std::cerr << "interrupt: " << *this << ::std::endl;
+    interrupt_flag = true;
+  }
+  if (terminate_on_interrupt) exit(0);
+}
+void Statistics::out_of_memory()
+{
+  if (!out_of_memory_flag) {
+    ::std::cerr << "memory limit exceeded: " << *this << ::std::endl;
+    out_of_memory_flag = true;
+  }
+  if (terminate_on_out_of_memory) exit(0);
+}
+void Statistics::out_of_stack()
+{
+  if (!out_of_stack_flag) {
+    ::std::cerr << "stack limit exceeded: " << *this << ::std::endl;
+    out_of_stack_flag = true;
+  }
+  if (terminate_on_out_of_stack) exit(0);
+}
+void Statistics::add(Statistics& s)
+{
+  Stopwatch::add(s);
+  add_nodes(s);
+  total_iterations_started += s.iterations_started;
+  total_iterations_finished += s.iterations_finished;
+}
+void Statistics::add_total(Statistics& s)
+{
+  Stopwatch::add_total(s);
+  add_nodes_total(s);
+  total_iterations_started += s.total_iterations_started;
+  total_iterations_finished += s.total_iterations_finished;
+}
+void Statistics::add_nodes(Statistics& s)
+{
+  total_min_nodes_created += s.min_nodes_created;
+  total_max_nodes_created += s.max_nodes_created;
+  total_min_nodes_expanded += s.min_nodes_expanded;
+  total_max_nodes_expanded += s.max_nodes_expanded;
+}
+void Statistics::add_nodes_total(Statistics& s)
+{
+  total_min_nodes_created += s.total_min_nodes_created;
+  total_max_nodes_created += s.total_max_nodes_created;
+  total_min_nodes_expanded += s.total_min_nodes_expanded;
+  total_max_nodes_expanded += s.total_max_nodes_expanded;
+}
+void Statistics::print_brief(::std::ostream& s, const char* p)
+{
+  if (p) s << p;
+  s << time() << " sec, "
+    << min_nodes_created << "/" << max_nodes_created << " n.c., "
+    << min_nodes_expanded << "/" << max_nodes_expanded << " n.x., "
+    << nodes()/time() << " nodes/sec." << ::std::endl;
+}
+void Statistics::print(::std::ostream& s, const char* p)
+{
+  if (p) s << p;
+  s << "time: " << time() << " seconds" << ::std::endl;
+  if (p) s << p;
+  s << "nodes created: " << min_nodes_created << " min / "
+    << max_nodes_created << " max" << ::std::endl;
+  if (p) s << p;
+  s << "nodes expanded: " << min_nodes_expanded << " min / "
+    << max_nodes_expanded << " max ("
+    << nodes()/time() << " nodes/sec.)" << ::std::endl;
+}
+void Statistics::print_total(::std::ostream& s, const char* p)
+{
+  if (p) s << p;
+  s << "total time: " << total_time() << " seconds" << ::std::endl;
+  if (running > 0) {
+    if (p) s << p;
+    s << "total nodes created: "
+      << total_min_nodes_created + min_nodes_created << " min / "
+      << total_max_nodes_created + max_nodes_created << " max" << ::std::endl;
+    if (p) s << p;
+    s << "total nodes expanded: "
+      << total_min_nodes_expanded + min_nodes_expanded << " min / "
+      << total_max_nodes_expanded + max_nodes_expanded << " max ("
+      << total_nodes()/total_time() << " nodes/sec.)" << ::std::endl;
+  }
+  else {
+    if (p) s << p;
+    s << "total nodes created: " << total_min_nodes_created << " min / "
+      << total_max_nodes_created << " max" << ::std::endl;
+    if (p) s << p;
+    s << "total nodes expanded: " << total_min_nodes_expanded << " min / "
+      << total_max_nodes_expanded << " max ("
+      << total_nodes()/total_time() << " nodes/sec.)" << ::std::endl;
+  }
+}
+}

--- a/pr/seq-opt-hspsf/string_table.ccx
+++ b/pr/seq-opt-hspsf/string_table.ccx
@@ -1,0 +1,1653 @@
+#include <string.h>
+inline char* strndup(char* s, unsigned int n)
+{
+  char* d = new char[n+1];
+  strncpy(s, d, n);
+  return d;
+}
+#include <assert.h>
+#include <limits.h>
+#include <vector>
+#include <utility>
+#include <iostream>
+namespace hsps {
+typedef unsigned int index_type;
+const index_type index_type_max = (UINT_MAX - 1);
+
+const index_type LARGE_PRIME = 2147483629U;
+const index_type no_such_index = UINT_MAX;
+
+typedef unsigned long count_type;
+const count_type count_type_max = ULONG_MAX;
+
+template<class T> class swapable_pair : public std::pair<T, T>
+{
+ public:
+  swapable_pair()
+    : std::pair<T, T>() { };
+  swapable_pair(const T& v1, const T& v2)
+    : std::pair<T, T>(v1, v2) { };
+  swapable_pair(const T& v)
+    : std::pair<T, T>(v, v) { };
+  swapable_pair(const swapable_pair& p)
+    : std::pair<T, T>(p) { };
+
+  void swap();
+};
+
+template<class T> class comparable_pair : public swapable_pair<T>
+{
+ public:
+  comparable_pair()
+    : swapable_pair<T>() { };
+  comparable_pair(const T& v1, const T& v2)
+    : swapable_pair<T>(v1, v2) { };
+  comparable_pair(const T& v)
+    : swapable_pair<T>(v) { };
+  comparable_pair(const comparable_pair& p)
+    : swapable_pair<T>(p) { };
+
+  void sort_ascending();
+  void sort_descending();
+};
+
+typedef comparable_pair<index_type> index_pair;
+
+template<class T> class zero_init_pair : public comparable_pair<T>
+{
+ public:
+  zero_init_pair()
+    : comparable_pair<T>(0) { };
+  zero_init_pair(const T& v1, const T& v2)
+    : comparable_pair<T>(v1, v2) { };
+  zero_init_pair(const T& v)
+    : comparable_pair<T>(v) { };
+  zero_init_pair(const zero_init_pair& p)
+    : comparable_pair<T>(p) { };
+};
+
+
+
+
+class index_set;
+class bool_vec;
+
+template<class T> class lvector : public std::vector<T>
+{
+ public:
+  lvector() : std::vector<T>() { };
+  lvector(const T& v, index_type l) : std::vector<T>(l, v) { };
+  lvector(const lvector<T>& vec) : std::vector<T>(vec) { };
+
+
+
+
+  class element_reference {
+    lvector* _vec;
+    index_type _pos;
+  public:
+    element_reference() : _vec(0), _pos(no_such_index) { };
+    element_reference(lvector& v, index_type p) : _vec(&v), _pos(p) { };
+    operator T*() const {
+      if (_vec == 0) return 0;
+      return &((*_vec)[_pos]);
+    };
+  };
+
+  class order {
+   public:
+    virtual bool operator()(const T& v0, const T& v1) const = 0;
+  };
+
+  index_type length() const;
+  bool contains(const T& v) const;
+  index_type first(const T& v) const;
+  index_type next(const T& v, index_type i) const;
+  index_type find(const T& v, bool_vec& s) const;
+  index_type count(const T& v) const;
+  index_type arg_max() const;
+  index_type arg_min() const;
+  index_type arg_first(const order& o) const;
+  index_type arg_last(const order& o) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  void difference(const lvector& v1, lvector& d0, lvector& d1);
+  bool operator==(const lvector& _vec) const;
+  bool operator!=(const lvector& _vec) const;
+  bool operator<(const lvector& vec) const;
+  bool operator>(const lvector& vec) const;
+  bool operator<=(const lvector& vec) const;
+  bool operator>=(const lvector& vec) const;
+  void assign_copy(const lvector& _vec);
+  void assign_copy(const T* _arr, index_type n);
+  void assign_value(const T& val);
+  void assign_value(const T& val, index_type l);
+  void assign_remap(const lvector& vec, const lvector<index_type>& map);
+  void remap(const lvector<index_type>& map);
+  void assign_select(const lvector& _vec, const index_set& s);
+  void assign_select(const lvector& _vec, const bool_vec& s);
+  const lvector& operator=(const lvector& _vec);
+  void set_length(index_type l);
+  void set_length(index_type l, const T& v);
+  void inc_length_to(index_type l);
+  void inc_length_to(index_type l, const T& v);
+  index_type inc_length() { return inc_length(1); };
+  index_type inc_length(index_type d);
+  index_type inc_length(index_type d, const T& v);
+  index_type dec_length() { return dec_length(1); };
+  index_type dec_length(index_type d);
+  void clear();
+  void append(const T& v);
+  void append(const lvector& v);
+  T& append();
+  void insert(const T& v, index_type p);
+  index_type insert_ordered(const T& v, const order& o, index_type f = 0);
+  index_type insert_ordered(const lvector& vec, const order& o);
+  void remove(index_type p);
+  void remove(index_type p0, index_type p1);
+  void remove(const index_set& s);
+  void remove(const index_set& s, lvector<index_type>& map);
+  void remove(const bool_vec& s);
+  void remove(const bool_vec& s, lvector<index_type>& map);
+  void remove_duplicate_elements();
+  void swap(index_type i, index_type j);
+};
+template<class T> class auto_expanding_vector : public lvector<T>
+{
+  T _default;
+ public:
+  auto_expanding_vector() : lvector<T>() { };
+  auto_expanding_vector(const T& v, index_type l)
+    : lvector<T>(v, l), _default(v) { };
+  auto_expanding_vector(const lvector<T>& vec)
+    : lvector<T>(vec) { };
+  auto_expanding_vector(const auto_expanding_vector<T>& vec)
+    : lvector<T>(vec), _default(vec._default) { };
+  typename std::vector<T>::reference
+  operator[](typename std::vector<T>::size_type k)
+  {
+    inc_length_to(k + 1, _default);
+    return lvector<T>::operator[](k);
+  };
+  typename std::vector<T>::const_reference
+  operator[](typename std::vector<T>::size_type k) const
+  {
+    if (k >= std::vector<T>::size())
+      return _default;
+    else
+      return lvector<T>::operator[](k);
+  };
+  void assign_value(const T& val)
+  {
+    _default = val;
+    lvector<T>::assign_value(val);
+  };
+  void assign_value(const T& val, index_type l)
+  {
+    _default = val;
+    lvector<T>::assign_value(val, l);
+  };
+};
+typedef lvector<index_type> index_vec;
+typedef lvector<index_pair> pair_vec;
+class index_vec_util : public index_vec
+{
+ public:
+  class decreasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 > v1); };
+  };
+  class increasing_index_order : public index_vec::order {
+  public:
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      { return (v0 < v1); };
+  };
+  class increasing_value_order : public index_vec::order {
+    const index_vec& value;
+  public:
+    increasing_value_order(const index_vec& v) : value(v) { };
+    virtual bool operator()
+      (const index_type& v0, const index_type& v1) const
+      {
+ assert(v0 < value.length());
+ assert(v1 < value.length());
+ return (value[v0] < value[v1]);
+      };
+  };
+  static class decreasing_index_order decreasing;
+  static class increasing_index_order increasing;
+  static void fill(index_vec& vec, index_type max);
+  static index_type min(const index_vec& vec, index_type def = no_such_index);
+  static index_type max(const index_vec& vec, index_type def = no_such_index);
+  static int compare(const index_vec& v0, const index_vec& v1);
+  static index_type hash(const index_vec& vec);
+  void fill(index_type max);
+  int compare(const index_vec& v1) const;
+  index_type hash() const;
+};
+void factors(index_type n, index_vec& f);
+template<class T> class svector : public lvector<T>
+{
+ public:
+  svector() : lvector<T>() { };
+  svector(const svector<T>& _svec) : lvector<T>(_svec) { };
+  svector(const lvector<T>& _lvec) : lvector<T>() {
+    for (index_type k = 0; k < _lvec.size(); k++) insert(_lvec[k]);
+  };
+  bool contains(const T& v) const;
+  bool contains(const svector& vec) const;
+  bool subset(const svector& vec) const;
+  index_pair first_common(const lvector<T>& vec) const;
+  index_pair next_common(const lvector<T>& vec, index_pair p) const;
+  index_pair first_common(const svector<T>& vec) const;
+  index_pair next_common(const svector<T>& vec, index_pair p) const;
+  index_type count_common(const svector& vec) const;
+  void assign_singleton(const T& _val);
+  void assign_values(const lvector<T>& vec);
+  void insert(const T& v);
+  void insert(const lvector<T>& vec);
+  void intersect(const svector& vec);
+  void difference(const svector& vec);
+  void subtract(const svector& vec);
+  void subtract(const T& v);
+};
+class index_set : public svector<index_type>
+{
+ public:
+  index_set()
+    : svector<index_type>() { };
+  index_set(const index_set& _svec)
+    : svector<index_type>(_svec) { };
+  index_set(const lvector<index_type>& _lvec)
+    : svector<index_type>(_lvec) { };
+  index_set(const bool* _arr, index_type n);
+  index_set(const bool_vec& _vec);
+  index_set(const index_set& s0, const index_set& s);
+  index_set(const index_set& s0, const bool_vec& s);
+  index_set(const index_set& s0, const index_vec& map);
+  index_type first_common_element(const index_set& set) const;
+  index_type first_common_element(const index_vec& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type first_common_element(const bool* vec, index_type n) const;
+  index_type count_common(const index_set& set) const;
+  index_type count_common(const bool_vec& set) const;
+  bool have_common_element(const index_set& set) const;
+  bool have_common_element(const bool_vec& set) const;
+  void insert(const index_type& v);
+  void insert(const index_vec& vec);
+  void insert(const bool_vec& set);
+  void intersect(const index_set& vec);
+  void intersect(const bool_vec& set);
+  void subtract(const index_vec& vec);
+  void subtract(const bool_vec& set);
+  void subtract(const index_type& v);
+  bool* copy_to(bool* s, index_type n) const;
+  void fill(index_type to);
+  void assign_remap(const index_set& set, const index_vec& map);
+  void remap(const index_vec& map);
+};
+extern const index_set EMPTYSET;
+typedef svector<index_pair> pair_set;
+class bool_vec : public lvector<bool>
+{
+ public:
+  bool_vec() : lvector<bool>() { };
+  bool_vec(bool _val, index_type l) : lvector<bool>(_val, l) { };
+  bool_vec(const bool_vec& _vec) : lvector<bool>(_vec) { };
+  bool_vec(const bool* _arr, index_type n) : lvector<bool>(false, n) {
+    for (index_type k = 0; k < n; k++) {
+      if (_arr[k])
+ (*this)[k] = true;
+      else
+ (*this)[k] = false;
+    }
+  };
+  bool_vec(const index_set& set, index_type l);
+  void complement();
+  void insert(const bool_vec& vec);
+  void insert(const index_set& set);
+  void intersect(const bool_vec& vec);
+  void intersect(const index_set& set);
+  void subtract(const bool_vec& vec);
+  void subtract(const index_set& set);
+  bool subset(const bool_vec& vec) const;
+  bool strict_subset(const bool_vec& vec) const;
+  bool superset(const bool_vec& vec) const;
+  bool strict_superset(const bool_vec& vec) const;
+  bool contains(const bool& v) const;
+  bool contains(const bool_vec& set) const;
+  bool contains(const index_set& set) const;
+  bool contains_any(const index_set& set) const;
+  index_type first_common_element(const index_set& vec) const;
+  index_type first_common_element(const bool_vec vec) const;
+  index_type count_common(const bool_vec& vec) const;
+  index_type count_common(const index_set& set) const;
+  index_set& copy_to(index_set& set) const;
+  index_set& insert_into(index_set& set) const;
+  index_set& subtract_from(index_set& set) const;
+  bool* copy_to(bool* s, index_type n) const;
+  int compare(const bool_vec& vec) const;
+  index_type hash() const;
+};
+class index_set_vec : public lvector<index_set>
+{
+ public:
+  index_set_vec()
+    : lvector<index_set>() { };
+  index_set_vec(const index_set& set, index_type l)
+    : lvector<index_set>(set, l) { };
+  index_set_vec(index_type l)
+    : lvector<index_set>(EMPTYSET, l) { };
+  index_set_vec(const index_set_vec& vec)
+    : lvector<index_set>(vec) { };
+  class decreasing_cardinality_order : public index_set_vec::order {
+  public:
+    virtual bool operator()
+      (const index_set& v0, const index_set& v1) const
+      { return (v0.size() > v1.size()); };
+  };
+  decreasing_cardinality_order decreasing_cardinality;
+  index_type minimum_cardinality() const;
+  index_type maxmimum_cardinality() const;
+  index_type selected_minimum_cardinality(const index_set& sel) const;
+  index_type selected_maximum_cardinality(const index_set& sel) const;
+  index_type first_minimum_cardinality_set() const;
+  index_type first_maxmimum_cardinality_set() const;
+  index_type first_superset(const index_set& set) const;
+  index_type first_strict_superset(const index_set& set) const;
+  index_type first_subset(const index_set& set) const;
+  index_type first_strict_subset(const index_set& set) const;
+  index_set& union_set(index_set& set) const;
+  index_set& selected_union_set(const index_set& sel, index_set& set) const;
+  index_set& intersection_set(index_set& set) const;
+  void insert_maximal(const index_set& set);
+  void insert_minimal(const index_set& set);
+  void reduce_to_maximal();
+  void reduce_to_minimal();
+  void append_if_not_subset(const index_set& set);
+  void append_if_not_superset(const index_set& set);
+  void append_if_new(const index_set& set);
+  void remove_sets_size_le(index_type l);
+  void remove_empty_sets();
+  void insert_in_all(index_type i);
+  void insert_in_all(const index_set& set);
+  void subtract_from_all(index_type i);
+  void subtract_from_all(const index_set& set);
+  void combinations_by_union(const index_set_vec& sv);
+  void combinations_by_union(const index_set_vec& sv1,
+        const index_set_vec& sv2);
+};
+template<class T> class matrix : public lvector< lvector<T> >
+{
+ public:
+  typedef lvector<T> row_type;
+  matrix()
+    : lvector<row_type>() { };
+  matrix(const T& _val, index_type r, index_type c)
+    : lvector<row_type>(row_type(_val, c), r) { };
+  matrix(const matrix& _mat)
+    : lvector<row_type>(_mat) { };
+  index_type rows() const
+  {
+    return lvector<row_type>::length();
+  };
+  index_type columns() const
+  {
+    if (lvector<row_type>::length() == 0) return 0;
+    else return (*this)[0].length();
+  };
+  void set_size(index_type r, index_type c);
+  void assign_value(const T& _val);
+  void assign_value(const T& _val, index_type r, index_type c);
+};
+class bool_matrix : public matrix<bool> {
+ public:
+  bool_matrix()
+    : matrix<bool>() { };
+  bool_matrix(const bool& v, index_type r, index_type c)
+    : matrix<bool>(v, c, r) { };
+  bool_matrix(const bool_matrix& m)
+    : matrix<bool>(m) { };
+  void complement();
+  void insert(const bool_matrix& m);
+  void intersect(const bool_matrix& m);
+  void subtract(const bool_matrix& m);
+  void multiply(const bool_matrix& m0, const bool_matrix& m1);
+  void transitive_closure();
+};
+typedef matrix<index_type> index_matrix;
+class mapping : public index_vec
+{
+ public:
+  static void identity_map
+    (index_type n, index_vec& map)
+    { index_vec_util::fill(map, n); };
+  static bool invert_map
+    (const index_vec& map, index_vec& inv, index_type m = 0);
+  static void delete_index_map
+    (index_type n, index_type i, index_vec& map);
+  static void compose
+    (const index_vec& m0, const index_vec& m1, index_vec& cm);
+  static void map_image
+    (const index_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const index_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const index_vec& map, const index_set& x, index_set& img);
+  static index_type range(const index_vec& map, index_type d);
+  mapping()
+    : index_vec() { };
+  mapping(index_type n)
+    : index_vec() { identity_map(n, *this); };
+  mapping(index_type n, index_type i, bool out) : index_vec() {
+    if (out) delete_index_map(n, i, *this); else assign_value(i, n);
+  };
+  mapping(const mapping& map)
+    : index_vec(map) { };
+  void assign_identity(index_type n)
+    { identity_map(n, *this); };
+  index_type operator()(index_type x) const
+    { assert(x < size()); return (*this)[x]; };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_vec& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_vec& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  bool invert(index_vec& rmap) const
+    { return invert_map(*this, rmap); };
+  bool invert()
+    { index_vec tmp(*this); return invert_map(tmp, *this); };
+  index_type range() const
+    { return range(*this, length()); };
+};
+class sparse_mapping : public pair_vec
+{
+ public:
+  static void dense_to_sparse(const index_vec& dm, pair_vec sm);
+  static void sparse_to_dense(const pair_vec& sm, index_vec dm);
+  static index_type map_image
+    (const pair_vec& map, index_type x);
+  static void map_image
+    (const pair_vec& map, const index_vec& vec, index_vec& img);
+  static void inverse_map_image
+    (const pair_vec& map, index_type x, index_set& img);
+  static void inverse_map_image
+    (const pair_vec& map, const index_set& x, index_set& img);
+  sparse_mapping()
+    : pair_vec() { };
+  sparse_mapping(const pair_vec& m)
+    : pair_vec(m) { };
+  sparse_mapping(const index_vec& m)
+    : pair_vec() { dense_to_sparse(m, *this); };
+  index_type operator()(index_type x) const
+    { return map_image(*this, x); };
+  index_vec operator()(const index_vec& vec) const
+    { index_vec res; map_image(*this, vec, res); return res; };
+  index_set& inverse(index_type x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+  index_set& inverse(const index_set& x, index_set& res) const
+    { inverse_map_image(*this, x, res); return res; };
+};
+class equivalence : public index_vec
+{
+ public:
+  equivalence()
+    : index_vec() { };
+  equivalence(index_type n)
+    : index_vec(no_such_index, n) { index_vec_util::fill(*this, n); };
+  equivalence(const equivalence& eq)
+    : index_vec(eq) { };
+  bool operator()(index_type a, index_type b) const;
+  index_type canonical(index_type a) const;
+  void extend(index_type a);
+  void merge(index_type a, index_type b);
+  void merge(const equivalence& eq);
+  void merge(const index_set& set);
+  void merge(const index_set& sa, const index_set& sb);
+  void reset();
+  void reset(index_type n);
+  void canonical_set(index_set& set) const;
+  void canonical_elements(index_set& set) const;
+  void class_elements(index_type rep, index_set& set) const;
+  index_type n_class_elements(index_type rep) const;
+  void classes(index_set_vec& sets) const;
+  void make_map(index_vec& map) const;
+  index_type n_classes() const;
+  index_type n_squeezed() const;
+};
+class set_hash_function : index_vec
+{
+ public:
+  set_hash_function(index_type n)
+    : index_vec() { init(n); };
+  void init(index_type n);
+  index_type operator()(index_type& i, index_type v) const;
+  index_type operator()(const index_set& set) const;
+  index_type operator()(const bool_vec& set) const;
+  index_type operator()(const bool* set, index_type n) const;
+};
+template<class T, class N> struct weighted
+{
+  T value;
+  N weight;
+  weighted() : weight(0) { };
+  weighted(const T& v) : value(v), weight(0) { };
+  weighted(const T& v, const N& w) : value(v), weight(w) { };
+  weighted(const weighted& w) : value(w.value), weight(w.weight) { };
+  ~weighted() { };
+  weighted& operator=(const T& v)
+  {
+    value = v;
+    weight = 0;
+    return *this;
+  };
+  weighted& operator=(const weighted& w)
+  {
+    value = w.value;
+    weight = w.weight;
+    return *this;
+  };
+  bool operator==(const weighted& w) const
+  {
+    return (value == w.value);
+  };
+  bool operator!=(const weighted& w) const
+  {
+    return (value != w.value);
+  };
+  bool operator<(const weighted& w) const
+  {
+    return (value < w.value);
+  };
+  bool operator<=(const weighted& w) const
+  {
+    return (value <= w.value);
+  };
+  bool operator>(const weighted& w) const
+  {
+    return (value > w.value);
+  };
+  bool operator>=(const weighted& w) const
+  {
+    return (value >= w.value);
+  };
+};
+template<class T, class N> class weighted_vec
+: public lvector< weighted<T, N> >
+{
+ public:
+  class decreasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight > v1.weight); };
+  };
+  class increasing_weight_order : public lvector< weighted<T,N> >::order {
+  public:
+    virtual bool operator()
+      (const weighted<T,N>& v0, const weighted<T,N>& v1) const
+      { return (v0.weight < v1.weight); };
+  };
+  static class decreasing_weight_order decreasing;
+  static class increasing_weight_order increasing;
+  void insert_increasing(const weighted<T,N>& v);
+  void insert_decreasing(const weighted<T,N>& v);
+  void insert_increasing(const T& v, const N& w);
+  void insert_decreasing(const T& v, const N& w);
+};
+template<class T, class N> class weighted_set
+: public svector< weighted<T,N> >
+{
+ public:
+  void insert(const T& v, const N& w);
+  void insert(const T& v);
+  index_type arg_max();
+  index_type arg_min();
+};
+template<class T>
+bool lvector<T>::operator==(const lvector& _vec) const
+{
+  if (lvector<T>::size() != _vec.size()) return false;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if (!((*this)[k] == _vec[k])) return false;
+  return true;
+}
+template<class T>
+bool lvector<T>::operator!=(const lvector& _vec) const
+{
+  if (*this == _vec) return false;
+  else return true;
+}
+template<class T>
+bool lvector<T>::operator<(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator<=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return true;
+  else if (lvector<T>::size() > vec.size()) return false;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return true;
+      else if ((*this)[k] > vec[k]) return false;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::operator>(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return false;
+  }
+}
+template<class T>
+bool lvector<T>::operator>=(const lvector& vec) const
+{
+  if (lvector<T>::size() < vec.size()) return false;
+  else if (lvector<T>::size() > vec.size()) return true;
+  else {
+    for (index_type k = 0; k < lvector<T>::size(); k++) {
+      if ((*this)[k] < vec[k]) return false;
+      else if ((*this)[k] > vec[k]) return true;
+    }
+    return true;
+  }
+}
+template<class T>
+bool lvector<T>::contains(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return true;
+  return false;
+}
+template<class T>
+index_type lvector<T>::first(const T& v) const
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::next(const T& v, index_type p) const
+{
+  for (index_type k = p + 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) return k;
+  return no_such_index;
+}
+template<class T>
+index_type lvector<T>::find(const T& v, bool_vec& s) const
+{
+  index_type n = 0;
+  s.assign_value(false, lvector<T>::size());
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) {
+      s[k] = true;
+      n += 1;
+    }
+  return n;
+}
+template<class T>
+index_type lvector<T>::count(const T& v) const
+{
+  index_type c = 0;
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    if ((*this)[k] == v) c += 1;
+  return c;
+}
+template<class T>
+index_type lvector<T>::length() const
+{
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::arg_max() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] > (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_min() const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if ((*this)[k] < (*this)[m]) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_first(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[k], (*this)[m])) m = k;
+  return m;
+}
+template<class T>
+index_type lvector<T>::arg_last(const order& o) const
+{
+  if (lvector<T>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < lvector<T>::size(); k++)
+    if (o((*this)[m], (*this)[k])) m = k;
+  return m;
+}
+template<class T>
+index_pair lvector<T>::first_common(const lvector<T>& vec) const
+{
+  for (index_type i = 0; i < lvector<T>::size(); i++) {
+    for (index_type j = 0; j < vec.size(); j++)
+      if ((*this)[i] == vec[j]) return index_pair(i, j);
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair lvector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  index_type i = p.first;
+  index_type j = p.second + 1;
+  while (j < vec.size()) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    j += 1;
+  }
+  i += 1;
+  while (i < lvector<T>::size()) {
+    j = 0;
+    while (j < vec.size()) {
+      if ((*this)[i] == vec[j])
+ return index_pair(i, j);
+      j += 1;
+    }
+    i += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+void lvector<T>::difference
+(const lvector& v1, lvector& d0, lvector& d1)
+{
+  d0.assign_copy(*this);
+  d1.assign_copy(v1);
+  index_type i0 = 0;
+  while (i0 < d0.size()) {
+    index_type i1 = d1.first(d0[i0]);
+    if (i1 != no_such_index) {
+      d0.remove(i0);
+      d1.remove(i1);
+    }
+    else {
+      i0 += 1;
+    }
+  }
+}
+template<class T>
+void lvector<T>::assign_copy(const lvector& _vec)
+{
+  std::vector<T>::resize(_vec.size());
+  for (index_type k = 0; k < _vec.size(); k++)
+    (*this)[k] = _vec[k];
+}
+template<class T>
+void lvector<T>::assign_copy(const T* _arr, index_type n)
+{
+  std::vector<T>::resize(n);
+  for (index_type k = 0; k < n; k++)
+    (*this)[k] = _arr[k];
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_value(const T& _val, index_type l)
+{
+  std::vector<T>::resize(l);
+  for (index_type k = 0; k < lvector<T>::size(); k++)
+    (*this)[k] = _val;
+}
+template<class T>
+void lvector<T>::assign_remap(const lvector<T>& vec, const index_vec& map)
+{
+  assert(map.length() == vec.length());
+  index_type m = 0;
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      if (map[k] > m) m = map[k];
+  set_length(m + 1);
+  for (index_type k = 0; k < vec.length(); k++)
+    if (map[k] != no_such_index)
+      (*this)[map[k]] = vec[k];
+}
+template<class T>
+void lvector<T>::remap(const index_vec& map)
+{
+  lvector v0(*this);
+  assign_remap(v0, map);
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const index_set& s)
+{
+  set_length(s.length());
+  for (index_type k = 0; k < s.length(); k++)
+    (*this)[k] = _vec[s[k]];
+}
+template<class T>
+void lvector<T>::assign_select(const lvector& _vec, const bool_vec& s)
+{
+  clear();
+  for (index_type k = 0; k < _vec.length(); k++)
+    if (s[k]) append(_vec[k]);
+}
+template<class T>
+const lvector<T>& lvector<T>::operator=(const lvector<T>& _vec)
+{
+  assign_copy(_vec);
+  return _vec;
+}
+template<class T>
+void lvector<T>::set_length(index_type l)
+{
+  std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::set_length(index_type l, const T& v)
+{
+  std::vector<T>::resize(l, v);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l);
+}
+template<class T>
+void lvector<T>::inc_length_to(index_type l, const T& v)
+{
+  if (std::vector<T>::size() < l)
+    std::vector<T>::resize(l, v);
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::inc_length(index_type d, const T& v)
+{
+  std::vector<T>::resize(std::vector<T>::size() + d, v);
+  return std::vector<T>::size();
+}
+template<class T>
+index_type lvector<T>::dec_length(index_type d)
+{
+  assert(std::vector<T>::size() >= d);
+  std::vector<T>::resize(std::vector<T>::size() - d);
+  return std::vector<T>::size();
+}
+template<class T>
+void lvector<T>::clear()
+{
+  std::vector<T>::clear();
+}
+template<class T>
+void lvector<T>::append(const T& v)
+{
+  std::vector<T>::push_back(v);
+}
+template<class T>
+void lvector<T>::append(const lvector<T>& v)
+{
+  for (index_type k = 0; k < v.size(); k++) append(v[k]);
+}
+template<class T>
+T& lvector<T>::append()
+{
+  T v;
+  std::vector<T>::push_back(v);
+  return (*this)[std::vector<T>::size() - 1];
+}
+template<class T>
+void lvector<T>::insert(const T& v, index_type p)
+{
+  if (p < lvector<T>::size()) {
+    std::vector<T>::insert(std::vector<T>::begin() + p, v);
+  }
+  else {
+    std::vector<T>::resize(p + 1);
+    (*this)[p] = v;
+  }
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const T& v, const order& o, index_type f)
+{
+  assert(f <= lvector<T>::size());
+  for (index_type k = f; k < lvector<T>::size(); k++) {
+    if (o(v, (*this)[k])) {
+      insert(v, k);
+      return k;
+    }
+  }
+  append(v);
+  return (lvector<T>::size() - 1);
+}
+template<class T>
+index_type lvector<T>::insert_ordered(const lvector& vec, const order& o)
+{
+  if (vec.empty()) return no_such_index;
+  index_type p0 = insert_ordered(vec[0], o);
+  for (index_type k = 1; k < vec.size(); k++) {
+    index_type p1 = insert_ordered(vec[k], o);
+    if (p1 < p0) p0 = p1;
+  }
+  return p0;
+}
+template<class T>
+void lvector<T>::remove(index_type p)
+{
+  if (p < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p);
+}
+template<class T>
+void lvector<T>::remove(index_type p0, index_type p1)
+{
+  assert(p0 < p1);
+  if (p1 < lvector<T>::size())
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::begin() + p1);
+  else
+    std::vector<T>::erase(std::vector<T>::begin() + p0,
+     std::vector<T>::end());
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s, index_vec& map)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  index_vec rm_map(no_such_index, lvector<T>::size());
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      rm_map[scan_p] = put_p;
+      put_p += 1;
+    }
+    else {
+      rm_map[scan_p] = no_such_index;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+  for (index_type k = 0; k < map.size(); k++)
+    if (map[k] != no_such_index) {
+      assert(map[k] < rm_map.size());
+      map[k] = rm_map[map[k]];
+    }
+}
+template<class T>
+void lvector<T>::remove(const bool_vec& s)
+{
+  assert(s.size() >= lvector<T>::size());
+  index_type scan_p = 0;
+  index_type put_p = 0;
+  while (scan_p < lvector<T>::size()) {
+    if (!s[scan_p]) {
+      if (put_p < scan_p) {
+ (*this)[put_p] = (*this)[scan_p];
+      }
+      put_p += 1;
+    }
+    scan_p += 1;
+  }
+  std::vector<T>::resize(put_p);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s)
+{
+  bool_vec s1(s, lvector<T>::size());
+  remove(s1);
+}
+template<class T>
+void lvector<T>::remove(const index_set& s, index_vec& map)
+{
+  bool_vec s1(s, std::vector<T>::size());
+  lvector<T>::remove(s1, map);
+}
+template<class T>
+void lvector<T>::remove_duplicate_elements()
+{
+  equivalence eq(lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    for (index_type j = i+1; j < lvector<T>::size(); j++)
+      if ((*this)[i] == (*this)[j])
+ eq.merge(i, j);
+  bool_vec s(false, lvector<T>::size());
+  for (index_type i = 0; i < lvector<T>::size(); i++)
+    if (eq.canonical(i) != i)
+      s[i] = true;
+  remove(s);
+}
+template<class T>
+void lvector<T>::swap(index_type i, index_type j)
+{
+  T tmp = (*this)[i];
+  (*this)[i] = (*this)[j];
+  (*this)[j] = tmp;
+}
+template<class T>
+void svector<T>::assign_singleton(const T& _val)
+{
+  lvector<T>::set_length(1);
+  (*this)[0] = _val;
+}
+template<class T>
+void svector<T>::assign_values(const lvector<T>& vec)
+{
+  lvector<T>::clear();
+  for (index_type k = 0; k < vec.size(); k++)
+    insert(vec[k]);
+}
+template<class T>
+void svector<T>::insert(const T& v) {
+  index_type i = 0;
+  bool seeking = (i < std::vector<T>::size());
+  while (seeking) {
+    if ((*this)[i] < v) {
+      i += 1;
+      if (i >= std::vector<T>::size())
+ seeking = false;
+    }
+    else {
+      seeking = false;
+    }
+  }
+  if (i < lvector<T>::size()) {
+    if ((*this)[i] == v)
+      return;
+    else
+      lvector<T>::insert(v, i);
+  }
+  else {
+    lvector<T>::append(v);
+  }
+}
+template<class T>
+void svector<T>::insert(const lvector<T>& vec)
+{
+  for (index_type k = 0; k < vec.size(); k++) insert(vec[k]);
+}
+template<class T>
+bool svector<T>::contains(const T& v) const
+{
+  index_type i = 0;
+  while ((i < lvector<T>::size()) &&
+  ((*this)[i] < v)) i += 1;
+  if (i < lvector<T>::size())
+    if ((*this)[i] == v) return true;
+  return false;
+}
+template<class T>
+bool svector<T>::contains(const svector& vec) const
+{
+  index_type v_i = 0;
+  index_type i = 0;
+  while (v_i < vec.size()) {
+    if (i >= lvector<T>::size()) return false;
+    if ((*this)[i] == vec[v_i]) {
+      v_i += 1;
+      i += 1;
+    }
+    else if ((*this)[i] > vec[v_i]) {
+      return false;
+    }
+    else {
+      while ((i < lvector<T>::size()) && ((*this)[i] < vec[v_i]))
+ i += 1;
+    }
+  }
+  return true;
+}
+template<class T>
+bool svector<T>::subset(const svector& vec) const
+{
+  return vec.contains(*this);
+}
+template<class T>
+void svector<T>::intersect(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (!vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::difference(const svector& vec)
+{
+  svector d(vec);
+  d.subtract(*this);
+  subtract(vec);
+  insert(d);
+}
+template<class T>
+index_pair svector<T>::first_common(const lvector<T>& vec) const
+{
+  return lvector<T>::first_common(vec);
+}
+template<class T>
+index_pair svector<T>::next_common(const lvector<T>& vec, index_pair p) const
+{
+  return lvector<T>::next_common(vec, p);
+}
+template<class T>
+index_pair svector<T>::first_common(const svector<T>& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if
+      ((*this)[i] < vec[j]) i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_pair svector<T>::next_common(const svector<T>& vec, index_pair p) const
+{
+  index_type i = p.first + 1;
+  index_type j = p.second + 1;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j])
+      return index_pair(i, j);
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return index_pair(no_such_index, no_such_index);
+}
+template<class T>
+index_type svector<T>::count_common(const svector& vec) const
+{
+  index_type i = 0;
+  index_type j = 0;
+  index_type c = 0;
+  while ((i < svector<T>::size()) && (j < vec.size())) {
+    if ((*this)[i] == vec[j]) {
+      c += 1;
+      i += 1;
+      j += 1;
+    }
+    else if ((*this)[i] < vec[j])
+      i += 1;
+    else
+      j += 1;
+  }
+  return c;
+}
+template<class T>
+void svector<T>::subtract(const svector& vec)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if (vec.contains((*this)[i]))
+      lvector<T>::remove(i);
+    else
+      i += 1;
+  }
+}
+template<class T>
+void svector<T>::subtract(const T& v)
+{
+  index_type i = 0;
+  while (i < lvector<T>::size()) {
+    if ((*this)[i] == v) {
+      lvector<T>::remove(i);
+      return;
+    }
+    else {
+      i += 1;
+    }
+  }
+}
+template<class T>
+void matrix<T>::set_size(index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].set_length(c);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val)
+{
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val);
+}
+template<class T>
+void matrix<T>::assign_value(const T& _val, index_type r, index_type c)
+{
+  lvector<row_type>::set_length(r);
+  for (index_type k = 0; k < lvector<row_type>::size(); k++)
+    (*this)[k].assign_value(_val, c);
+}
+template<class T>
+void swapable_pair<T>::swap()
+{
+  T tmp = this->first;
+  this->first = this->second;
+  this->second = tmp;
+}
+template<class T>
+void comparable_pair<T>::sort_ascending()
+{
+  if (this->first > this->second) swapable_pair<T>::swap();
+}
+template<class T>
+void comparable_pair<T>::sort_descending()
+{
+  if (this->first < this->second) swapable_pair<T>::swap();
+}
+template<class T, class N>
+class weighted_vec<T,N>::decreasing_weight_order
+  weighted_vec<T,N>::decreasing;
+template<class T, class N>
+class weighted_vec<T,N>::increasing_weight_order
+  weighted_vec<T,N>::increasing;
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const weighted<T,N>& v)
+{
+  insert_ordered(v, decreasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_increasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), increasing);
+}
+template<class T, class N>
+void weighted_vec<T,N>::insert_decreasing(const T& v, const N& w)
+{
+  insert_ordered(weighted<T,N>(v, w), decreasing);
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v, const N& w)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, w));
+  }
+  else {
+    (*this)[p].weight += w;
+  }
+}
+template<class T, class N>
+void weighted_set<T,N>::insert(const T& v)
+{
+  index_type p = svector< weighted<T,N> >::first(v);
+  if (p == no_such_index) {
+    svector< weighted<T,N> >::insert(weighted<T,N>(v, 1));
+  }
+  else {
+    (*this)[p].weight += 1;
+  }
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_max()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight > (*this)[m].weight) m = k;
+  return m;
+}
+template<class T, class N>
+index_type weighted_set<T,N>::arg_min()
+{
+  if (weighted_set<T,N>::empty()) return no_such_index;
+  index_type m = 0;
+  for (index_type k = 1; k < weighted_set<T,N>::size(); k++)
+    if ((*this)[k].weight < (*this)[m].weight) m = k;
+  return m;
+}
+template<class T>
+inline std::ostream& operator<<(std::ostream& s, const swapable_pair<T>& p)
+{
+  return s << '(' << p.first << ',' << p.second << ')';
+}
+template<class T>
+::std::ostream& operator<<(::std::ostream& s, const lvector<T>& _vec)
+{
+  s << '[';
+  for (index_type k = 0; k < _vec.size(); k++) {
+    if (k > 0) s << ',';
+    s << _vec[k];
+  }
+  s << ']';
+  return s;
+}
+inline std::ostream& operator<<(std::ostream& s, const mapping& m)
+{
+  s << '{';
+  for (index_type k = 0; k < m.length(); k++) {
+    if (k > 0) s << ',';
+    s << k << '-' << '>';
+    if (m[k] == no_such_index)
+      s << '_';
+    else
+      s << m[k];
+  }
+  return s << '}';
+}
+inline std::ostream& operator<<(std::ostream& s, const equivalence& eq)
+{
+  s << '{';
+  bool first = true;
+  for (index_type k = 0; k < eq.length(); k++) {
+    index_type c = eq.canonical(k);
+    if (!first) {
+      s << ',';
+    }
+    else {
+      first = false;
+    }
+    s << k << '=' << c;
+  }
+  return s << '}';
+}
+template<class T, class N>
+std::ostream& operator<<(::std::ostream& s, const weighted<T,N>& w)
+{
+  s << '<' << w.value << ':' << w.weight << '>';
+}
+}
+namespace hsps {
+class char_map {
+ public:
+  static const unsigned int _CHAR_COUNT = 256;
+ private:
+  char _map[_CHAR_COUNT];
+ public:
+  char_map();
+  char_map(const char in[_CHAR_COUNT]);
+  void identify(const char _c0, const char _c1);
+  char operator[](const char _in) const
+    { return _map[(unsigned char)_in]; };
+  void apply(char* s) const;
+  void apply(char* s, index_type len) const;
+  int strcmp(const char *s0, const char *s1) const;
+  int strcmp(const char *s0, const char *s1, index_type len) const;
+  const char* strchr(const char* s, char c) const;
+  const char* strchr(const char* s, index_type len, char c) const;
+  char* strcpy(const char *s0, char *s1) const;
+  char* strcpy(const char *s0, index_type len, char *s1) const;
+  char* strdup(const char *s0) const;
+  char* strdup(const char *s0, index_type len) const;
+  index_type hash(const char *s) const;
+  index_type hash(const char *s, index_type len) const;
+};
+extern const char lowercase[char_map::_CHAR_COUNT];
+extern const char rot13[char_map::_CHAR_COUNT];
+extern char_map lowercase_map;
+extern char_map rot13_map;
+}
+namespace hsps {
+typedef lvector<char*> string_vec;
+typedef lvector<void*> element_vec;
+inline ::std::ostream& operator<<(::std::ostream& s, const string_vec& vec) {
+  s << '[';
+  for (index_type k = 0; k < vec.length(); k++) {
+    if (k > 0) s << ',';
+    s << '"' << vec[k] << '"';
+  }
+  s << ']';
+  return s;
+}
+class StringTable {
+ public:
+  struct Cell {
+    index_type bin;
+    char* text;
+    void* val;
+    Cell* next;
+    Cell(const char* s, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(0), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(0), next(n) { };
+    Cell(const char* s, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s)), val(v), next(n) { };
+    Cell(const char* s, index_type len, char_map& map, void* v, index_type b, Cell* n)
+      : bin(b), text(map.strdup(s, len)), val(v), next(n) { };
+    ~Cell() { delete text; if (next) delete next; };
+  };
+ private:
+  index_type n_bin;
+  char_map& map;
+  Cell** table;
+  index_type n_entries;
+ public:
+  StringTable(index_type b, char_map& cm);
+  ~StringTable();
+  StringTable::Cell* inserta(const char* str);
+  StringTable::Cell* inserta(const char* str, index_type len);
+  StringTable::Cell* gensym(const char* str);
+  char* insert(const char* str);
+  char* insert(const char* str, index_type len);
+  char* set(const char* str, void* val);
+  char* set(const char* str, index_type len, void* val);
+  char* set(const char* str)
+    { return set(str, (void*)0); };
+  char* set(const char* str, index_type len)
+    { return set(str, len, (void*)0); };
+  const StringTable::Cell* find(const char* str) const;
+  const StringTable::Cell* find(const char* str, index_type len) const;
+  void* find_val(const char* str) const;
+  void* find_val(const char* str, index_type len) const;
+  const StringTable::Cell* first() const;
+  const StringTable::Cell* next(const StringTable::Cell* c) const;
+  string_vec* keys();
+  element_vec* values();
+  index_type table_bins() { return n_bin; };
+  index_type table_entries() { return n_entries; };
+  char_map& table_char_map() { return map; };
+  void apply_map(const char_map& map);
+};
+}
+#include <sstream>
+namespace hsps {
+StringTable::StringTable(index_type b, char_map& cm)
+  : n_bin(b), map(cm), table(0), n_entries(0)
+{
+  table = new StringTable::Cell*[n_bin];
+  for (index_type k = 0; k < n_bin; k++) table[k] = 0;
+}
+StringTable::~StringTable() {
+  for (index_type k = 0; k < n_bin; k++)
+    if (table[k]) delete table[k];
+  delete [] table;
+}
+StringTable::Cell* StringTable::gensym(const char* str)
+{
+  Cell* sc = inserta(str);
+  index_type i = 0;
+  while (sc->val) {
+    ::std::ostringstream s;
+    s << str << i++;
+    sc = inserta(s.str().c_str());
+  }
+  return sc;
+}
+StringTable::Cell* StringTable::inserta(const char* str) {
+  index_type l = map.hash(str) % n_bin;
+  StringTable::Cell **sc = &(table[l]);
+  while (1) {
+    if (!*sc) {
+      *sc = new StringTable::Cell(str, map, 0, l, 0);
+      n_entries += 1;
+      return *sc;
+    }
+    else {
+      int d = map.strcmp((*sc)->text, str);
+      if (d == 0) {
+ return *sc;
+      }
+      else if (d < 0) sc = &((*sc)->next);
+      else {
+ *sc = new StringTable::Cell(str, map, 0, l, *sc);
+ n_entries += 1;
+ return *sc;
+      }
+    }
+  }
+}
+StringTable::Cell* StringTable::inserta(const char* str, index_type len) {
+  index_type l = map.hash(str, len) % n_bin;
+  StringTable::Cell **sc = &(table[l]);
+  while (1) {
+    if (!*sc) {
+      *sc = new StringTable::Cell(str, map, 0, l, 0);
+      n_entries += 1;
+      return *sc;
+    }
+    else {
+      int d = map.strcmp((*sc)->text, str, len);
+      if (d == 0) {
+ return *sc;
+      }
+      else if (d < 0) sc = &((*sc)->next);
+      else {
+ *sc = new StringTable::Cell(str, len, map, 0, l, *sc);
+ n_entries += 1;
+ return *sc;
+      }
+    }
+  }
+}
+char* StringTable::insert(const char* str) {
+  StringTable::Cell *sc = inserta(str);
+  return sc->text;
+}
+char* StringTable::insert(const char* str, index_type len) {
+  StringTable::Cell *sc = inserta(str, len);
+  return sc->text;
+}
+char* StringTable::set(const char* str, void* val) {
+  StringTable::Cell *sc = inserta(str);
+  sc->val = val;
+  return sc->text;
+}
+char* StringTable::set(const char* str, index_type len, void* val) {
+  StringTable::Cell *sc = inserta(str, len);
+  sc->val = val;
+  return sc->text;
+}
+const StringTable::Cell* StringTable::find(const char* str) const {
+  index_type l = map.hash(str) % n_bin;
+  StringTable::Cell **sc = &(table[l]);
+  while (1) {
+    if (!*sc) {
+      return 0;
+    }
+    else {
+      int d = map.strcmp((*sc)->text, str);
+      if (d == 0) return *sc;
+      else if (d < 0) sc = &((*sc)->next);
+      else return 0;
+    }
+  }
+}
+const StringTable::Cell* StringTable::find(const char* str,
+        index_type len) const {
+  index_type l = map.hash(str, len) % n_bin;
+  StringTable::Cell **sc = &(table[l]);
+  while (1) {
+    if (!*sc) {
+      return 0;
+    }
+    else {
+      int d = map.strcmp((*sc)->text, str, len);
+      if (d == 0) return *sc;
+      else if (d < 0) sc = &((*sc)->next);
+      else return 0;
+    }
+  }
+}
+void* StringTable::find_val(const char* str) const {
+  const StringTable::Cell* sc = find(str);
+  if (sc) return sc->val;
+  else return (void*)0;
+}
+void* StringTable::find_val(const char* str, index_type len) const {
+  const StringTable::Cell* sc = find(str, len);
+  if (sc) return sc->val;
+  else return (void*)0;
+}
+const StringTable::Cell* StringTable::first() const {
+  for (index_type k = 0; k < n_bin; k++)
+    if (table[k]) return table[k];
+  return 0;
+}
+const StringTable::Cell* StringTable::next(const StringTable::Cell* c) const {
+  if (c->next) return c->next;
+  for (index_type k = c->bin + 1; k < n_bin; k++)
+    if (table[k]) return table[k];
+  return 0;
+}
+string_vec* StringTable::keys() {
+  string_vec* vec = new string_vec();
+  for (const StringTable::Cell* sc = first(); sc; sc = next(sc))
+    vec->append((char*)sc->text);
+  return vec;
+}
+element_vec* StringTable::values() {
+  element_vec* vec = new element_vec();
+  for (const StringTable::Cell* sc = first(); sc; sc = next(sc))
+    if (sc->val) vec->append((void*)sc->val);
+  return vec;
+}
+void StringTable::apply_map(const char_map& map)
+{
+  Cell* c = (Cell*)first();
+  while (c != 0) {
+    map.apply(c->text);
+    c = (Cell*)next(c);
+  }
+}
+}


### PR DESCRIPTION
# Add HSP optimal-planner sources and the plan-recognition dataset

## What this does

This branch collects the optimal-planning dependency and the evaluation data that the probabilistic
plan recogniser needs, so the project can be built and evaluated from a single checkout. It contains
no obs-compiler changes; those are handled in a separate pull request.

## Changes

- **HSP sources.** Add Patrik Haslum's `seq-opt-hspsf` (`hsp_f`) sources under `pr/seq-opt-hspsf/`,
  the optimal planner used for optimal probabilistic recognition (`-O`).
- **Dataset.** Add the goal/plan-recognition dataset as a git submodule at `experiments/`, pointing
  at `pucrs-automated-planning/goal-plan-recognition-dataset`.
- **Attribution.** Link the README to Ramírez's original implementation.

## Notes

Base this on `master`. After merging, run `git submodule update --init` to populate `experiments/`.
